### PR TITLE
Fixes for master on live reports from Sentry, fix to stop phenotype a…

### DIFF
--- a/src/pages/dataset/DatasetPage.js
+++ b/src/pages/dataset/DatasetPage.js
@@ -332,11 +332,11 @@ class DatasetDetail extends Component {
 			);
 		}
 
-		if (data.relatedObjects === null || typeof data.relatedObjects === 'undefined') {
-			data.relatedObjects = [];
-		}
+    if (_.isNil(data.relatedObjects)) { 
+      data.relatedObjects = []; 
+    }
 
-		if (data.datasetfields.phenotypes !== 'undefined' && data.datasetfields.phenotypes.length > 0) {
+		if (!_.isNil(data.datasetfields.phenotypes) && data.datasetfields.phenotypes.length > 0) {
 			data.datasetfields.phenotypes.sort((a, b) =>
 				a.name.toLowerCase() > b.name.toLowerCase() ? 1 : b.name.toLowerCase() > a.name.toLowerCase() ? -1 : 0
 			);
@@ -346,10 +346,10 @@ class DatasetDetail extends Component {
 			const [show, setShow] = useState(false);
 			const target = useRef(null);
 
-			var rating = 'Not Rated';
+			let rating = 'Not Rated';
 
-			if (data.datasetfields.metadataquality && typeof data.datasetfields.metadataquality.quality_rating !== 'undefined') {
-				rating = data.datasetfields.metadataquality.quality_rating;
+      if (data.datasetfields.metadataquality && !_.isNil(data.datasetfields.metadataquality.quality_rating)) {				
+        rating = data.datasetfields.metadataquality.quality_rating;
 			} else {
 				return (
 					<Fragment>
@@ -787,7 +787,7 @@ class DatasetDetail extends Component {
 												</Col>
 											</Row>
 
-											{data.datasetfields.phenotypes !== 'undefined' && data.datasetfields.phenotypes.length > 0 ? (
+											{!_.isNil(data.datasetfields.phenotypes) && data.datasetfields.phenotypes.length > 0 ? (
 												<Fragment>
 													<Row className='mt-2'>
 														<Col sm={12}>

--- a/src/pages/dataset/components/DataQuality.js
+++ b/src/pages/dataset/components/DataQuality.js
@@ -1,11 +1,12 @@
 import React from "react";
 import { Col, Row } from "react-bootstrap";
+import _ from 'lodash';
 import '../Dataset.scss'; 
 import DataQualityInfo from "./DataQualityInfo";
 
 class DataQuality extends React.Component {
   state = {
-    datasetUtility: null,
+    datasetUtility: {},
     allOpen: false,
     displayOption: "",
     documentationWeight: "",
@@ -17,15 +18,15 @@ class DataQuality extends React.Component {
 
   constructor(props) { 
     super(props);
-    this.state.datasetUtility = props.datasetUtility;
+    this.state.datasetUtility = props.datasetUtility || {};
   }
 
   async componentWillMount() {    
-    await this.displaySections(this.props.datasetUtility);
+    if(!_.isEmpty(this.props.datasetUtility))
+      await this.displaySections(this.props.datasetUtility);
   }
 
-  async displaySections(datasetUtility){
-
+  async displaySections(datasetUtility = {}){
     if(datasetUtility.metadata_richness && datasetUtility.metadata_richness.trim() === "Not Rated" && !datasetUtility.availability_of_additional_documentation_and_support && !datasetUtility.data_model && !datasetUtility.data_dictionary && !datasetUtility.provenance && !datasetUtility.data_quality_management_process && !datasetUtility.dama_quality_dimensions && !datasetUtility.allowable_uses && !datasetUtility.research_environment && !datasetUtility.time_lag && !datasetUtility.timeliness && !datasetUtility.linkages && !datasetUtility.data_enrichments && !datasetUtility.pathway_coverage && !datasetUtility.length_of_follow_up){
         this.setState({displayOption: "none"})
     } else if(datasetUtility.metadata_richness && datasetUtility.metadata_richness.trim() !== "Not Rated" && !datasetUtility.availability_of_additional_documentation_and_support && !datasetUtility.data_model && !datasetUtility.data_dictionary && !datasetUtility.provenance && !datasetUtility.data_quality_management_process && !datasetUtility.dama_quality_dimensions && !datasetUtility.allowable_uses && !datasetUtility.research_environment && !datasetUtility.time_lag && !datasetUtility.timeliness && !datasetUtility.linkages && !datasetUtility.data_enrichments && !datasetUtility.pathway_coverage && !datasetUtility.length_of_follow_up){
@@ -38,38 +39,38 @@ class DataQuality extends React.Component {
   }
 
 
-  async getWeights(datasetUtility) {
+  async getWeights(datasetUtility = {}) {
+    if(!_.isEmpty(datasetUtility)) {
+      let weights = ["","Bronze","Silver","Gold","Platinum"] 
 
-    let weights = ["","Bronze","Silver","Gold","Platinum"] 
+      let documentationWeight = weights[Math.floor((weights.indexOf(datasetUtility.metadata_richness.trim())
+          +weights.indexOf(datasetUtility.availability_of_additional_documentation_and_support.trim())
+          +weights.indexOf(datasetUtility.data_model.trim())
+          +weights.indexOf(datasetUtility.data_dictionary.trim())
+          +weights.indexOf(datasetUtility.provenance.trim()))/5)];
 
-    let documentationWeight = weights[Math.floor((weights.indexOf(datasetUtility.metadata_richness.trim())
-        +weights.indexOf(datasetUtility.availability_of_additional_documentation_and_support.trim())
-        +weights.indexOf(datasetUtility.data_model.trim())
-        +weights.indexOf(datasetUtility.data_dictionary.trim())
-        +weights.indexOf(datasetUtility.provenance.trim()))/5)];
+      let technicalQualityWeight = weights[Math.floor((weights.indexOf(datasetUtility.data_quality_management_process.trim())
+          +weights.indexOf(datasetUtility.dama_quality_dimensions.trim()))/2)];
 
-    let technicalQualityWeight = weights[Math.floor((weights.indexOf(datasetUtility.data_quality_management_process.trim())
-        +weights.indexOf(datasetUtility.dama_quality_dimensions.trim()))/2)];
+      let accessProvisionWeight = weights[Math.floor((weights.indexOf(datasetUtility.allowable_uses.trim())
+          +weights.indexOf(datasetUtility.research_environment.trim())
+          +weights.indexOf(datasetUtility.time_lag.trim())
+          +weights.indexOf(datasetUtility.timeliness.trim()))/4)];
 
-    let accessProvisionWeight = weights[Math.floor((weights.indexOf(datasetUtility.allowable_uses.trim())
-        +weights.indexOf(datasetUtility.research_environment.trim())
-        +weights.indexOf(datasetUtility.time_lag.trim())
-        +weights.indexOf(datasetUtility.timeliness.trim()))/4)];
+      let valueInterestWeight = weights[Math.floor((weights.indexOf(datasetUtility.linkages.trim())
+          +weights.indexOf(datasetUtility.data_enrichments.trim()))/2)];
+      
+      let coverageWeight = weights[Math.floor((weights.indexOf(datasetUtility.pathway_coverage.trim())
+          +weights.indexOf(datasetUtility.length_of_follow_up.trim()))/2)];
 
-    let valueInterestWeight = weights[Math.floor((weights.indexOf(datasetUtility.linkages.trim())
-        +weights.indexOf(datasetUtility.data_enrichments.trim()))/2)];
-    
-    let coverageWeight = weights[Math.floor((weights.indexOf(datasetUtility.pathway_coverage.trim())
-        +weights.indexOf(datasetUtility.length_of_follow_up.trim()))/2)];
-
-    this.setState({
-      documentationWeight: documentationWeight,
-      technicalQualityWeight: technicalQualityWeight,
-      accessProvisionWeight: accessProvisionWeight,
-      valueInterestWeight: valueInterestWeight,
-      coverageWeight: coverageWeight
-    })
-
+      this.setState({
+        documentationWeight: documentationWeight,
+        technicalQualityWeight: technicalQualityWeight,
+        accessProvisionWeight: accessProvisionWeight,
+        valueInterestWeight: valueInterestWeight,
+        coverageWeight: coverageWeight
+      });
+    }
   }
 
   renderDataQualityInfo(displayOption) {

--- a/src/pages/dataset/components/DataQualityInfo.js
+++ b/src/pages/dataset/components/DataQualityInfo.js
@@ -1,5 +1,6 @@
 import React from "react"; 
 import { Col, Row, Collapse } from "react-bootstrap";
+import _ from 'lodash';
 import SVGIcon from "../../../images/SVGIcon";
 import "../Dataset.scss";
 import { ReactComponent as SubBronzeSVG } from "../../../images/sub_bronze.svg";
@@ -17,7 +18,7 @@ class DataQualityInfo extends React.Component {
     open: false,
     flagClosed: true,
     section: "",
-    datasetUtility: null,
+    datasetUtility: {},
     documentationWeight: null,
     technicalQualityWeight: null,
     accessProvisionWeight: null,
@@ -299,7 +300,7 @@ class DataQualityInfo extends React.Component {
     this.state.open = props.open;
     this.updateFlag = this.updateFlag.bind(this);
     this.state.section = props.section;
-    this.state.datasetUtility = props.datasetUtility;
+    this.state.datasetUtility = props.datasetUtility || {};
     this.state.documentationWeight = props.documentationWeight;
     this.state.technicalQualityWeight = props.technicalQualityWeight;
     this.state.accessProvisionWeight = props.accessProvisionWeight;
@@ -308,7 +309,8 @@ class DataQualityInfo extends React.Component {
   }
 
   async componentWillMount() {    
-    await this.updateSections(this.props.datasetUtility);
+    if(!_.isEmpty(this.props.datasetUtility)) 
+        await this.updateSections(this.props.datasetUtility);
   }
 
   componentDidUpdate(prevProps) {
@@ -365,30 +367,32 @@ class DataQualityInfo extends React.Component {
     } 
   }
 
-  async updateSections(datasetUtility){
-    if(datasetUtility.metadata_richness.trim() === "Not Rated"){
-        this.setState({metadataRichnessOnly: false})
+  async updateSections(datasetUtility = {}){
+    if(!_.isEmpty(datasetUtility)) {
+        if(datasetUtility.metadata_richness.trim() === "Not Rated"){
+            this.setState({metadataRichnessOnly: false})
+        }
+
+        if(!datasetUtility.availability_of_additional_documentation_and_support && !datasetUtility.data_model && !datasetUtility.data_dictionary && !datasetUtility.provenance){
+            this.setState({documentSection: false})
+        } 
+
+        if(!datasetUtility.data_quality_management_process && !datasetUtility.dama_quality_dimensions){
+        this.setState({techQualitySection: false})
+        } 
+
+        if(!datasetUtility.allowable_uses && !datasetUtility.research_environment && !datasetUtility.time_lag && !datasetUtility.timeliness){
+        this.setState({accessProvisionSection: false})
+        } 
+
+        if(!datasetUtility.linkages && !datasetUtility.data_enrichments){
+        this.setState({valueInterestSection: false})
+        } 
+
+        if(!datasetUtility.pathway_coverage && !datasetUtility.length_of_follow_up){
+        this.setState({coverageSection: false})
+        } 
     }
-
-    if(!datasetUtility.availability_of_additional_documentation_and_support && !datasetUtility.data_model && !datasetUtility.data_dictionary && !datasetUtility.provenance){
-        this.setState({documentSection: false})
-    } 
-
-    if(!datasetUtility.data_quality_management_process && !datasetUtility.dama_quality_dimensions){
-      this.setState({techQualitySection: false})
-    } 
-
-    if(!datasetUtility.allowable_uses && !datasetUtility.research_environment && !datasetUtility.time_lag && !datasetUtility.timeliness){
-      this.setState({accessProvisionSection: false})
-    } 
-
-    if(!datasetUtility.linkages && !datasetUtility.data_enrichments){
-      this.setState({valueInterestSection: false})
-    } 
-
-    if(!datasetUtility.pathway_coverage && !datasetUtility.length_of_follow_up){
-      this.setState({coverageSection: false})
-    } 
   }
 
   render() {


### PR DESCRIPTION
# PR 
Phenotype checking
Dataset datautility check and default value setting

## Solution
Interim solution placed for type checking dataUtility and phenotypes, will need to look at better ways of setting this data either from the API and using DTO's that always returns a structured reponse via  a model regardless of missing types or  building the data in the frontend via a reduce method to ensure FE can render and not fall over. 