### PR TITLE
Fix DAR 'about application' section edit mode post submission

### DIFF
--- a/src/pages/DataAccessRequest/DataAccessRequest.js
+++ b/src/pages/DataAccessRequest/DataAccessRequest.js
@@ -1280,6 +1280,7 @@ class DataAccessRequest extends Component {
 					nationalCoreStudiesProjectId={
 						this.state.aboutApplication.nationalCoreStudiesProjectId
 					}
+					applicationStatus={this.state.applicationStatus}
 					toggleCard={this.toggleCard}
 					toggleDrawer={this.toggleDrawer}
 					onHandleDataSetChange={this.onHandleDataSetChange}

--- a/src/pages/DataAccessRequest/DataAccessRequest.js
+++ b/src/pages/DataAccessRequest/DataAccessRequest.js
@@ -1253,7 +1253,7 @@ class DataAccessRequest extends Component {
 					allowedNavigation={this.state.allowedNavigation}
 					userType={this.state.userType}
 					selectedDatasets={this.state.aboutApplication.selectedDatasets}
-					readOnly={this.state.readOnly}
+					readOnly={this.state.readOnly || this.state.applicationStatus !== DarHelper.darStatus.inProgress}
 					projectNameValid={this.state.projectNameValid}
 					projectName={this.state.aboutApplication.projectName}
 					nationalCoreStudiesProjects={this.state.nationalCoreStudiesProjects}
@@ -1280,7 +1280,6 @@ class DataAccessRequest extends Component {
 					nationalCoreStudiesProjectId={
 						this.state.aboutApplication.nationalCoreStudiesProjectId
 					}
-					applicationStatus={this.state.applicationStatus}
 					toggleCard={this.toggleCard}
 					toggleDrawer={this.toggleDrawer}
 					onHandleDataSetChange={this.onHandleDataSetChange}

--- a/src/pages/DataAccessRequest/components/AboutApplication/AboutApplication.js
+++ b/src/pages/DataAccessRequest/components/AboutApplication/AboutApplication.js
@@ -38,7 +38,6 @@ const AboutApplication = (props) => {
 		nationalCoreStudiesProjectId,
 		toggleMrcModal,
 		toggleContributorModal
-		applicationStatus
 	} = props;
 
 	return (
@@ -136,7 +135,7 @@ const AboutApplication = (props) => {
 										onBlur={(e) => onHandleProjectNameBlur()}
 										onChange={(e) => onHandleProjectNameChange(e.target.value)}
 										value={projectName}
-										disabled={readOnly || applicationStatus !== DarHelper.darStatus.inProgress}
+										disabled={readOnly}
 									/>
 									{!projectNameValid && _.isEmpty(projectName) ? <div className='errorMessages'>This cannot be empty</div> : null}
 								</div>

--- a/src/pages/DataAccessRequest/components/AboutApplication/AboutApplication.js
+++ b/src/pages/DataAccessRequest/components/AboutApplication/AboutApplication.js
@@ -38,6 +38,7 @@ const AboutApplication = (props) => {
 		nationalCoreStudiesProjectId,
 		toggleMrcModal,
 		toggleContributorModal
+		applicationStatus
 	} = props;
 
 	return (
@@ -135,7 +136,7 @@ const AboutApplication = (props) => {
 										onBlur={(e) => onHandleProjectNameBlur()}
 										onChange={(e) => onHandleProjectNameChange(e.target.value)}
 										value={projectName}
-										disabled={readOnly}
+										disabled={readOnly || applicationStatus !== DarHelper.darStatus.inProgress}
 									/>
 									{!projectNameValid && _.isEmpty(projectName) ? <div className='errorMessages'>This cannot be empty</div> : null}
 								</div>


### PR DESCRIPTION
Fix applied to keep about application in read only mode when editing a previous submission. This prevents the user from changing details such as datasets applied for, application name etc.