### PR TITLE
Exit report - 2.8 modifications

### DIFF
--- a/src/pages/dashboard/AccountAdvancedSearch.js
+++ b/src/pages/dashboard/AccountAdvancedSearch.js
@@ -104,7 +104,7 @@ export const AccountAdvancedSearch = props => {
 						<p className='gray800-15 margin-bottom-6'>
 							Cohort Discovery provides remote querying of multiple clinical databases in situ, even those with different data models to
 							determine the dataset appropriate for your research needs. We are adding more datasets into the cohort discovery service
-							monthly, please check back in form time to time to discover datasets suitable for your research.
+							monthly, please check back in from time to time to discover datasets suitable for your research.
 						</p>
 					</div>
 				</Col>
@@ -118,7 +118,7 @@ export const AccountAdvancedSearch = props => {
 						<Card className={activeAccordionCardState === 0 ? 'activeCard datasetCard' : 'datasetCard'}>
 							<Accordion.Toggle as={Card.Header} eventKey='0' onClick={e => toggleCard(e, 0)} className='datasetCard'>
 								<div className={activeAccordionCardState === 0 ? 'stepNumber active' : 'stepNumber'}>1</div>
-								<span className='black-16 noTextDecoration'>Creating a cohort</span>
+								<span className='black-16 noTextDecoration'>Creating cohorts</span>
 							</Accordion.Toggle>
 							<Accordion.Collapse eventKey='0'>
 								<Card.Body className='datasetCard gray800-14'>

--- a/src/pages/dashboard/AdvancedSearchTAndCsModal.js
+++ b/src/pages/dashboard/AdvancedSearchTAndCsModal.js
@@ -88,7 +88,7 @@ const AdvancedSearchTAndCsModal = ({ open, close, updateUserAcceptedAdvancedSear
 									<p>
 										This Gateway Portal (the <b>“site“</b>) is operated by Health Data Research UK (“HDR UK”). HDR UK is a limited company
 										registered in England and Wales under company number 10887014 and its registered office is at 215 Euston Road, London,
-										England, NW1 2BE.w
+										England, NW1 2BE.
 									</p>
 									<p>To contact us, please use the contact details on our page.</p>
 									<p id='terms-3' className='termsSubtitle'>


### PR DESCRIPTION
Text updates only for exit report sprint 2.8

**Cohort discovery**

- ‘Creating a Cohort’, instead of 'Creating Cohorts' title grammar.
- Random 'w' at end of address in Cohort Discovery T&Cs
- 'Form' typo in section header change to 'from'
