### PR TITLE
Winterfell Package.json update

### DIFF
--- a/package.json
+++ b/package.json
@@ -49,7 +49,7 @@
     "snyk": "^1.425.4",
     "uniqid": "^5.2.0",
     "uuid": "^8.3.1",
-    "winterfell": "github:HDRUK/Winterfell#HDWIN-008-FlagsHover",
+    "winterfell": "github:HDRUK/Winterfell",
     "yup": "^0.28.1"
   },
   "scripts": {


### PR DESCRIPTION
# PR
Winterfell package.json update

## Issue
Winterfell was using a development branch FlagsHover in our dev branch (package.json). The  branch HDWIN-008-FlagsHover has now been merged into HDRUK>Winterfell (master). The resource has been update to reflect.