### PR TITLE
SUPP-460 - DAR - National Core Studies Project Id Data Format Fix

### DIFF
--- a/src/pages/DataAccessRequest/DataAccessRequest.js
+++ b/src/pages/DataAccessRequest/DataAccessRequest.js
@@ -1037,7 +1037,7 @@ class DataAccessRequest extends Component {
 		// 1. Deconstruct aboutApplication from state
 		let { aboutApplication } = this.state;
 		// 2. Update about application object
-		aboutApplication.nationalCoreStudiesProjectId = e;
+		aboutApplication.nationalCoreStudiesProjectId = e.toString();
 		// 3. Set state updating validation
 		this.setState({
 			aboutApplication,


### PR DESCRIPTION
Data Access Request (DAR) applications attributed to NCS projects are linked via the ID field of the project entity.  This is stored in the 'aboutApplication' object in the DAR.  The property which stores the ID itself does not have database or ODM validation, which allowed the saving of a double type representation of the selected project ID.  The value should always be captured as a string however.

**Development**

- Added explicit cast to project Id field to ensure format is always string