### PR TITLE
IG-1442 - Update dataset typeahead to support multiple publishers

### DIFF
--- a/src/pages/DataAccessRequest/DataAccessRequest.scss
+++ b/src/pages/DataAccessRequest/DataAccessRequest.scss
@@ -570,7 +570,7 @@ input[type='radio']:disabled {
 	}
 }
 
-.datasetName {
+.optionName {
 	@include font-source(14px, $gray-800, $font-weight-semibold);
 	width: 100%;
 	white-space: nowrap;
@@ -578,7 +578,7 @@ input[type='radio']:disabled {
 	text-overflow: ellipsis;
 }
 
-.datasetDescription {
+.optionDescription {
 	@include font-source(14px, $gray-600, $font-weight-semibold);
 	width: 100%;
 	white-space: nowrap;

--- a/src/pages/DataAccessRequest/components/AboutApplication/AboutApplication.js
+++ b/src/pages/DataAccessRequest/components/AboutApplication/AboutApplication.js
@@ -83,6 +83,7 @@ const AboutApplication = props => {
 										selectedDatasets={selectedDatasets}
 										onHandleDataSetChange={e => onHandleDataSetChange(e)}
 										readOnly={readOnly}
+										allowAllCustodians={false}
 									/>
 								</div>
 								{_.isEmpty(selectedDatasets) ? <div className='errorMessages'>You must select at least one dataset</div> : null}

--- a/src/pages/DataAccessRequest/components/TypeaheadDataset/TypeaheadDataset.js
+++ b/src/pages/DataAccessRequest/components/TypeaheadDataset/TypeaheadDataset.js
@@ -23,22 +23,24 @@ class TypeaheadDataset extends React.Component {
 	}
 
 	componentDidUpdate(prevProps) {
-		debugger;
-		if (this.props.selectedDatasets !== prevProps.selectedDatasets) {
-			this.setState({
-				value: this.props.selectedDatasets,
-			});
-			if (this.props.selectedDatasets.length < 2) {
+		const { selectedDatasets } = this.props;
+		if (selectedDatasets !== prevProps.selectedDatasets) {
+			if (selectedDatasets.length < 2) {
 				this.getData();
 			}
+			this.setState({
+				value: selectedDatasets,
+			});
 		}
 	}
 
 	getData() {
+		const { selectedDatasets, allowAllCustodians } = this.props;
 		let { publisher } = this.state;
-		if (this.props.selectedDatasets && this.props.selectedDatasets.length > 0) {
-			({ publisher } = this.props.selectedDatasets[0]);
-		} else if (this.props.allowAllCustodians) {
+		
+		if (selectedDatasets && selectedDatasets.length > 0) {
+			({ publisher } = selectedDatasets[0]);
+		} else if (allowAllCustodians) {
 			publisher = null;
 		}
 

--- a/src/pages/DataAccessRequest/components/TypeaheadDataset/TypeaheadDataset.js
+++ b/src/pages/DataAccessRequest/components/TypeaheadDataset/TypeaheadDataset.js
@@ -23,21 +23,28 @@ class TypeaheadDataset extends React.Component {
 	}
 
 	componentDidUpdate(prevProps) {
+		debugger;
 		if (this.props.selectedDatasets !== prevProps.selectedDatasets) {
 			this.setState({
 				value: this.props.selectedDatasets,
 			});
+			if (this.props.selectedDatasets.length < 2) {
+				this.getData();
+			}
 		}
 	}
 
 	getData() {
-		let publisher;
-		if (this.props.selectedDatasets) {
-			 ({ publisher } = this.props.selectedDatasets[0]);
-			this.setState({
-				publisher,
-			});
+		let { publisher } = this.state;
+		if (this.props.selectedDatasets && this.props.selectedDatasets.length > 0) {
+			({ publisher } = this.props.selectedDatasets[0]);
+		} else if (this.props.allowAllCustodians) {
+			publisher = null;
 		}
+
+		this.setState({
+			publisher,
+		});
 
 		axios
 			.get(`${baseURL}/api/v2/datasets`, {
@@ -47,7 +54,7 @@ class TypeaheadDataset extends React.Component {
 					populate: 'publisher',
 					is5Safes: true,
 					...(publisher ? { ['datasetfields.publisher']: publisher } : {}),
-				}
+				},
 			})
 			.then(res => {
 				const {

--- a/src/pages/DataAccessRequest/components/TypeaheadDataset/TypeaheadDataset.js
+++ b/src/pages/DataAccessRequest/components/TypeaheadDataset/TypeaheadDataset.js
@@ -37,7 +37,7 @@ class TypeaheadDataset extends React.Component {
 	getData() {
 		const { selectedDatasets, allowAllCustodians } = this.props;
 		let { publisher } = this.state;
-		
+
 		if (selectedDatasets && selectedDatasets.length > 0) {
 			({ publisher } = selectedDatasets[0]);
 		} else if (allowAllCustodians) {
@@ -98,6 +98,20 @@ class TypeaheadDataset extends React.Component {
 		});
 	}
 
+	datasetOption(item) {
+		const { publisher = 'No publisher set', description, abstract, name: optionName = 'No dataset name' } = item;
+		const { publisher: publisherSelected } = this.state;
+		const optionDescription =
+			publisherSelected === null ? publisher : description || abstract || 'No description set';
+
+		return (
+			<div>
+				<div className='optionName'>{optionName}</div>
+				<div className='optionDescription'>{optionDescription}</div>
+			</div>
+		);
+	}
+
 	render() {
 		return (
 			<Typeahead
@@ -114,12 +128,7 @@ class TypeaheadDataset extends React.Component {
 				disabled={this.state.readOnly}
 				defaultSelected={this.state.value}
 				labelKey={options => `${options.name}`}
-				renderMenuItemChildren={(option, props) => (
-					<div>
-						<div className='datasetName'>{option.name}</div>
-						<div className='datasetDescription'>{option.description || option.abstract || 'No description set'}</div>
-					</div>
-				)}
+				renderMenuItemChildren={option => this.datasetOption(option)}
 			/>
 		);
 	}


### PR DESCRIPTION
Update dataset typeahead to support multiple publishers when no publisher is set.  This needs to be configurable by a property, so that the DAR application form is not affected as it should only ever render datasets for one publisher.

- Updated dataset typeahead
- Updated DAR application form instance of typeahead to use only single custodian
- Made css classes generic to reflect changes in typeahead options output (can be either dataset description or publisher name now)