### PR TITLE
IG-1413 - Moved members tab into team notifications

### DIFF
--- a/src/css/styles.scss
+++ b/src/css/styles.scss
@@ -182,6 +182,7 @@ button {
 }
 
 .subHeader {
+	display: flex;
 	box-shadow: 1px 1px 3px 0 rgba(0, 0, 0, 0.09);
 	background-color: $white;
 	width: 100%;
@@ -190,6 +191,7 @@ button {
 }
 
 .entryBox {
+	display: flex;
 	width: 100%;
 	box-shadow: 1px 1px 3px 0 #00000017;
 	background-color: $white;

--- a/src/pages/dashboard/Account.js
+++ b/src/pages/dashboard/Account.js
@@ -91,6 +91,7 @@ class Account extends Component {
 		profileComplete: true,
 		savedTeamNotificationSuccess: false,
 		isSubmitting: false,
+		teamManagementInternalTab: 'Notifications'
 	};
 
 	constructor(props) {
@@ -356,6 +357,10 @@ class Account extends Component {
 		this.setState({ isSubmitting, savedTeamNotificationSuccess });
 	};
 
+	onTeamManagementTabChange = (teamManagementTab) => {
+		this.setState({ teamManagementTab: teamManagementTab});
+	}
+
 	render() {
 		const {
 			searchString,
@@ -372,6 +377,7 @@ class Account extends Component {
 			datasetAccordion,
 			savedTeamNotificationSuccess,
 			isSubmitting,
+			teamManagementTab
 		} = this.state;
 		if (typeof data.datasetids === 'undefined') {
 			data.datasetids = [];
@@ -566,12 +572,12 @@ class Account extends Component {
 											</Fragment>
 										)}
 									</div>
-									<div className={`${tabId === 'members' ? 'activeCard' : 'accountNav'}`} onClick={e => this.toggleNav('members')}>
+									{/* <div className={`${tabId === 'members' ? 'activeCard' : 'accountNav'}`} onClick={e => this.toggleNav('members')}>
 										<Nav.Link className='verticalNavBar gray700-13'>
 											<MembersSvg className='membersSvg' />
 											<span style={{ marginLeft: '11px' }}>Members</span>
 										</Nav.Link>
-									</div>
+									</div> */}
 									<div className={`${tabId === 'help' ? 'activeCard' : 'accountNav'}`} onClick={e => this.toggleNav('help')}>
 										<Nav.Link className='verticalNavBar gray700-13'>
 											<SVGIcon name='info' fill={'#b3b8bd'} className='accountSvgs' />
@@ -618,12 +624,13 @@ class Account extends Component {
 									this.saveNotifiations = c;
 								}}
 								onTeamManagementSave={this.onTeamManagementSave}
+								onTeamManagementTabChange={this.onTeamManagementTabChange}
 							/>
 						) : (
 							''
 						)}
 
-						{tabId === 'members' ? <AccountMembers userState={userState} team={team} teamId={teamId} /> : ''}
+						{/* {tabId === 'members' ? <AccountMembers userState={userState} team={team} teamId={teamId} /> : ''} */}
 
 						{tabId === 'help' ? <TeamHelp /> : ''}
 					</div>
@@ -637,7 +644,7 @@ class Account extends Component {
 						drawerIsOpen={this.state.showDrawer}
 					/>
 				</SideDrawer>
-				{tabId === 'teamManagement' && (
+				{tabId === 'teamManagement' && teamManagementTab == 'Notifications' && (
 					<ActionBar userState={userState}>
 						<div>
 							{/* <button className='btn btn-primary white-14-semibold' onClick={this.onSaveNotificationsClick} type='button'>Save</button> */}

--- a/src/pages/dashboard/AccountMembers.js
+++ b/src/pages/dashboard/AccountMembers.js
@@ -74,9 +74,9 @@ export const AccountMembers = props => {
 			<Row>
 				<Col xs={1}></Col>
 				<Col xs={10}>
-					<Row className='accountHeader'>
+					<div className='accountHeader d-flex'>
 						<Col sm={12} md={9}>
-							<Row className=''>
+							<Row>
 								<span className='black-20'>Members</span>
 							</Row>
 							<Row>
@@ -112,7 +112,7 @@ export const AccountMembers = props => {
 								''
 							)}
 						</Col>
-					</Row>
+					</div>
 
 					{(() => {
 						return (
@@ -120,11 +120,11 @@ export const AccountMembers = props => {
 								{members.length <= 0 ? (
 									''
 								) : (
-									<Row className='subHeader mt-3 gray800-14-bold'>
+									<div className='subHeader mt-3 gray800-14-bold'>
 										<Col xs={5}>Name</Col>
 										<Col xs={4}>Role</Col>
 										<Col xs={3}></Col>
-									</Row>
+									</div>
 								)}
 								{members.length <= 0 ? (
 									<Row className='margin-right-15'>
@@ -133,7 +133,7 @@ export const AccountMembers = props => {
 								) : (
 									members.map(m => {
 										return (
-											<Row className='entryBox padding-left-20 '>
+											<div className='entryBox padding-left-20'>
 												<Col sm={12} lg={5}>
 													<a href={'/person/' + m.id} className='purple-14'>
 														{m.firstname} {m.lastname}
@@ -147,7 +147,7 @@ export const AccountMembers = props => {
 												<Col sm={4} lg={4} className='black-14'>
 													{m.roles[0].charAt(0).toUpperCase() + m.roles[0].slice(1)}
 												</Col>
-											</Row>
+											</div>
 										);
 									})
 								)}

--- a/src/pages/dashboard/AccountTeamManagement.js
+++ b/src/pages/dashboard/AccountTeamManagement.js
@@ -5,6 +5,7 @@ import { isEmpty } from 'lodash';
 import axios from 'axios';
 import Loading from '../commonComponents/Loading';
 import { baseURL } from '../../configs/url.config';
+import AccountMembers from './AccountMembers';
 import TeamGatewayEmail from './Team/TeamGatewayEmail';
 import TeamGatewayNotificationEmails from './Team/TeamGatewayNotificationEmails';
 import FieldRepeater from '../commonComponents/FieldRepeater/FieldRepeater';
@@ -12,10 +13,11 @@ import TeamEmailAlertModal from './Team/TeamEmailAlertModal';
 import SVGIcon from '../../images/SVGIcon';
 import './Dashboard.scss';
 
-const AccountTeamManagement = ({ userState = [], team = '', forwardRef, onTeamManagementSave }) => {
+const AccountTeamManagement = ({ userState = [], team = '', forwardRef, onTeamManagementSave, onTeamManagementTabChange }) => {
 	// constants
 	const tabTypes = {
-		Notifications: 'Notifications',
+		Members: 'Members',
+		Notifications: 'Notifications'
 	};
 	// state
 	const [isLoading, setLoading] = useState(false);
@@ -26,12 +28,13 @@ const AccountTeamManagement = ({ userState = [], team = '', forwardRef, onTeamMa
 		{ notificationType: 'dataAccessRequest', optIn: false, subscribedEmails: [{ value: '', error: '' }] },
 	]);
 	const [alertModal, setAlertModal] = useState(false);
-	const [activeTabKey, setActiveTab] = useState(tabTypes.Notifications);
+	const [activeTabKey, setActiveTab] = useState(tabTypes.Members);
 	let history = useHistory();
 	forwardRef(() => saveNotifications());
 
 	// functions
 	const onTabChange = key => {
+		onTeamManagementTabChange(key);
 		setActiveTab(key);
 	};
 
@@ -194,7 +197,9 @@ const AccountTeamManagement = ({ userState = [], team = '', forwardRef, onTeamMa
 				let { notificationType, optIn, subscribedEmails } = teamNotification;
 
 				if (!isEmpty(subscribedEmails)) {
-					emails = [...subscribedEmails].map(item => item.value);
+					emails = [...subscribedEmails].filter((item) => {
+                      return item.value !== '';
+                    }).map(value => value.value);
 				}
 
 				arr = [...arr, { notificationType, optIn, subscribedEmails: emails }];
@@ -336,6 +341,8 @@ const AccountTeamManagement = ({ userState = [], team = '', forwardRef, onTeamMa
 				{/*CLOSE col-sm-10 */}
 				<Col xs={1}></Col>
 			</Row>
+
+			{activeTabKey == tabTypes.Members && <AccountMembers userState={userState} team={team} teamId={teamId}/>}
 
 			{activeTabKey === tabTypes.Notifications && (
 				<Row>


### PR DESCRIPTION
# PR
IG-1413

# Notes
Moved members into team management as per design from zeplin. Picked up on 08/04/2021 pr meeting. Rectified to suit the designs.

Other changes include 

- SCSS flex properties
- Callback for Team management tab change to hide action bar if on members tab
- Update of HTML and remove empty class tags

<img width="1664" alt="Team_management_members" src="https://user-images.githubusercontent.com/65283091/114175971-81cc5a80-9932-11eb-9041-d37917fcc78f.png">
