### PR TITLE
DAR - Make a decision dropdown - Fix display issue in Safari

### DIFF
--- a/src/pages/DataAccessRequest/DataAccessRequest.js
+++ b/src/pages/DataAccessRequest/DataAccessRequest.js
@@ -1050,10 +1050,7 @@ class DataAccessRequest extends Component {
 		});
 	};
 
-	onCustodianAction = e => {
-		let {
-			target: { value },
-		} = e;
+	onCustodianAction = value => {
 		value === 'AssignWorkflow' ? this.toggleAssignWorkflowModal() : this.toggleActionModal(value);
 	};
 

--- a/src/pages/DataAccessRequest/DataAccessRequest.scss
+++ b/src/pages/DataAccessRequest/DataAccessRequest.scss
@@ -820,13 +820,14 @@ input[type='checkbox']:after {
 
 .makeADecisionDropdown {
 	position: relative;
+	left:-87px !important;
 	width: 320px !important;
 	max-height: 314px !important;
 	box-shadow: 3px 3px 6px 0 rgba(0, 0, 0, 0.09), -3px -3px 4px 0 rgba(0, 0, 0, 0.03) !important;
 	background-color: $white !important;
 	padding: 12px 16px 12px 16px !important;
 
-	option {
+	.option {
 		padding: 4px 0;
 	}
 }
@@ -844,7 +845,7 @@ input[type='checkbox']:after {
 	margin-bottom: 20px;
 	position: relative;
 
-	option {
+	.option {
 		padding: 4px 0;
 	}
 

--- a/src/pages/DataAccessRequest/components/CustodianActionButtons/CustodianActionButtons.js
+++ b/src/pages/DataAccessRequest/components/CustodianActionButtons/CustodianActionButtons.js
@@ -71,12 +71,12 @@ const CustodianActionButtons = ({
 								<Row className='makeADecisionHeader'>
 									<span className='gray800-14-bold mb-1'>Review this phase</span>
 								</Row>
-								<option className='gray800-14 pointer' onClick={e => onWorkflowReviewDecisionClick(false)}>
+								<div className='gray800-14 pointer option' onClick={e => onWorkflowReviewDecisionClick(false)}>
 									Issues found
-								</option>
-								<option className='gray800-14 pointer' onClick={e => onWorkflowReviewDecisionClick(true)}>
+								</div>
+								<div className='gray800-14 pointer option' onClick={e => onWorkflowReviewDecisionClick(true)}>
 									No issues found
-								</option>
+								</div>
 							</div>
 						)}
 						{roles.includes('manager') && (
@@ -86,15 +86,15 @@ const CustodianActionButtons = ({
 									<br />
 									<span className='gray700-13 mb-2'>This will end the review process and send a final response to the applicant</span>
 								</Row>
-								<option className='gray800-14 pointer' onClick={e => onActionClick(e)} value='Approve'>
+								<div className='gray800-14 pointer option' onClick={e => onActionClick('Approve')}>
 									Approve
-								</option>
-								<option className='gray800-14 pointer' onClick={e => onActionClick(e)} value='ApproveWithConditions'>
+								</div>
+								<div className='gray800-14 pointer option' onClick={e => onActionClick('ApproveWithConditions')}>
 									Approve with conditions
-								</option>
-								<option className='gray800-14 pointer' onClick={e => onActionClick(e)} value='Reject'>
+								</div>
+								<div className='gray800-14 pointer option' onClick={e => onActionClick('Reject')}>
 									Reject
-								</option>
+								</div>
 							</Fragment>
 						)}
 					</Dropdown.Menu>


### PR DESCRIPTION
Browser compatibility testing showed Safari's inability to render option tags inside only select parents, meaning that the React-bootstrap Dropdown does not work properly.

The fix was to change the option elements to clickable divs and apply to appropriate styling for it to render again.

Now re-tested in all browsers.

![Screenshot 2020-12-22 at 15 03 26](https://user-images.githubusercontent.com/67896409/102902432-e688a580-4466-11eb-96af-04dab132bc74.png)
