### PR TITLE
Ig 1750

### DIFF
--- a/package.json
+++ b/package.json
@@ -28,6 +28,7 @@
 		"react-autosuggest": "^9.4.3",
 		"react-bootstrap": "^1.0.0-beta.16",
 		"react-bootstrap-typeahead": "^4.0.0-rc.2",
+		"react-countup": "^4.3.3",
 		"react-datepicker": "^2.15.0",
 		"react-dom": "^16.12.0",
 		"react-dropzone": "^11.2.0",

--- a/src/css/_typography.scss
+++ b/src/css/_typography.scss
@@ -154,7 +154,7 @@ h6 {
 }
 
 .gray700-12 {
-	@include font-source(13px, $gray-700, $font-weight-semibold);
+	@include font-source(12px, $gray-700, $font-weight-semibold);
 }
 
 .gray700-13 {

--- a/src/pages/dashboard/AccountAnalyticsDashboard.js
+++ b/src/pages/dashboard/AccountAnalyticsDashboard.js
@@ -259,7 +259,7 @@ class AccountAnalyticsDashboard extends React.Component {
 							<Col sm={12} lg={12}>
 								<Row>
 									<Col sm={8} lg={8}>
-										<span className='black-20'>Dashboard</span>
+										<span className='black-20-semibold'>Dashboard</span>
 									</Col>
 									<Col sm={4} lg={4}>
 										<span className='gray700-13 floatRight' data-test-id='dashboard-metrics-last-updated'>
@@ -268,12 +268,49 @@ class AccountAnalyticsDashboard extends React.Component {
 									</Col>
 								</Row>
 								<Row>
-									<Col sm={8} lg={8}>
+									<Col sm={12} lg={12}>
 										<span className='gray700-13'>
 											A collection of statistics, metrics and analytics; giving an overview of the sites data and performance
 										</span>
 									</Col>
-									<Col sm={4} lg={4}>
+								</Row>
+							</Col>
+						</Row>
+
+						<Row className='kpiContainer'>
+							<Col sm={3} lg={3} className='kpiClass'>
+								<DashboardKPI kpiText='total datasets' kpiValue={statsDataType.dataset} testId='dashboard-dataset-count' />
+							</Col>
+							<Col sm={3} lg={3} className='kpiClass'>
+								<DashboardKPI
+									kpiText='datasets with technical metadata'
+									kpiValue={datasetsWithTechMetaData.toFixed(0)}
+									percentageFlag={true}
+									testId='dashboard-dataset-metadata-percent'
+								/>
+							</Col>
+							<Col sm={3} lg={3} className='kpiClass'>
+								<DashboardKPI
+									kpiText='unique registered users'
+									kpiValue={uniqueUsers.toFixed(0)}
+									percentageFlag={true}
+									testId='dashboard-users-registered-percent'
+								/>
+							</Col>
+							<Col sm={3} lg={3} className='kpiClass'>
+								<DashboardKPI kpiText='' kpiValue='' />
+							</Col>
+						</Row>
+
+						<Row className='accountHeader mt-2'>
+							<Col sm={12} lg={12}>
+								<Row>
+									<Col sm={7} lg={8}>
+										<span className='black-16-semibold'>Monthly</span>
+										<br />
+										<span className='gray700-13'>View the site’s data and performance on a monthly basis</span>
+									</Col>
+									<Col sm={5} lg={4}>
 										<div className='select_option'>
 											<DropdownButton
 												variant='light'
@@ -296,30 +333,8 @@ class AccountAnalyticsDashboard extends React.Component {
 
 						<Row className='kpiContainer'>
 							<Col sm={3} lg={3} className='kpiClass'>
-								<DashboardKPI kpiText='total datasets' kpiValue={statsDataType.dataset} testId='dashboard-dataset-count' />
-							</Col>
-							<Col sm={3} lg={3} className='kpiClass'>
-								<DashboardKPI
-									kpiText='datasets with technical metadata'
-									kpiValue={datasetsWithTechMetaData.toFixed(0)}
-									percentageFlag={true}
-									testId='dashboard-dataset-metadata-percent'
-								/>
-							</Col>
-							<Col sm={3} lg={3} className='kpiClass'>
 								<DashboardKPI kpiText='users this month' kpiValue={gaUsers} testId='dashboard-users-monthly-count' />
 							</Col>
-							<Col sm={3} lg={3} className='kpiClass'>
-								<DashboardKPI
-									kpiText='unique registered users'
-									kpiValue={uniqueUsers.toFixed(0)}
-									percentageFlag={true}
-									testId='dashboard-users-registered-percent'
-								/>
-							</Col>
-						</Row>
-
-						<Row className='kpiContainer'>
 							<Col sm={3} lg={3} className='kpiClass'>
 								<DashboardKPI
 									kpiText='searches with results this month'
@@ -329,7 +344,11 @@ class AccountAnalyticsDashboard extends React.Component {
 								/>
 							</Col>
 							<Col sm={3} lg={3} className='kpiClass'>
-								<DashboardKPI kpiText='new access requests' kpiValue={accessRequests} testId='dashboard-data-access-requests-count' />
+								<DashboardKPI
+									kpiText='data access requests this month'
+									kpiValue={accessRequests}
+									testId='dashboard-data-access-requests-count'
+								/>
 							</Col>
 							<Col sm={3} lg={3} className='kpiClass'>
 								<DashboardKPI
@@ -338,9 +357,6 @@ class AccountAnalyticsDashboard extends React.Component {
 									percentageFlag={true}
 									testId='dashboard-gateway-uptime-percent'
 								/>
-							</Col>
-							<Col sm={3} lg={3} className='kpiClass'>
-								<DashboardKPI kpiText='' kpiValue='' />
 							</Col>
 						</Row>
 

--- a/src/pages/dashboard/AccountAnalyticsDashboard.js
+++ b/src/pages/dashboard/AccountAnalyticsDashboard.js
@@ -298,7 +298,12 @@ class AccountAnalyticsDashboard extends React.Component {
 								/>
 							</Col>
 							<Col sm={3} lg={3} className='kpiClass'>
-								<DashboardKPI kpiText='' kpiValue='' />
+								<DashboardKPI
+									kpiText='uptime in current month'
+									kpiValue={uptime.toFixed(2) % 1 === 0 ? Math.trunc(uptime.toFixed(2)) : uptime.toFixed(2)}
+									percentageFlag={true}
+									testId='dashboard-gateway-uptime-percent'
+								/>
 							</Col>
 						</Row>
 
@@ -351,12 +356,7 @@ class AccountAnalyticsDashboard extends React.Component {
 								/>
 							</Col>
 							<Col sm={3} lg={3} className='kpiClass'>
-								<DashboardKPI
-									kpiText='uptime this month'
-									kpiValue={uptime.toFixed(2) % 1 === 0 ? Math.trunc(uptime.toFixed(2)) : uptime.toFixed(2)}
-									percentageFlag={true}
-									testId='dashboard-gateway-uptime-percent'
-								/>
+								<DashboardKPI kpiText='' kpiValue='' />
 							</Col>
 						</Row>
 

--- a/src/pages/dashboard/DARComponents/DashboardKPI.js
+++ b/src/pages/dashboard/DARComponents/DashboardKPI.js
@@ -1,31 +1,47 @@
- // /ShowObjects/Title.js
+// /ShowObjects/Title.js
 import React, { Component } from 'react';
 import { Row, Col } from 'react-bootstrap';
-import { ReactComponent as PersonPlaceholderSvg } from '../../../images/person-placeholder.svg';
-import SVGIcon from '../../../images/SVGIcon';
-import '../Dashboard.scss'; 
- 
+import '../Dashboard.scss';
+import CountUp from 'react-countup';
+import _ from 'lodash';
 
-class  DashboardKPI extends Component {
+class DashboardKPI extends Component {
+	render() {
+		const { kpiText, kpiValue, percentageFlag, testId } = this.props;
 
-  render() {
-    const { kpiText, kpiValue, percentageFlag, testId } = this.props;
+		let overallStats = ['total datasets', 'datasets with technical metadata', 'unique registered users'];
 
-    return (
-      <span> 
-        <Row className="kpiCard"> 
-            <Col sm={12} lg={12}>
-                <Row className="text-left ml-2">                
-                    <span className="black-28 text-left" data-test-id={testId} > { percentageFlag===true ? kpiValue + '%' : kpiValue} </span> 
-                </Row>
-                <Row className="text-left ml-2">
-                    <span className="gray700-12" data-test-id="kpiText" > {kpiText} </span>  
-                </Row>
-            </Col>
-        </Row>
-      </span> 
-    );
-  }
+		return (
+			<span>
+				<Row className='kpiCard'>
+					<Col sm={12} lg={12}>
+						<Row className='text-left ml-2'>
+							<span className='black-28 text-left' data-test-id={testId}>
+								{_.isEmpty(kpiText) ? (
+									''
+								) : overallStats.includes(kpiText) ? (
+									kpiValue
+								) : kpiText === 'uptime this month' ? (
+									<CountUp end={kpiValue} decimals={2} />
+								) : (
+									<CountUp end={kpiValue} />
+								)}
+
+								{percentageFlag === true ? '%' : ''}
+							</span>
+						</Row>
+
+						<Row className='text-left ml-2'>
+							<span className='gray700-12' data-test-id='kpiText'>
+								{' '}
+								{kpiText}{' '}
+							</span>
+						</Row>
+					</Col>
+				</Row>
+			</span>
+		);
+	}
 }
 
 export default DashboardKPI;

--- a/src/pages/dashboard/DARComponents/DashboardKPI.js
+++ b/src/pages/dashboard/DARComponents/DashboardKPI.js
@@ -9,7 +9,7 @@ class DashboardKPI extends Component {
 	render() {
 		const { kpiText, kpiValue, percentageFlag, testId } = this.props;
 
-		let overallStats = ['total datasets', 'datasets with technical metadata', 'unique registered users'];
+		let overallStats = ['total datasets', 'datasets with technical metadata', 'unique registered users', 'uptime in current month'];
 
 		return (
 			<span>

--- a/src/pages/dashboard/Dashboard.scss
+++ b/src/pages/dashboard/Dashboard.scss
@@ -88,7 +88,8 @@
 }
 
 .accountNav {
-	a, button {
+	a,
+	button {
 		display: flex;
 		align-items: center;
 	}
@@ -205,6 +206,12 @@ textarea {
 	font-family: inherit;
 	font-size: inherit !important;
 	color: inherit !important;
+}
+
+#dateDropdown {
+	background-color: $white !important;
+	border-color: $gray-400 !important;
+	min-width: 160px;
 }
 
 #metadataButton {
@@ -430,11 +437,9 @@ textarea {
 		align-items: center;
 	}
 
-	&-switch  {
+	&-switch {
 		display: flex;
 		align-items: center;
 		padding-right: 15px;
 	}
 }
-
-

--- a/src/pages/publicDashboard/PublicAnalyticsDashboard.js
+++ b/src/pages/publicDashboard/PublicAnalyticsDashboard.js
@@ -85,8 +85,6 @@ class PublicAnalyticsDashboard extends React.Component {
 		initGA('UA-166025838-1');
 		await Promise.all([this.getUnmetDemand(), this.getTopSearches()]);
 
-		this.setState({ isLoading: false });
-
 		await Promise.all([
 			this.getTotalGAUsers(),
 			this.getGAUsers(
@@ -100,7 +98,7 @@ class PublicAnalyticsDashboard extends React.Component {
 			this.getTopDatasets(this.state.selectedOption),
 		]);
 
-		this.setState({ uniqueUsers: (this.state.statsDataType.person / this.state.totalGAUsers) * 100 });
+		this.setState({ uniqueUsers: (this.state.statsDataType.person / this.state.totalGAUsers) * 100, isLoading: false });
 	}
 
 	getUnmetDemand(selectedOption) {

--- a/src/pages/publicDashboard/PublicAnalyticsDashboard.js
+++ b/src/pages/publicDashboard/PublicAnalyticsDashboard.js
@@ -306,7 +306,7 @@ class PublicAnalyticsDashboard extends React.Component {
 								<Col sm={12} lg={12}>
 									<Row>
 										<Col sm={8} lg={8}>
-											<span className='black-20'>Dashboard</span>
+											<span className='black-20-semibold'>Dashboard</span>
 										</Col>
 										<Col sm={4} lg={4}>
 											<span className='gray700-13 floatRight' data-test-id='dashboard-metrics-last-updated'>
@@ -315,12 +315,49 @@ class PublicAnalyticsDashboard extends React.Component {
 										</Col>
 									</Row>
 									<Row>
-										<Col sm={8} lg={8}>
+										<Col sm={12} lg={12}>
 											<span className='gray700-13'>
 												A collection of statistics, metrics and analytics; giving an overview of the sites data and performance
 											</span>
 										</Col>
-										<Col sm={4} lg={4}>
+									</Row>
+								</Col>
+							</Row>
+
+							<Row className='kpiContainer'>
+								<Col sm={3} lg={3} className='kpiClass'>
+									<DashboardKPI kpiText='total datasets' kpiValue={statsDataType.dataset} testId='dashboard-dataset-count' />
+								</Col>
+								<Col sm={3} lg={3} className='kpiClass'>
+									<DashboardKPI
+										kpiText='datasets with technical metadata'
+										kpiValue={datasetsWithTechMetaData.toFixed(0)}
+										percentageFlag={true}
+										testId='dashboard-dataset-metadata-percent'
+									/>
+								</Col>
+								<Col sm={3} lg={3} className='kpiClass'>
+									<DashboardKPI
+										kpiText='unique registered users'
+										kpiValue={uniqueUsers.toFixed(0)}
+										percentageFlag={true}
+										testId='dashboard-users-registered-percent'
+									/>
+								</Col>
+								<Col sm={3} lg={3} className='kpiClass'>
+									<DashboardKPI kpiText='' kpiValue='' />
+								</Col>
+							</Row>
+
+							<Row className='accountHeader mt-2'>
+								<Col sm={12} lg={12}>
+									<Row>
+										<Col sm={7} lg={8}>
+											<span className='black-16-semibold'>Monthly</span>
+											<br />
+											<span className='gray700-13'>View the site’s data and performance on a monthly basis</span>
+										</Col>
+										<Col sm={5} lg={4}>
 											<div className='select_option'>
 												<DropdownButton
 													variant='light'
@@ -343,30 +380,8 @@ class PublicAnalyticsDashboard extends React.Component {
 
 							<Row className='kpiContainer'>
 								<Col sm={3} lg={3} className='kpiClass'>
-									<DashboardKPI kpiText='total datasets' kpiValue={statsDataType.dataset} testId='dashboard-dataset-count' />
-								</Col>
-								<Col sm={3} lg={3} className='kpiClass'>
-									<DashboardKPI
-										kpiText='datasets with technical metadata'
-										kpiValue={datasetsWithTechMetaData.toFixed(0)}
-										percentageFlag={true}
-										testId='dashboard-dataset-metadata-percent'
-									/>
-								</Col>
-								<Col sm={3} lg={3} className='kpiClass'>
 									<DashboardKPI kpiText='users this month' kpiValue={gaUsers} testId='dashboard-users-monthly-count' />
 								</Col>
-								<Col sm={3} lg={3} className='kpiClass'>
-									<DashboardKPI
-										kpiText='unique registered users'
-										kpiValue={uniqueUsers.toFixed(0)}
-										percentageFlag={true}
-										testId='dashboard-users-registered-percent'
-									/>
-								</Col>
-							</Row>
-
-							<Row className='kpiContainer'>
 								<Col sm={3} lg={3} className='kpiClass'>
 									<DashboardKPI
 										kpiText='searches with results this month'
@@ -376,7 +391,11 @@ class PublicAnalyticsDashboard extends React.Component {
 									/>
 								</Col>
 								<Col sm={3} lg={3} className='kpiClass'>
-									<DashboardKPI kpiText='new access requests' kpiValue={accessRequests} testId='dashboard-data-access-requests-count' />
+									<DashboardKPI
+										kpiText='data access requests this month'
+										kpiValue={accessRequests}
+										testId='dashboard-data-access-requests-count'
+									/>
 								</Col>
 								<Col sm={3} lg={3} className='kpiClass'>
 									<DashboardKPI
@@ -385,9 +404,6 @@ class PublicAnalyticsDashboard extends React.Component {
 										percentageFlag={true}
 										testId='dashboard-gateway-uptime-percent'
 									/>
-								</Col>
-								<Col sm={3} lg={3} className='kpiClass'>
-									<DashboardKPI kpiText='' kpiValue='' />
 								</Col>
 							</Row>
 

--- a/src/pages/publicDashboard/PublicAnalyticsDashboard.js
+++ b/src/pages/publicDashboard/PublicAnalyticsDashboard.js
@@ -343,7 +343,12 @@ class PublicAnalyticsDashboard extends React.Component {
 									/>
 								</Col>
 								<Col sm={3} lg={3} className='kpiClass'>
-									<DashboardKPI kpiText='' kpiValue='' />
+									<DashboardKPI
+										kpiText='uptime in current month'
+										kpiValue={uptime.toFixed(2) % 1 === 0 ? Math.trunc(uptime.toFixed(2)) : uptime.toFixed(2)}
+										percentageFlag={true}
+										testId='dashboard-gateway-uptime-percent'
+									/>
 								</Col>
 							</Row>
 
@@ -396,12 +401,7 @@ class PublicAnalyticsDashboard extends React.Component {
 									/>
 								</Col>
 								<Col sm={3} lg={3} className='kpiClass'>
-									<DashboardKPI
-										kpiText='uptime this month'
-										kpiValue={uptime.toFixed(2) % 1 === 0 ? Math.trunc(uptime.toFixed(2)) : uptime.toFixed(2)}
-										percentageFlag={true}
-										testId='dashboard-gateway-uptime-percent'
-									/>
+									<DashboardKPI kpiText='' kpiValue='' />
 								</Col>
 							</Row>
 

--- a/test/DashboardKPI.test.js
+++ b/test/DashboardKPI.test.js
@@ -16,15 +16,53 @@ describe('<DashboardKPI /> rendering', () => {
 		);
 	});
 
-	it('will render with "uptime this month"', () => {
+	it('will render with "data access requests this month"', () => {
+		wrapper = shallow(
+			<DashboardKPI kpiText='data access requests this month' kpiValue={4} testId='dashboard-data-access-requests-count' />
+		);
+		expect(wrapper.find('[data-test-id="kpiText"]').text().trim()).toEqual('data access requests this month');
+	});
+
+	it('will render using <CountUp />', () => {
+		wrapper = shallow(
+			<DashboardKPI kpiText='data access requests this month' kpiValue={4} testId='dashboard-data-access-requests-count' />
+		);
+		expect(wrapper.find('[data-test-id="dashboard-data-access-requests-count"]').exists()).toEqual(true);
+		expect(wrapper.find('[data-test-id="dashboard-data-access-requests-count"]').text().trim()).toEqual('<CountUp />');
+	});
+
+	it('will render with "total datasets"', () => {
+		wrapper = shallow(<DashboardKPI kpiText='total datasets' kpiValue={648} testId='dashboard-dataset-count' />);
+		expect(wrapper.find('[data-test-id="kpiText"]').text().trim()).toEqual('total datasets');
+	});
+
+	it('will render with "648"', () => {
+		wrapper = shallow(<DashboardKPI kpiText='total datasets' kpiValue={648} testId='dashboard-dataset-count' />);
+		expect(wrapper.find('[data-test-id="dashboard-dataset-count"]').exists()).toEqual(true);
+		expect(wrapper.find('[data-test-id="dashboard-dataset-count"]').text().trim()).toEqual('648');
+	});
+
+	it('will render with "datasets with technical metadata"', () => {
 		wrapper = shallow(
 			<DashboardKPI
-				kpiText={dashboardKPIData.kpiText}
-				kpiValue={dashboardKPIData.kpiValue}
-				percentageFlag={dashboardKPIData.percentageFlag}
-				testId='dashboard-gateway-uptime-percent'
+				kpiText='datasets with technical metadata'
+				kpiValue='47'
+				percentageFlag={true}
+				testId='dashboard-dataset-metadata-percent'
 			/>
 		);
-		expect(wrapper.find('[data-test-id="kpiText"]').text().trim()).toEqual('uptime this month');
+		expect(wrapper.find('[data-test-id="kpiText"]').text().trim()).toEqual('datasets with technical metadata');
+	});
+
+	it('will render with "47%"', () => {
+		wrapper = shallow(
+			<DashboardKPI
+				kpiText='datasets with technical metadata'
+				kpiValue={47}
+				percentageFlag={true}
+				testId='dashboard-dataset-metadata-percent'
+			/>
+		);
+		expect(wrapper.find('[data-test-id="dashboard-dataset-metadata-percent"]').text().trim()).toEqual('47%');
 	});
 });

--- a/test/DashboardKPI.test.js
+++ b/test/DashboardKPI.test.js
@@ -1,18 +1,12 @@
 import React from 'react';
 import DashboardKPI from '../src/pages/dashboard/DARComponents/DashboardKPI';
-import { dashboardKPIData } from './mocks/dataMock';
 
 let wrapper;
 
 describe('<DashboardKPI /> rendering', () => {
 	it('renders without crashing', () => {
 		wrapper = shallow(
-			<DashboardKPI
-				kpiText={dashboardKPIData.kpiText}
-				kpiValue={dashboardKPIData.kpiValue}
-				percentageFlag={dashboardKPIData.percentageFlag}
-				testId='dashboard-gateway-uptime-percent'
-			/>
+			<DashboardKPI kpiText='uptime in current month' kpiValue={99.86} percentageFlag={true} testId='dashboard-gateway-uptime-percent' />
 		);
 	});
 

--- a/test/DashboardKPI.test.js
+++ b/test/DashboardKPI.test.js
@@ -11,6 +11,7 @@ describe('<DashboardKPI /> rendering', () => {
 				kpiText={dashboardKPIData.kpiText}
 				kpiValue={dashboardKPIData.kpiValue}
 				percentageFlag={dashboardKPIData.percentageFlag}
+				testId='dashboard-gateway-uptime-percent'
 			/>
 		);
 	});
@@ -21,19 +22,9 @@ describe('<DashboardKPI /> rendering', () => {
 				kpiText={dashboardKPIData.kpiText}
 				kpiValue={dashboardKPIData.kpiValue}
 				percentageFlag={dashboardKPIData.percentageFlag}
+				testId='dashboard-gateway-uptime-percent'
 			/>
 		);
-		expect(wrapper.find('[data-testid="kpiText"]').text().trim()).toEqual('uptime this month');
-	});
-
-	it('will render with "97%"', () => {
-		wrapper = shallow(
-			<DashboardKPI
-				kpiText={dashboardKPIData.kpiText}
-				kpiValue={dashboardKPIData.kpiValue}
-				percentageFlag={dashboardKPIData.percentageFlag}
-			/>
-		);
-		expect(wrapper.find('[data-testid="kpiValue"]').text().trim()).toEqual('97%');
+		expect(wrapper.find('[data-test-id="kpiText"]').text().trim()).toEqual('uptime this month');
 	});
 });

--- a/test/mocks/dataMock.js
+++ b/test/mocks/dataMock.js
@@ -255,12 +255,6 @@ const __dataSetState = {
 	detailsData: [],
 };
 
-const _dashboardKPI = {
-	kpiText: 'uptime this month',
-	kpiValue: 97,
-	percentageFlag: true,
-};
-
 const _userState = {
 	userState: [
 		{
@@ -5189,7 +5183,6 @@ module.exports = {
 	dataSetState: __dataSetState,
 	creatorsData: __creatorsData,
 	unsubscribeState: __unsubscribeState,
-	dashboardKPIData: _dashboardKPI,
 	userStateData: _userState,
 	accountCollectionsData: _accountCollections,
 	accountToolsData: _accountTools,


### PR DESCRIPTION
[IG-1748](https://hdruk.atlassian.net/browse/IG-1748)

- Stats at the top of the dashboards split into overall and monthly sections
![image](https://user-images.githubusercontent.com/57766586/121546845-87fab800-ca03-11eb-8d0f-24cfdc0e7561.png)


[IG-1750](https://hdruk.atlassian.net/browse/IG-1750)

- React-countup added for monthly stats
- Dashboard KPI test updated