### PR TITLE
SUPP - Fixed broken filters check/uncheck

### DIFF
--- a/src/pages/search/SearchPage.js
+++ b/src/pages/search/SearchPage.js
@@ -915,7 +915,7 @@ class SearchPage extends React.Component {
 			if (!_.isEmpty(foundNode)) {
 				// find if the node already exists in the selectedV2 - if so we are unchecking / removing
 				const exists = [...this.state.selectedV2].some(selected => selected.id === foundNode.id);
-				if(!exists) {
+				if (!exists || (exists && foundNode.checked != checkValue)) {
 					// 4. set check value
 					foundNode.checked = checkValue;
 					// 5. increment highest parent count


### PR DESCRIPTION
# PR
Fix broken search filter during selection

##  Notes
If you select a publisher and try deselect using the provided checkbox you will realise you can not deselect it. The following update allows you to uncheck the value, this was due to another fix that had conflicted with the logic, additional logic has been put in which is correct and tested.

