### PR TITLE
SUPP-369 - On DAR submission, custodian emails do not contain NCS project details

### DIFF
--- a/src/pages/DataAccessRequest/components/AboutApplication/AboutApplication.js
+++ b/src/pages/DataAccessRequest/components/AboutApplication/AboutApplication.js
@@ -180,7 +180,7 @@ const AboutApplication = props => {
 													Select a project
 												</option>
 												{nationalCoreStudiesProjects.map(item => (
-													<option key={item._id} value={item._id}>
+													<option key={item.id} value={item.id}>
 														{item.name}
 													</option>
 												))}


### PR DESCRIPTION
- Changed storage of NCS project within DAR application from _id to id, in order to provide a working hyperlink when submitting the application. This is due to the website accepting the numeric id as the route value to identify the correct project to load.