### PR TITLE
Clickable links on datasets regression fix

### DIFF
--- a/src/pages/dataset/components/AboutCardElement.js
+++ b/src/pages/dataset/components/AboutCardElement.js
@@ -1,5 +1,6 @@
 import React from 'react';
 import { Col, Row } from 'react-bootstrap';
+import Linkify from 'react-linkify';
 import '../Dataset.scss';
 import _ from 'lodash';
 import { ReactComponent as InfoSVG } from '../../../images/info.svg';
@@ -60,13 +61,13 @@ class AboutCardElement extends React.Component {
 						<Col sm={8} className='gray800-14 v2Value'>
 							{typeof description === 'object' ? (
 								description.map((item, index) => (
-									<span className='overflowWrap'>
+									<Linkify properties={{target: '_blank'}} className='overflowWrap'>
 										{' '}
 										{index !== 0 ? ', ' : ''} {item}
-									</span>
+									</Linkify>
 								))
 							) : (
-								<span className='overflowWrap'>{description}</span>
+								<Linkify properties={{target: '_blank'}} className='overflowWrap'>{description}</Linkify>
 							)}
 						</Col>
 					)}


### PR DESCRIPTION
# PR
AboutCardElement was missing Linkify

## Solution 
Links were broken on datasets which used the AboutCardElement so this PR wraps the necessary information to ensure that hyperlinks are created once the data is rendered. 