### PR TITLE
SUPP-419 Collection render issue

### DIFF
--- a/src/css/styles.scss
+++ b/src/css/styles.scss
@@ -1591,6 +1591,11 @@ button a {
 	margin-right: 12px;
 }
 
+.hdruk-section-body p a[href] {
+	word-break: break-all;
+	word-wrap: break-word;
+}
+
 .text-break {
 	word-break: break-all;
 	overflow-wrap: break-word !important;

--- a/src/css/styles.scss
+++ b/src/css/styles.scss
@@ -1591,7 +1591,7 @@ button a {
 	margin-right: 12px;
 }
 
-.hdruk-section-body p a[href] {
+.hdruk-section-body p > a[href] {
 	word-break: break-all;
 	word-wrap: break-word;
 }

--- a/src/css/styles.scss
+++ b/src/css/styles.scss
@@ -1591,7 +1591,7 @@ button a {
 	margin-right: 12px;
 }
 
-.hdruk-section-body p > a[href] {
+.hdruk-section-body p a[href] {
 	word-break: break-all;
 	word-wrap: break-word;
 }

--- a/src/pages/collections/CollectionPage.js
+++ b/src/pages/collections/CollectionPage.js
@@ -257,8 +257,8 @@ export const CollectionPage = props => {
 
 					<Row className='pad-top-32'>
 						<Col sm={1} lg={1} />
-						<Col sm={10} lg={10} className='gray800-14'>
-							<ReactMarkdown className='text-break' source={collectionData.description} data-testid='collectionDescription' />
+						<Col sm={10} lg={10} className='gray800-14 hdruk-section-body'>
+							<ReactMarkdown source={collectionData.description} data-testid='collectionDescription' />
 						</Col>
 						<Col sm={1} lg={1} />
 					</Row>

--- a/src/pages/commonComponents/relatedObject/RelatedObject.js
+++ b/src/pages/commonComponents/relatedObject/RelatedObject.js
@@ -331,7 +331,7 @@ class RelatedObject extends React.Component {
 										</Col>
 										{!this.props.showRelationshipQuestion && (
 											<Col sm={12} lg={12} className='pad-left-24 pad-right-24 pad-top-24 pad-bottom-16'>
-												<span className='gray800-14 text-break'>
+												<span className='gray800-14'>
 													{data.description.substr(0, 255) + (data.description.length > 255 ? '...' : '')}
 												</span>
 											</Col>
@@ -469,7 +469,7 @@ class RelatedObject extends React.Component {
 										</Col>
 										{!this.props.showRelationshipQuestion && (
 											<Col sm={12} lg={12} className='pad-left-24 pad-right-24 pad-top-24 pad-bottom-16'>
-												<span className='gray800-14 text-break'>
+												<span className='gray800-14'>
 													{data.description.substr(0, 255) + (data.description.length > 255 ? '...' : '')}
 												</span>
 											</Col>
@@ -588,7 +588,7 @@ class RelatedObject extends React.Component {
 										</Col>
 										{!this.props.showRelationshipQuestion && (
 											<Col sm={12} lg={12} className='pad-left-24 pad-right-24 pad-top-24 pad-bottom-16'>
-												<span className='gray800-14 text-break'>
+												<span className='gray800-14'>
 													{data.description.substr(0, 255) + (data.description.length > 255 ? '...' : '')}
 												</span>
 											</Col>
@@ -619,7 +619,7 @@ class RelatedObject extends React.Component {
 												</span>
 											)}
 											<br />
-											<span className='gray800-14 text-break'> {data.bio} </span>
+											<span className='gray800-14'> {data.bio} </span>
 										</Col>
 										<Col sm={2} lg={2} className='pad-right-24'>
 											{this.props.showRelationshipQuestion ? (
@@ -748,7 +748,7 @@ class RelatedObject extends React.Component {
 										</Col>
 										{!this.props.showRelationshipQuestion && (
 											<Col sm={12} lg={12} className='pad-left-24 pad-right-24 pad-top-24 pad-bottom-16'>
-												<span className='gray800-14 text-break'>
+												<span className='gray800-14'>
 													{data.description.substr(0, 255) + (data.description.length > 255 ? '...' : '')}
 												</span>
 											</Col>

--- a/src/pages/course/CoursePage.js
+++ b/src/pages/course/CoursePage.js
@@ -336,8 +336,8 @@ export const CourseDetail = props => {
 														<Col sm={12}>Description</Col>
 													</Row>
 													<Row className='mt-3'>
-														<Col sm={12} className='gray800-14'>
-															<ReactMarkdown className='text-break' source={courseData.description} />
+														<Col sm={12} className='gray800-14 hdruk-section-body'>
+															<ReactMarkdown source={courseData.description} />
 														</Col>
 													</Row>
 												</div>
@@ -352,8 +352,8 @@ export const CourseDetail = props => {
 															<Col sm={12}>Results/Insights</Col>
 														</Row>
 														<Row className='mt-3'>
-															<Col sm={12} className='gray800-14'>
-																<ReactMarkdown className='text-break' source={courseData.resultsInsights} />
+															<Col sm={12} className='gray800-14 hdruk-section-body'>
+																<ReactMarkdown source={courseData.resultsInsights} />
 															</Col>
 														</Row>
 													</div>

--- a/src/pages/paper/PaperPage.js
+++ b/src/pages/paper/PaperPage.js
@@ -477,8 +477,8 @@ export const PaperDetail = props => {
 													</Row>
 													<Row className='mt-3'>
 														<Col>
-															<span className='gray800-14'>
-																<ReactMarkdown className='text-break' source={paperData.description} />
+															<span className='gray800-14 hdruk-section-body'>
+																<ReactMarkdown source={paperData.description} />
 															</span>
 														</Col>
 													</Row>
@@ -497,8 +497,8 @@ export const PaperDetail = props => {
 														</Row>
 														<Row className='mt-3'>
 															<Col>
-																<span className='gray800-14'>
-																	<ReactMarkdown className='text-break' source={paperData.resultsInsights} />
+																<span className='gray800-14 hdruk-section-body'>
+																	<ReactMarkdown source={paperData.resultsInsights} />
 																</span>
 															</Col>
 														</Row>

--- a/src/pages/project/ProjectPage.js
+++ b/src/pages/project/ProjectPage.js
@@ -320,8 +320,8 @@ export const ProjectDetail = props => {
 														<Col sm={12}>Description</Col>
 													</Row>
 													<Row className='mt-3'>
-														<Col sm={12} className='gray800-14'>
-															<ReactMarkdown className='text-break' source={projectData.description} />
+														<Col sm={12} className='gray800-14 hdruk-section-body'>
+															<ReactMarkdown source={projectData.description} />
 														</Col>
 													</Row>
 												</div>
@@ -336,8 +336,8 @@ export const ProjectDetail = props => {
 															<Col sm={12}>Results/Insights</Col>
 														</Row>
 														<Row className='mt-3'>
-															<Col sm={12} className='gray800-14'>
-																<ReactMarkdown className='text-break' source={projectData.resultsInsights} />
+															<Col sm={12} className='gray800-14 hdruk-section-body'>
+																<ReactMarkdown source={projectData.resultsInsights} />
 															</Col>
 														</Row>
 													</div>

--- a/src/pages/tool/ToolPage.js
+++ b/src/pages/tool/ToolPage.js
@@ -406,7 +406,7 @@ export const ToolDetail = props => {
 															<Col sm={12}>Results/Insights</Col>
 														</Row>
 														<Row className='mt-3'>
-															<Col sm={12} className='gray800-14 hrduk-section-body'>
+															<Col sm={12} className='gray800-14 hdruk-section-body'>
 																<ReactMarkdown source={toolData.resultsInsights} />
 															</Col>
 														</Row>

--- a/src/pages/tool/ToolPage.js
+++ b/src/pages/tool/ToolPage.js
@@ -390,8 +390,8 @@ export const ToolDetail = props => {
 														<Col sm={12}>Description</Col>
 													</Row>
 													<Row className='mt-3'>
-														<Col sm={12} className='gray800-14' data-test-id='tool-description'>
-															<ReactMarkdown className='text-break' source={toolData.description} />
+														<Col sm={12} className='gray800-14 hdruk-section-body' data-test-id='tool-description'>
+															<ReactMarkdown source={toolData.description} />
 														</Col>
 													</Row>
 												</div>
@@ -406,8 +406,8 @@ export const ToolDetail = props => {
 															<Col sm={12}>Results/Insights</Col>
 														</Row>
 														<Row className='mt-3'>
-															<Col sm={12} className='gray800-14'>
-																<ReactMarkdown className='text-break' source={toolData.resultsInsights} />
+															<Col sm={12} className='gray800-14 hrduk-section-body'>
+																<ReactMarkdown source={toolData.resultsInsights} />
 															</Col>
 														</Row>
 													</div>


### PR DESCRIPTION
# PR
[SUPP-419](https://hdruk.atlassian.net/browse/SUPP-419)

## Issue 
Request to change the rendering of words within our collections, tools, papers, projects as requested by HDRUK. Words split across multiple lines as a direct result of our text-break class which was introduced to handle URLS. The new CSS will target a div specifically and only a[href] attributes which need to break if they are lengthy and have the potential to break the overall layout.

### Tests
Tested using UATBeta database via localhost, various tools that used ReactMarkdown and anchors within these  areas.
- Tools, created and viewed ALL OK /tool/4764541661155508
- Projects, created and viewed  ALL OK  /project/5377703726941019
-  Papers, updated and viewed ALL OK, /paper/5379076543724559
- Courses, updated and viewed ALL OK, /course/8862855021445375
- Collections, updated and viewed ALL OK /collection/377490360482964
- Related resources rendering



 