### PR TITLE
Fixed overflow for team dropdown in dashboard area

### DIFF
--- a/src/pages/dashboard/Dashboard.scss
+++ b/src/pages/dashboard/Dashboard.scss
@@ -269,6 +269,10 @@ textarea {
 	padding: 4px 0px 0px 45px !important;
 }
 
+.teamSelectorMenu .dropdown-item {
+	white-space: normal;
+}
+
 .custom-dropdown {
 	max-width: 375px;
 	width: 100%;


### PR DESCRIPTION
-Added text wrapping to allow navigation dropdown to show longer team names without overflowing, default css property was no-wrap