### PR TITLE
SUPP-247 - image urls cant always guarantee to have an extension

### DIFF
--- a/src/pages/collections/AddCollectionPage.js
+++ b/src/pages/collections/AddCollectionPage.js
@@ -222,7 +222,7 @@ const AddCollectionForm = (props) => {
                 .required('This cannot be empty'),
             authors: Yup.lazy(val => (Array.isArray(val) ? Yup.array().of(Yup.number()) : Yup.number())), 
             imageLink: Yup.string()
-                .matches( /^[http|https]+:\/\/(?:([\w\-\.])+(\[?\.\]?)([\w]){2,4}|(?:(?:25[0–5]|2[0–4]\d|[01]?\d\d?)\[?\.\]?){3}(?:25[0–5]|2[0–4]\d|[01]?\d\d?))*([\w\/+=%&_\.~?\-]*)+[.gif|.jpeg|.png|.svg]$/ , 'Invalid image URL' )
+                .matches( /^(http|https){1}:\/\/[A-Za-z0-9-\/\._~:\?#\[\]@!\$&'\(\)\*\+,;%=]+$/ , 'Invalid URL: should start with http:// or https://' )
         }),
 
         onSubmit: values => {

--- a/src/pages/collections/EditCollectionPage.js
+++ b/src/pages/collections/EditCollectionPage.js
@@ -242,7 +242,7 @@ const EditCollectionForm = (props) => {
                 .required('This cannot be empty'),
             authors: Yup.lazy(val => (Array.isArray(val) ? Yup.array().of(Yup.number()) : Yup.number())), 
             imageLink: Yup.string()
-                .matches( /^[http|https]+:\/\/(?:([\w\-\.])+(\[?\.\]?)([\w]){2,4}|(?:(?:25[0–5]|2[0–4]\d|[01]?\d\d?)\[?\.\]?){3}(?:25[0–5]|2[0–4]\d|[01]?\d\d?))*([\w\/+=%&_\.~?\-]*)+[.gif|.jpeg|.png|.svg]$/ , 'Invalid image URL' )
+                .matches( /^(http|https){1}:\/\/[A-Za-z0-9-\/\._~:\?#\[\]@!\$&'\(\)\*\+,;%=]+$/ , 'Invalid URL: should start with http:// or https://' )
         }),
 
         onSubmit: values => {


### PR DESCRIPTION
Image URLs cant always guarantee to have an extension and the existing regex is OTT, changed to make sure this is a full URL with accepted characters and not much more.