### PR TITLE
Linked datasets should match on title not URL

### DIFF
--- a/src/pages/dataset/DatasetPage.js
+++ b/src/pages/dataset/DatasetPage.js
@@ -325,15 +325,13 @@ class DatasetDetail extends Component {
 		} else {
 			// 2. Check if relation is a String that matches a dataset title
 			await axios.get(baseURL + '/api/v1/relatedobject/linkeddatasets/' + relation).then(async res => {
-				const { datasetFound, pid } = res.data;
+				const { datasetFound, pid, name, publisher } = res.data;
 				if (datasetFound && !_.isNil(pid)) {
-					await axios.get(baseURL + '/api/v1/relatedobject/' + pid).then(async res => {
-						linkedDatasets.push({
-							title: res.data.data[0].name,
-							info: res.data.data[0].datasetfields.publisher,
-							type: 'gatewaylink',
-							id: pid,
-						});
+					linkedDatasets.unshift({
+						title: name,
+						info: publisher,
+						type: 'gatewaylink',
+						id: pid,
 					});
 				} else {
 					// 3. Else determine that relation is an unrecognised dataset title


### PR DESCRIPTION
On linked datasets we are showing a dataset link only if MDC input data matches a **URL link** to a dataset on the gateway.  This logic is incorrect.  We should be showing the dataset link if MDC input data matches a **Dataset title** instead.
This change involves calling a new endpoint to check if a dataset exists in our database based on a given dataset title.

Logic from ticket:
"On linked datasets, we have a bit of code to identify the input from the user.

How it works today:

1. URL + matches Gateway dataset = show dataset link
2. URL + does not match Gateway dataset = show external linK
3. String of text = show unrecognised dataset label + link to search

How it should be:

1. Dataset title + matches Gateway dataset = show dataset link
2. URL = show external link (any URL, gateway or not)
3. String of text = show unrecognised dataset label + link to search"