### PR TITLE
IG-1204 IE - Registration fix rednering on selected dropdown for sector

### DIFF
--- a/src/css/styles.scss
+++ b/src/css/styles.scss
@@ -1591,4 +1591,6 @@ button a {
 .sectorValue {
 	position: absolute;
 	z-index: 1;
+	top: 13px;
+	left: 15px;
 }


### PR DESCRIPTION
# PR
[IG-1204 IE - Registration fix rednering on selected dropdown for sector](https://hdruk.atlassian.net/browse/IG-1204?atlOrigin=eyJpIjoiMTdiYWJmZDI3MzRjNGFmMmIxYWU4YjRlYWRkYWRkN2MiLCJwIjoiaiJ9)

## Browser Compatibility
Testing via PA browserstack

- [x] IE 11
- [x] Edge
- [x] Safari 14
- [x] Firefox 83
- [x] Chrome 86

## Solution decsription 
Rendering issue with account **'Sector'** dropdown.

The issue is visible by logging in and navigating to user account and viewing **‘Sector'** within **IE 11**. The main cause is with the absolute position value set on the value class, IE is rendering it correctly to it’s browsers document object model. There should be a top and left property added to this class within the CSS, it is standard practice that an absolute position must have a property for each axis (x, y or top, right, bottom, left). The reason for this is, to set it in relation to the parent containing div so it knows how to position the element relatively.New properties to the class of **'sectorValue' top: 13px; left: 15px;**


![WIN_10_IE_11](https://user-images.githubusercontent.com/65283091/104470558-bdfd5280-55b1-11eb-8773-7a66ee981630.png)
