### PR TITLE
DAR - Cloning - Fixed locking dataset selector and spelling mistakes

### DIFF
--- a/src/pages/DataAccessRequest/DataAccessRequest.js
+++ b/src/pages/DataAccessRequest/DataAccessRequest.js
@@ -1532,6 +1532,7 @@ class DataAccessRequest extends Component {
 		if (activePanelId === 'about') {
 			return (
 				<AboutApplication
+					key={this.state._id}
 					activeAccordionCard={this.state.activeAccordionCard}
 					allowedNavigation={this.state.allowedNavigation}
 					userType={this.state.userType}

--- a/src/pages/DataAccessRequest/components/AboutApplication/AboutApplication.js
+++ b/src/pages/DataAccessRequest/components/AboutApplication/AboutApplication.js
@@ -42,8 +42,6 @@ const AboutApplication = props => {
 		context,
 	} = props;
 
-	debugger;
-
 	return (
 		<div className='aboutAccordion'>
 			<Accordion defaultActiveKey='0' activeKey={activeAccordionCard.toString()}>

--- a/src/pages/DataAccessRequest/components/AboutApplication/AboutApplication.js
+++ b/src/pages/DataAccessRequest/components/AboutApplication/AboutApplication.js
@@ -9,6 +9,7 @@ import TypeaheadDataset from '../TypeaheadDataset/TypeaheadDataset';
 
 const AboutApplication = props => {
 	let {
+		key,
 		activeAccordionCard,
 		allowedNavigation,
 		userType,
@@ -16,7 +17,7 @@ const AboutApplication = props => {
 		toggleDrawer,
 		onHandleDataSetChange,
 		selectedDatasets,
-		readOnly = true,
+		readOnly = false,
 		onNextStep,
 		projectNameValid = true,
 		projectName = '',
@@ -40,6 +41,8 @@ const AboutApplication = props => {
 		toggleContributorModal,
 		context,
 	} = props;
+
+	debugger;
 
 	return (
 		<div className='aboutAccordion'>
@@ -80,6 +83,7 @@ const AboutApplication = props => {
 								<span>Datasets</span>
 								<div className='form-group'>
 									<TypeaheadDataset
+										key={key}
 										selectedDatasets={selectedDatasets}
 										onHandleDataSetChange={e => onHandleDataSetChange(e)}
 										readOnly={readOnly}

--- a/src/pages/DataAccessRequest/components/DuplicateApplicationModal/DuplicateApplicationModal.js
+++ b/src/pages/DataAccessRequest/components/DuplicateApplicationModal/DuplicateApplicationModal.js
@@ -52,7 +52,7 @@ const DuplicateApplicationModal = ({ isOpen, closeModal, duplicateApplication, s
 					<div className='duplicateApplicationModal-alert--icon'>
 						<SVGIcon name='attention' width={16} height={16} fill={'#f0bb24'} className='duplicateApplicationModal-alert--icon--svg' />
 					</div>
-					<div>By selecting a pre-submission application, any already existing answers will be overriden.</div>
+					<div>By selecting a pre-submission application, any already existing answers will be overridden.</div>
 				</Alert>
 			</div>
 			<div className='duplicateApplicationModal-body'>


### PR DESCRIPTION
Fixed a state issue relating to the reload of the application page once a clone operation had completed.  Previously, the dataset selector was being disabled when the page loaded the newly created application.

**Development** 

- Added a key prop to be passed down through component tree to ensure all child component re-render (DAR -> About application -> Dataset selector)
- Fixed spelling mistake