### PR TITLE
Fixed undefined checks for phenotype data

### DIFF
--- a/src/pages/dataset/DatasetPage.js
+++ b/src/pages/dataset/DatasetPage.js
@@ -371,15 +371,10 @@ class DatasetDetail extends Component {
       );
     }
 
-    if (
-      data.relatedObjects === null ||
-      typeof data.relatedObjects === "undefined"
-    ) {
-      data.relatedObjects = [];
+    if (_.isNil(data.relatedObjects)) { 
+      data.relatedObjects = []; 
     }
-
-    
-    if (data.datasetfields.phenotypes !== "undefined" && data.datasetfields.phenotypes.length > 0) {
+    if (!_.isNil(data.datasetfields.phenotypes) && data.datasetfields.phenotypes.length > 0) {
         data.datasetfields.phenotypes.sort((a,b) => (a.name.toLowerCase() > b.name.toLowerCase()) ? 1 : ((b.name.toLowerCase() > a.name.toLowerCase()) ? -1 : 0));
     }
 
@@ -389,7 +384,7 @@ class DatasetDetail extends Component {
 
         var rating = "Not Rated";
 
-        if (data.datasetfields.metadataquality && typeof data.datasetfields.metadataquality.quality_rating !== "undefined") {
+        if (data.datasetfields.metadataquality && !_.isNil(data.datasetfields.metadataquality.quality_rating)) {
             rating = data.datasetfields.metadataquality.quality_rating;
         }
         else {
@@ -866,7 +861,7 @@ class DatasetDetail extends Component {
                         </Col>
                       </Row>
 
-                      {data.datasetfields.phenotypes !== "undefined" &&
+                      {!_.isNil(data.datasetfields.phenotypes) &&
                       data.datasetfields.phenotypes.length > 0 ? (
                         <Fragment>
                           <Row className="mt-2">


### PR DESCRIPTION
**Sentry Issue**
[https://sentry.io/organizations/hdruk-gateway-16/issues/2039909637/events/6689e53112034150a0af9b7e0c318450/](url)

**Cause**
Incorrect undefined check (missing 'typeof') allowing code execution to attempt to find the length of an undefined/null reference.

**Resolution**
Fixed undefined checks using Lodash 'nil' check which returns true if a reference is either null or undefined.