### PR TITLE
SUPP-389 - Fixed error thrown in DAR selection of multiple datasets if any dataset is missing a required value

### DIFF
--- a/src/pages/DataAccessRequest/components/TypeaheadDataset/TypeaheadDataset.js
+++ b/src/pages/DataAccessRequest/components/TypeaheadDataset/TypeaheadDataset.js
@@ -73,7 +73,7 @@ class TypeaheadDataset extends React.Component {
 				renderMenuItemChildren={(option, props) => (
 					<div>
 						<div className='datasetName'>{option.name}</div>
-						<div className='datasetDescription'>{option.description || option.datasetfields.abstract}</div>
+						<div className='datasetDescription'>{option.description || option.abstract || 'No description set'}</div>
 					</div>
 				)}
 			/>


### PR DESCRIPTION
- The dataset autocomplete component had a fail over to use the abstract of the dataset in the event the description property was missing.  This was throwing an error as the path was incorrect in the case of the failover.  This PR fixed the path and adds a further default value in the event both description and abstract are missing.