### PR TITLE
SUPP-339 - Project uploader shown as ID NOT name

### DIFF
--- a/src/pages/paper/PaperPage.js
+++ b/src/pages/paper/PaperPage.js
@@ -392,7 +392,7 @@ export const PaperDetail = props => {
 																Uploader
 															</Col>
 															<Col sm={10} className='gray800-14 overflowWrap'>
-																{paperData.uploaderIs[0].firstname} {paperData.uploaderIs[0].lastname}
+																{paperData.uploader}
 															</Col>
 														</Row>
 													) : (

--- a/src/pages/tool/ToolPage.js
+++ b/src/pages/tool/ToolPage.js
@@ -459,7 +459,7 @@ export const ToolDetail = props => {
 																Uploader
 															</Col>
 															<Col sm={10} className='gray800-14 overflowWrap'>
-																{toolData.uploaderIs[0].firstname} {toolData.uploaderIs[0].lastname}
+																{toolData.uploader}
 															</Col>
 														</Row>
 													) : (


### PR DESCRIPTION
# PR
[SUPP 339](https://hdruk.atlassian.net/browse/SUPP-339?atlOrigin=eyJpIjoiYzA0NjgyOGZmYzkzNDFjYTgwZGFiZDNlY2IxMjIwMDIiLCJwIjoiaiJ9)

## Solution description
An small issue was reported that the Uploader field within Tool, Projects and Papers was outputting the numeric user id based in tools > users. A solution has been implemented to declare a new field called **uploader** which concats **$uploaderIs** and selects out the users **firstname** and **lastname** 

Backend API update

![SUPP-339](https://user-images.githubusercontent.com/65283091/104612702-67117f00-567e-11eb-99c1-af10f0f740b0.png)

Frontend 

![SUPP-339-FE](https://user-images.githubusercontent.com/65283091/104613159-d8513200-567e-11eb-86e1-cb33c7cb9d1d.png)

