### PR TITLE
Distinguishing author/uploader for tools/projects/papers

### DIFF
--- a/src/pages/commonComponents/CommonComponents.scss
+++ b/src/pages/commonComponents/CommonComponents.scss
@@ -3,7 +3,7 @@
 .login-modal {
 	background: rgba(0, 0, 0, 0.5);
 	z-index: 9999 !important;
-	
+
 	.modal-dialog {
 		margin: 10% auto 0 auto;
 	}
@@ -171,4 +171,24 @@
 	margin-right: auto;
 	width: 200px;
 	z-index: 9999;
+}
+
+.uploader-container {
+	display: inline-block;
+}
+
+.uploader-chip {
+	display: flex;
+	align-items: center;
+	background-color: #e5f7f1;
+	padding: 2px 12px;
+	border-radius: 16px;
+	margin-bottom: 4px;
+	color: $gray-800;
+	white-space: nowrap;
+}
+
+.uploader-avatar {
+	margin-right: 8px;
+	padding: 1px 0px;
 }

--- a/src/pages/commonComponents/RemoveUploaderErrorModal.js
+++ b/src/pages/commonComponents/RemoveUploaderErrorModal.js
@@ -1,0 +1,35 @@
+import React, { Fragment } from 'react';
+import { Modal } from 'react-bootstrap';
+import { ReactComponent as CloseButtonSvg } from '../../images/close-alt.svg';
+
+import './RemoveUploaderModal.scss';
+
+const RemoveUploaderErrorModal = ({ open, cancelUploaderRemoval, entityType, uploaderToBeRemoved, removingOriginalUploader }) => {
+	return (
+		<Fragment>
+			<Modal
+				show={open}
+				onHide={cancelUploaderRemoval}
+				size='lg'
+				aria-labelledby='contained-modal-title-vcenter'
+				centered
+				className='removeUploaderModal mt-5'>
+				<div className='removeUploaderModal-header '>
+					<div className='removeUploaderModal-header--wrap pb-5'>
+						<div className='removeUploaderModal-head'>
+							<h1 className='black-20-semibold'>Remove uploader</h1>
+							<CloseButtonSvg className='removeUploaderModal-head--close' onClick={cancelUploaderRemoval} />
+						</div>
+						<div className='gray700-13 new-line'>
+							{removingOriginalUploader
+								? `You cannot remove the original uploader of this ${entityType}.`
+								: `You cannot remove ${uploaderToBeRemoved.name} as the uploader of this ${entityType} if there is no other user assigned as an uploader. Please assign another uploader before removing ${uploaderToBeRemoved.name}.`}
+						</div>
+					</div>
+				</div>
+			</Modal>
+		</Fragment>
+	);
+};
+
+export default RemoveUploaderErrorModal;

--- a/src/pages/commonComponents/RemoveUploaderModal.js
+++ b/src/pages/commonComponents/RemoveUploaderModal.js
@@ -1,0 +1,47 @@
+import React, { Fragment } from 'react';
+import { Modal } from 'react-bootstrap';
+import { ReactComponent as CloseButtonSvg } from '../../images/close-alt.svg';
+
+import './RemoveUploaderModal.scss';
+
+const RemoveUploaderModal = ({ open, cancelUploaderRemoval, confirmUploaderRemoval, entityType, userState, uploaderToBeRemoved }) => {
+	const removingCurrentUser = uploaderToBeRemoved.id === userState[0].id;
+	return (
+		<Fragment>
+			<Modal
+				show={open}
+				onHide={cancelUploaderRemoval}
+				size='lg'
+				aria-labelledby='contained-modal-title-vcenter'
+				centered
+				className='removeUploaderModal'>
+				<div className='removeUploaderModal-header'>
+					<div className='removeUploaderModal-header--wrap'>
+						<div className='removeUploaderModal-head'>
+							<h1 className='black-20-semibold'>{removingCurrentUser ? 'Remove yourself as uploader?' : 'Remove uploader?'}</h1>
+							<CloseButtonSvg className='removeUploaderModal-head--close' onClick={cancelUploaderRemoval} />
+						</div>
+						<div className='gray700-13 new-line'>
+							{removingCurrentUser
+								? `Are you sure that you want to remove yourself as an uploader on this ${entityType}? \n \n You will no longer be able to edit this ${entityType} \n \n `
+								: `Are you sure that you want to remove ${uploaderToBeRemoved.name} as an uploader on this ${entityType}? \n \n They will no longer be able to edit this ${entityType} \n \n `}
+						</div>
+					</div>
+				</div>
+
+				<div className='removeUploaderModal-footer'>
+					<div className='removeUploaderModal-footer--wrap'>
+						<button className='button-secondary' onClick={cancelUploaderRemoval}>
+							No, nevermind
+						</button>
+						<button className='button-primary' onClick={confirmUploaderRemoval}>
+							Confirm removal
+						</button>
+					</div>
+				</div>
+			</Modal>
+		</Fragment>
+	);
+};
+
+export default RemoveUploaderModal;

--- a/src/pages/commonComponents/RemoveUploaderModal.scss
+++ b/src/pages/commonComponents/RemoveUploaderModal.scss
@@ -1,0 +1,95 @@
+@import '../../css/variables';
+@import '../../css/typography';
+
+.modal {
+	p,
+	li {
+		@include font-source(14px, $gray-dark);
+	}
+}
+
+.removeUploaderModal {
+	box-sizing: border-box;
+
+	.modal-dialog {
+		transform: translate(0%, 50%) !important;
+		width: 394px;
+	}
+
+	&-header {
+		display: flex;
+		flex-flow: column nowrap;
+		width: 100%;
+		padding: 32px 32px 0 32px;
+
+		&--wrap {
+			padding-bottom: 12px;
+
+			p {
+				margin-bottom: 0;
+				color: $gray-800;
+				font-size: 14px;
+			}
+		}
+	}
+
+	&-head {
+		display: flex;
+		flex-flow: row nowrap;
+		justify-content: space-between;
+		margin-bottom: 16px;
+
+		&--close {
+			width: 20px;
+			height: 20px;
+			fill: $indigo;
+			&:hover {
+				cursor: pointer;
+			}
+		}
+	}
+
+	&-body {
+		width: 100%;
+		padding: 12px 32px 16px 32px;
+
+		label {
+			display: flex;
+			width: 100%;
+			flex-flow: row nowrap;
+			justify-content: space-between;
+			margin: 0;
+		}
+
+		&--item {
+			padding: 16px;
+
+			h2 {
+				margin-bottom: 10px;
+			}
+		}
+	}
+
+	&-footer {
+		display: flex;
+		flex-flow: row nowrap;
+		justify-content: flex-end;
+		align-items: center;
+		width: 100%;
+		background: $white;
+
+		&--wrap {
+			display: flex;
+			flex-flow: row nowrap;
+			padding: 0 32px 32px 32px;
+
+			button {
+				margin-left: 8px;
+			}
+		}
+	}
+}
+
+.new-line {
+	white-space: pre-line;
+}

--- a/src/pages/commonComponents/Uploader.js
+++ b/src/pages/commonComponents/Uploader.js
@@ -1,0 +1,22 @@
+import React from 'react';
+import { Fragment } from 'react';
+import { ReactComponent as PersonPlaceholderSvg } from '../../images/person-placeholder.svg';
+import './CommonComponents.scss';
+
+const Uploader = props => {
+	const { uploader } = props;
+	return (
+		<Fragment>
+			<div className='mb-1 mr-2 uploader-container'>
+				<a data-testid='href' href={'/person/' + uploader.id}>
+					<span className='uploader-chip'>
+						<PersonPlaceholderSvg className='uploader-avatar' />
+						{uploader.firstname} {uploader.lastname}
+					</span>
+				</a>
+			</div>
+		</Fragment>
+	);
+};
+
+export default Uploader;

--- a/src/pages/paper/PaperPage.js
+++ b/src/pages/paper/PaperPage.js
@@ -4,7 +4,7 @@ import queryString from 'query-string';
 import * as Sentry from '@sentry/react';
 import { Row, Col, Tabs, Tab, Container, Alert, Button } from 'react-bootstrap';
 import NotFound from '../commonComponents/NotFound';
-import Creators from '../commonComponents/Creators';
+import Uploader from '../commonComponents/Uploader';
 import Loading from '../commonComponents/Loading';
 import RelatedObject from '../commonComponents/relatedObject/RelatedObject';
 import SearchBar from '../commonComponents/searchBar/SearchBar';
@@ -437,18 +437,30 @@ export const PaperDetail = props => {
 															<span className='gray800-14'>{moment(paperData.updatedon).format('DD MMMM YYYY')}</span>
 														</Col>
 													</Row>
-													{paperData.uploader ? (
+													{paperData.authorsNew ? (
 														<Row className='mt-2'>
-															<Col sm={2} className='gray800-14'>
-																Uploader
+															<Col sm={2}>
+																<span className='gray800-14'>Authors</span>
 															</Col>
 															<Col sm={10} className='gray800-14 overflowWrap'>
-																{paperData.uploader}
+																{paperData.authorsNew}
 															</Col>
 														</Row>
 													) : (
 														''
 													)}
+													<Row className='mt-3'>
+														<Col sm={2}>
+															<span className='gray800-14'>Uploaders</span>
+														</Col>
+														<Col sm={10} className='gray800-14 overflowWrap'>
+															{paperData.persons.map(uploader => (
+																<span key={uploader.id}>
+																	<Uploader key={uploader.id} uploader={uploader} />
+																</span>
+															))}
+														</Col>
+													</Row>
 													<Row className='mt-2'>
 														<Col sm={2}>
 															<span className='gray800-14'>Keywords</span>
@@ -539,25 +551,6 @@ export const PaperDetail = props => {
 										) : (
 											''
 										)}
-
-										<Row className='mt-2'>
-											<Col className='mb-5'>
-												<div className='rectangle'>
-													<Row>
-														<Col>
-															<span className='gray800-14-bold'>Authors</span>
-														</Col>
-													</Row>
-													<Row className='mt-3'>
-														{paperData.persons.map(author => (
-															<Col sm={6} key={author.id}>
-																<Creators key={author.id} author={author} />
-															</Col>
-														))}
-													</Row>
-												</div>
-											</Col>
-										</Row>
 									</Tab>
 
 									<Tab eventKey='Collaboration' title={`Discussion (${discoursePostCount})`}>

--- a/src/pages/project/AddEditProjectForm.js
+++ b/src/pages/project/AddEditProjectForm.js
@@ -1,24 +1,33 @@
-import React from 'react';
+import React, { useState, useEffect } from 'react';
 import axios from 'axios';
 import { useFormik } from 'formik';
 import * as Yup from 'yup';
 import { Typeahead } from 'react-bootstrap-typeahead';
 import moment from 'moment';
 import { Form, Button, Row, Col, Container } from 'react-bootstrap';
+import { isNil, isEmpty } from 'lodash';
 import RelatedResources from '../commonComponents/relatedResources/RelatedResources';
 import RelatedObject from '../commonComponents/relatedObject/RelatedObject';
 import ActionBar from '../commonComponents/actionbar/ActionBar';
 import 'react-bootstrap-typeahead/css/Typeahead.css';
 import SVGIcon from '../../images/SVGIcon';
-import _ from 'lodash';
-import { isEditMode } from '../../utils/GeneralHelper.util';
+import RemoveUploaderModal from '../commonComponents/RemoveUploaderModal';
+import RemoveUploaderErrorModal from '../commonComponents/RemoveUploaderErrorModal';
 
-var baseURL = require('../commonComponents/BaseURL').getURL();
+const baseURL = require('../commonComponents/BaseURL').getURL();
 
 const AddEditProjectForm = props => {
-	let isEdit = isEditMode(window.location.pathname);
-	//Fix for projects were features are set to null
-	if (isEdit && props.data && props.data.tags.features === null) props.data.tags.features = [];
+	const [uploadersList, setUploadersList] = useState([]);
+	const [uploaderToBeRemoved, setUploaderToBeRemoved] = useState({});
+	const [showRemoveUploaderModal, setShowRemoveUploaderModal] = useState(false);
+	const [showRemoveUploaderErrorModal, setShowRemoveUploaderErrorModal] = useState(false);
+	const [removingOriginalUploader, setRemovingOriginalUploader] = useState(false);
+	const originalUploader = props.isEdit ? props.data.uploaderId : props.userState[0].id;
+	useEffect(() => {
+		buildListOfUploaders();
+	}, []);
+	//Fix for projects where features are set to null
+	if (props.isEdit && props.data && props.data.tags.features === null) props.data.tags.features = [];
 
 	// Pass the useFormik() hook initial form values and a submit function that will
 	// be called when the form is submitted
@@ -30,6 +39,8 @@ const AddEditProjectForm = props => {
 			link: props.data.link || '',
 			description: props.data.description || '',
 			resultsInsights: props.data.resultsInsights || '',
+			leadResearcher: props.data.leadResearcher || '',
+			authorsNew: props.data.authorsNew || '',
 			authors: props.data.authors || [props.userState[0].id],
 			categories: props.data.categories || {
 				category: '',
@@ -49,14 +60,14 @@ const AddEditProjectForm = props => {
 			categories: Yup.object().shape({
 				category: Yup.string().required('This cannot be empty'),
 			}),
-			authors: Yup.string().required('This cannot be empty'),
 		}),
 
 		onSubmit: values => {
 			//add via same post as add tool form - type set as 'project'
 			values.relatedObjects = props.relatedObjects;
 			values.toolCreator = props.userState[0];
-			if (isEdit) {
+			values.authors = uploadersList.map(uploader => uploader.id);
+			if (props.isEdit) {
 				axios.put(baseURL + '/api/v1/projects/' + props.data.id, values).then(res => {
 					window.location.href = window.location.search + '/project/' + props.data.id + '/?projectEdited=true';
 				});
@@ -68,33 +79,49 @@ const AddEditProjectForm = props => {
 		},
 	});
 
-	var listOfAuthors = [];
+	const buildListOfUploaders = () => {
+		let listOfUploaders = [];
 
-	if (isEdit) {
-		props.data.authors.forEach(author => {
-			props.combinedUsers.forEach(user => {
-				if (user.id === author) {
-					if (props.userState[0].id === user.id) {
-						listOfAuthors.push({ id: user.id, name: user.name + ' (You)' });
-						if (!user.name.includes('(You)')) {
-							user.name = user.name + ' (You)';
+		if (props.isEdit) {
+			props.data.authors.forEach(uploader => {
+				props.combinedUsers.forEach(user => {
+					if (user.id === uploader) {
+						if (props.userState[0].id === user.id) {
+							listOfUploaders.push({ id: user.id, name: user.name + ' (You)' });
+							if (!user.name.includes('(You)')) {
+								user.name = user.name + ' (You)';
+							}
+						} else {
+							listOfUploaders.push({ id: user.id, name: user.name });
 						}
-					} else {
-						listOfAuthors.push({ id: user.id, name: user.name });
+					}
+				});
+			});
+		} else {
+			props.combinedUsers.forEach(user => {
+				if (user.id === props.userState[0].id) {
+					listOfUploaders.push({ id: user.id, name: user.name + ' (You)' });
+					if (!user.name.includes('(You)')) {
+						user.name = user.name + ' (You)';
 					}
 				}
 			});
-		});
-	} else {
-		props.combinedUsers.forEach(user => {
-			if (user.id === props.userState[0].id) {
-				listOfAuthors.push({ id: user.id, name: user.name + ' (You)' });
-				if (!user.name.includes('(You)')) {
-					user.name = user.name + ' (You)';
-				}
-			}
-		});
-	}
+		}
+		setUploadersList(listOfUploaders);
+	};
+
+	const cancelUploaderRemoval = () => {
+		setUploaderToBeRemoved({});
+		setRemovingOriginalUploader(false);
+		setShowRemoveUploaderModal(false);
+		setShowRemoveUploaderErrorModal(false);
+	};
+
+	const confirmUploaderRemoval = () => {
+		setUploadersList(uploadersList.filter(uploader => uploader.id !== uploaderToBeRemoved.id));
+		setUploaderToBeRemoved({});
+		setShowRemoveUploaderModal(false);
+	};
 
 	function updateReason(id, reason, type, pid) {
 		let inRelatedObject = false;
@@ -134,13 +161,29 @@ const AddEditProjectForm = props => {
 	return (
 		<div>
 			<Container>
+				<RemoveUploaderModal
+					open={showRemoveUploaderModal}
+					cancelUploaderRemoval={cancelUploaderRemoval}
+					confirmUploaderRemoval={confirmUploaderRemoval}
+					entityType={'project'}
+					userState={props.userState}
+					uploaderToBeRemoved={uploaderToBeRemoved}></RemoveUploaderModal>
+
+				<RemoveUploaderErrorModal
+					open={showRemoveUploaderErrorModal}
+					cancelUploaderRemoval={cancelUploaderRemoval}
+					entityType={'project'}
+					uploaderToBeRemoved={uploaderToBeRemoved}
+					removingOriginalUploader={removingOriginalUploader}></RemoveUploaderErrorModal>
 				<Row className='margin-top-32'>
 					<Col sm={1} lg={1} />
 					<Col sm={10} lg={10}>
 						<div className='rectangle'>
 							<Row>
 								<Col sm={10} lg={10}>
-									<p className='black-20 margin-bottom-0 pad-bottom-8'>{isEdit ? 'Edit your project' : 'Add a new research project'}</p>
+									<p className='black-20 margin-bottom-0 pad-bottom-8'>
+										{props.isEdit ? 'Edit your project' : 'Add a new research project'}
+									</p>
 								</Col>
 								<Col sm={2} lg={2} className='text-right'>
 									<span className='badge-project'>
@@ -281,26 +324,30 @@ const AddEditProjectForm = props => {
 								</Form.Group>
 
 								<Form.Group>
-									<p className='gray800-14 margin-bottom-0 pad-bottom-4'>Collaborators</p>
-									<p className='gray700-13 margin-bottom-0'>Their name will appear on the project page, and will be able to make edits.</p>
-									<Typeahead
-										id='authors'
-										labelKey={authors => `${authors.name}`}
-										defaultSelected={listOfAuthors}
-										multiple
-										options={props.combinedUsers}
-										className={
-											formik.touched.authors && formik.errors.authors
-												? 'emptyFormInputTypeAhead addFormInputTypeAhead'
-												: 'addFormInputTypeAhead'
-										}
-										onChange={selected => {
-											var tempSelected = [];
-											selected.forEach(selectedItem => {
-												tempSelected.push(selectedItem.id);
-											});
-											formik.values.authors = tempSelected;
-										}}
+									<span className='gray800-14'>Lead researcher (optional)</span>
+									<p className='gray700-13 margin-bottom-0'>Please add the name of the lead researcher on this project</p>
+									<Form.Control
+										id='leadResearcher'
+										name='leadResearcher'
+										type='text'
+										className='addFormInput gray700-13'
+										onChange={formik.handleChange}
+										value={formik.values.leadResearcher}
+									/>
+								</Form.Group>
+
+								<Form.Group>
+									<span className='gray800-14'>Collaborators (optional)</span>
+									<p className='gray700-13 margin-bottom-0'>
+										Please add the names of the people who collaborated on this project, using a comma to separate the names
+									</p>
+									<Form.Control
+										id='authorsNew'
+										name='authorsNew'
+										type='text'
+										className='addFormInput gray700-13'
+										onChange={formik.handleChange}
+										value={formik.values.authorsNew}
 									/>
 								</Form.Group>
 
@@ -347,6 +394,56 @@ const AddEditProjectForm = props => {
 										}}
 									/>
 								</Form.Group>
+
+								<Form.Group>
+									<p className='gray800-14 margin-bottom-0 pad-bottom-4'>Uploaders</p>
+									<p className='gray700-13 margin-bottom-0'>Uploaders are Gateway members with editing rights on this project.</p>
+									<Typeahead
+										id='authors'
+										labelKey={authors => `${authors.name}`}
+										defaultSelected={uploadersList}
+										multiple
+										className={
+											formik.touched.authors && formik.errors.authors
+												? 'emptyFormInputTypeAhead addFormInputTypeAhead'
+												: 'addFormInputTypeAhead'
+										}
+										options={props.combinedUsers}
+										selected={uploadersList}
+										onChange={selectedOptions => {
+											// 1. Check if removing any uploader
+											const removedUploader = uploadersList.filter(
+												uploader => !selectedOptions.map(selectedOpt => selectedOpt.id).includes(uploader.id)
+											)[0];
+											if (!isEmpty(removedUploader)) {
+												// 2. Check if removing original uploader
+												if (removedUploader.id === originalUploader) {
+													setRemovingOriginalUploader(true);
+													setShowRemoveUploaderErrorModal(true);
+												}
+												// 3. Check if removing last uploader
+												else if (isEmpty(selectedOptions)) {
+													setUploaderToBeRemoved(removedUploader);
+													setShowRemoveUploaderErrorModal(true);
+												} else {
+													// 4. If removing a regular uploader show regular remove uploader modal
+													setUploaderToBeRemoved(removedUploader);
+													setShowRemoveUploaderModal(true);
+												}
+											} else {
+												// 5. If not removing uploader, user is adding uploader
+												const addedUploader = selectedOptions
+													.filter(selectedOpt => !uploadersList.map(uploader => uploader.id).includes(selectedOpt.id))
+													.map(newUploader => {
+														return { id: newUploader.id, name: newUploader.name };
+													})[0];
+												if (!isEmpty(addedUploader)) {
+													setUploadersList([...uploadersList, addedUploader]);
+												}
+											}
+										}}
+									/>
+								</Form.Group>
 							</div>
 
 							<div className='rectangle mt-2'>
@@ -363,7 +460,7 @@ const AddEditProjectForm = props => {
 							) : (
 								<div className='rectangle'>
 									{props.relatedObjects.map(object => {
-										if (!_.isNil(object.objectId)) {
+										if (!isNil(object.objectId)) {
 											return (
 												<RelatedObject
 													showRelationshipQuestion={true}
@@ -431,7 +528,7 @@ const AddEditProjectForm = props => {
 					</Button>
 
 					<Button variant='primary' className='publishButton white-14-semibold mr-2' type='submit' onClick={formik.handleSubmit}>
-						{isEdit ? 'Update' : 'Publish'}
+						{props.isEdit ? 'Update' : 'Publish'}
 					</Button>
 				</div>
 			</ActionBar>

--- a/src/pages/project/ProjectPage.js
+++ b/src/pages/project/ProjectPage.js
@@ -10,7 +10,7 @@ import RelatedObject from '../commonComponents/relatedObject/RelatedObject';
 import NotFound from '../commonComponents/NotFound';
 import SearchBar from '../commonComponents/searchBar/SearchBar';
 import Loading from '../commonComponents/Loading';
-import Creators from '../commonComponents/Creators';
+import Uploader from '../commonComponents/Uploader';
 import SVGIcon from '../../images/SVGIcon';
 import DiscourseTopic from '../discourse/DiscourseTopic';
 import SideDrawer from '../commonComponents/sidedrawer/SideDrawer';
@@ -372,13 +372,37 @@ export const ProjectDetail = props => {
 															{moment(projectData.updatedon).format('DD MMM YYYY')}
 														</Col>
 													</Row>
-													{projectData.uploader ? (
+													<Row className='mt-3'>
+														<Col sm={2}>
+															<span className='gray800-14'>Uploaders</span>
+														</Col>
+														<Col sm={10} className='gray800-14 overflowWrap'>
+															{projectData.persons.map(uploader => (
+																<span key={uploader.id}>
+																	<Uploader key={uploader.id} uploader={uploader} />
+																</span>
+															))}
+														</Col>
+													</Row>
+													{projectData.authorsNew ? (
 														<Row className='mt-2'>
-															<Col sm={2} className='gray800-14'>
-																Uploader
+															<Col sm={2}>
+																<span className='gray800-14'>Collaborators</span>
 															</Col>
 															<Col sm={10} className='gray800-14 overflowWrap'>
-																{projectData.uploader}
+																{projectData.authorsNew}
+															</Col>
+														</Row>
+													) : (
+														''
+													)}
+													{projectData.leadResearcher ? (
+														<Row className='mt-2'>
+															<Col sm={2}>
+																<span className='gray800-14'>Lead researcher</span>
+															</Col>
+															<Col sm={10} className='gray800-14 overflowWrap'>
+																{projectData.leadResearcher}
 															</Col>
 														</Row>
 													) : (
@@ -429,23 +453,6 @@ export const ProjectDetail = props => {
 																})
 															)}
 														</Col>
-													</Row>
-												</div>
-											</Col>
-										</Row>
-
-										<Row className='mt-2'>
-											<Col sm={12} className='mb-5'>
-												<div className='rectangle'>
-													<Row className='gray800-14-bold'>
-														<Col sm={12}>Collaborators</Col>
-													</Row>
-													<Row className='mt-3'>
-														{projectData.persons.map(author => (
-															<Col sm={6} key={author.id}>
-																<Creators key={author.id} author={author} />
-															</Col>
-														))}
 													</Row>
 												</div>
 											</Col>

--- a/src/pages/tool/AddEditToolForm.js
+++ b/src/pages/tool/AddEditToolForm.js
@@ -1,17 +1,17 @@
-import React, { Fragment } from 'react';
+import React, { useState, useEffect, Fragment } from 'react';
 import axios from 'axios';
-
 import { Formik, useFormik, FieldArray } from 'formik';
 import * as Yup from 'yup';
 import { Typeahead } from 'react-bootstrap-typeahead';
-import _ from 'lodash';
 import moment from 'moment';
 import { Form, Button, Row, Col } from 'react-bootstrap';
+import { isNil, isEmpty } from 'lodash';
 
+import RemoveUploaderModal from '../commonComponents/RemoveUploaderModal';
+import RemoveUploaderErrorModal from '../commonComponents/RemoveUploaderErrorModal';
 import RelatedResources from '../commonComponents/relatedResources/RelatedResources';
 import RelatedObject from '../commonComponents/relatedObject/RelatedObject';
 import ActionBar from '../commonComponents/actionbar/ActionBar';
-
 import SVGIcon from '../../images/SVGIcon';
 import './Tool.scss';
 
@@ -37,6 +37,16 @@ const validateSchema = Yup.object().shape({
 var baseURL = require('../commonComponents/BaseURL').getURL();
 
 const AddEditToolForm = props => {
+	const [uploadersList, setUploadersList] = useState([]);
+	const [uploaderToBeRemoved, setUploaderToBeRemoved] = useState({});
+	const [showRemoveUploaderModal, setShowRemoveUploaderModal] = useState(false);
+	const [showRemoveUploaderErrorModal, setShowRemoveUploaderErrorModal] = useState(false);
+	const [removingOriginalUploader, setRemovingOriginalUploader] = useState(false);
+	const originalUploader = props.isEdit ? props.data.uploader : props.userState[0].id;
+	useEffect(() => {
+		buildListOfUploaders();
+	}, []);
+
 	const formik = useFormik({
 		initialValues: {
 			id: props.data.id || '',
@@ -45,6 +55,7 @@ const AddEditToolForm = props => {
 			link: props.data.link || '',
 			description: props.data.description || '',
 			resultsInsights: props.data.resultsInsights || '',
+			authorsNew: props.data.authorsNew || '',
 			categories: props.data.categories || {
 				category: '',
 			},
@@ -82,6 +93,7 @@ const AddEditToolForm = props => {
 		onSubmit: values => {
 			values.relatedObjects = props.relatedObjects;
 			values.toolCreator = props.userState[0];
+			values.authors = uploadersList.map(uploader => uploader.id);
 			if (props.isEdit) {
 				axios.put(baseURL + '/api/v1/tools/' + props.data.id, values).then(res => {
 					window.location.href = window.location.search + '/tool/' + props.data.id + '/?toolEdited=true';
@@ -94,33 +106,49 @@ const AddEditToolForm = props => {
 		},
 	});
 
-	var listOfAuthors = [];
+	const buildListOfUploaders = () => {
+		let listOfUploaders = [];
 
-	if (props.isEdit) {
-		props.data.authors.forEach(author => {
-			props.combinedUsers.forEach(user => {
-				if (user.id === author) {
-					if (props.userState[0].id === user.id) {
-						listOfAuthors.push({ id: user.id, name: user.name + ' (You)' });
-						if (!user.name.includes('(You)')) {
-							user.name = user.name + ' (You)';
+		if (props.isEdit) {
+			props.data.authors.forEach(uploader => {
+				props.combinedUsers.forEach(user => {
+					if (user.id === uploader) {
+						if (props.userState[0].id === user.id) {
+							listOfUploaders.push({ id: user.id, name: user.name + ' (You)' });
+							if (!user.name.includes('(You)')) {
+								user.name = user.name + ' (You)';
+							}
+						} else {
+							listOfUploaders.push({ id: user.id, name: user.name });
 						}
-					} else {
-						listOfAuthors.push({ id: user.id, name: user.name });
+					}
+				});
+			});
+		} else {
+			props.combinedUsers.forEach(user => {
+				if (user.id === props.userState[0].id) {
+					listOfUploaders.push({ id: user.id, name: user.name + ' (You)' });
+					if (!user.name.includes('(You)')) {
+						user.name = user.name + ' (You)';
 					}
 				}
 			});
-		});
-	} else {
-		props.combinedUsers.forEach(user => {
-			if (user.id === props.userState[0].id) {
-				listOfAuthors.push({ id: user.id, name: user.name + ' (You)' });
-				if (!user.name.includes('(You)')) {
-					user.name = user.name + ' (You)';
-				}
-			}
-		});
-	}
+		}
+		setUploadersList(listOfUploaders);
+	};
+
+	const cancelUploaderRemoval = () => {
+		setUploaderToBeRemoved({});
+		setRemovingOriginalUploader(false);
+		setShowRemoveUploaderModal(false);
+		setShowRemoveUploaderErrorModal(false);
+	};
+
+	const confirmUploaderRemoval = () => {
+		setUploadersList(uploadersList.filter(uploader => uploader.id !== uploaderToBeRemoved.id));
+		setUploaderToBeRemoved({});
+		setShowRemoveUploaderModal(false);
+	};
 
 	function updateReason(id, reason, type, pid) {
 		let inRelatedObject = false;
@@ -161,6 +189,20 @@ const AddEditToolForm = props => {
 	return (
 		<div>
 			<div className={'container'}>
+				<RemoveUploaderModal
+					open={showRemoveUploaderModal}
+					cancelUploaderRemoval={cancelUploaderRemoval}
+					confirmUploaderRemoval={confirmUploaderRemoval}
+					entityType={'tool'}
+					userState={props.userState}
+					uploaderToBeRemoved={uploaderToBeRemoved}></RemoveUploaderModal>
+
+				<RemoveUploaderErrorModal
+					open={showRemoveUploaderErrorModal}
+					cancelUploaderRemoval={cancelUploaderRemoval}
+					entityType={'tool'}
+					uploaderToBeRemoved={uploaderToBeRemoved}
+					removingOriginalUploader={removingOriginalUploader}></RemoveUploaderErrorModal>
 				<Formik
 					initialValues={initialValues}
 					validationSchema={validateSchema}
@@ -323,31 +365,18 @@ const AddEditToolForm = props => {
 													) : null}
 												</Form.Group>
 
-												<Form.Group>
-													<span className='gray800-14'>Authors on the Gateway</span>
-													<Typeahead
-														id='authors'
-														labelKey={authors => `${authors.name}`}
-														defaultSelected={listOfAuthors}
-														multiple
-														options={props.combinedUsers}
-														className={
-															formik.touched.authors && formik.errors.authors
-																? 'emptyFormInputTypeAhead addFormInputTypeAhead'
-																: 'addFormInputTypeAhead'
-														}
-														onChange={selected => {
-															var tempSelected = [];
-															selected.forEach(selectedItem => {
-																tempSelected.push(selectedItem.id);
-															});
-															formik.values.authors = tempSelected;
-														}}
-													/>
-													{formik.touched.authors && formik.errors.authors ? (
-														<div className='errorMessages'>{formik.errors.authors}</div>
-													) : null}
-												</Form.Group>
+												<span className='gray800-14'>Authors (optional)</span>
+												<p className='gray700-13 margin-bottom-0'>
+													Please add the names of the people who authored this tool, using a comma to separate the names
+												</p>
+												<Form.Control
+													id='authorsNew'
+													name='authorsNew'
+													type='text'
+													className='addFormInput gray700-13'
+													onChange={formik.handleChange}
+													value={formik.values.authorsNew}
+												/>
 
 												<Row className='mt-2'>
 													<Col sm={12} md={8}>
@@ -537,6 +566,56 @@ const AddEditToolForm = props => {
 														}}
 													/>
 												</Form.Group>
+
+												<Form.Group>
+													<p className='gray800-14 margin-bottom-0 pad-bottom-4'>Uploaders</p>
+													<p className='gray700-13 margin-bottom-0'>Uploaders are Gateway members with editing rights on this tool.</p>
+													<Typeahead
+														id='authors'
+														labelKey={authors => `${authors.name}`}
+														defaultSelected={uploadersList}
+														multiple
+														className={
+															formik.touched.authors && formik.errors.authors
+																? 'emptyFormInputTypeAhead addFormInputTypeAhead'
+																: 'addFormInputTypeAhead'
+														}
+														options={props.combinedUsers}
+														selected={uploadersList}
+														onChange={selectedOptions => {
+															// 1. Check if removing any uploader
+															const removedUploader = uploadersList.filter(
+																uploader => !selectedOptions.map(selectedOpt => selectedOpt.id).includes(uploader.id)
+															)[0];
+															if (!isEmpty(removedUploader)) {
+																// 2. Check if removing original uploader
+																if (removedUploader.id === originalUploader) {
+																	setRemovingOriginalUploader(true);
+																	setShowRemoveUploaderErrorModal(true);
+																}
+																// 3. Check if removing last uploader
+																else if (isEmpty(selectedOptions)) {
+																	setUploaderToBeRemoved(removedUploader);
+																	setShowRemoveUploaderErrorModal(true);
+																} else {
+																	// 4. If removing a regular uploader show regular remove uploader modal
+																	setUploaderToBeRemoved(removedUploader);
+																	setShowRemoveUploaderModal(true);
+																}
+															} else {
+																// 5. If not removing uploader, user is adding uploader
+																const addedUploader = selectedOptions
+																	.filter(selectedOpt => !uploadersList.map(uploader => uploader.id).includes(selectedOpt.id))
+																	.map(newUploader => {
+																		return { id: newUploader.id, name: newUploader.name };
+																	})[0];
+																if (!isEmpty(addedUploader)) {
+																	setUploadersList([...uploadersList, addedUploader]);
+																}
+															}
+														}}
+													/>
+												</Form.Group>
 											</div>
 
 											<div className='rectangle mt-2'>
@@ -553,7 +632,7 @@ const AddEditToolForm = props => {
 											) : (
 												<div className='rectangle'>
 													{props.relatedObjects.map(object => {
-														if (!_.isNil(object.objectId)) {
+														if (!isNil(object.objectId)) {
 															return (
 																<RelatedObject
 																	showRelationshipQuestion={true}

--- a/src/pages/tool/ToolPage.js
+++ b/src/pages/tool/ToolPage.js
@@ -2,13 +2,13 @@ import React, { useState, useEffect } from 'react';
 import axios from 'axios';
 import queryString from 'query-string';
 import * as Sentry from '@sentry/react';
-import { Row, Col, Tabs, Tab, Container, Alert, Button } from 'react-bootstrap';
+import { Row, Col, Tabs, Tab, Container, Alert } from 'react-bootstrap';
 import NotFound from '../commonComponents/NotFound';
+import Uploader from '../commonComponents/Uploader';
 import Loading from '../commonComponents/Loading';
 import Reviews from '../commonComponents/reviews/Reviews';
 import RelatedObject from '../commonComponents/relatedObject/RelatedObject';
 import SearchBar from '../commonComponents/searchBar/SearchBar';
-import Creators from '../commonComponents/Creators';
 import DiscourseTopic from '../discourse/DiscourseTopic';
 import 'react-tabs/style/react-tabs.css';
 import { baseURL } from '../../configs/url.config';
@@ -460,18 +460,30 @@ export const ToolDetail = props => {
 															{moment(toolData.updatedon).format('DD MMM YYYY')}
 														</Col>
 													</Row>
-													{toolData.uploader ? (
+													{toolData.authorsNew ? (
 														<Row className='mt-2'>
-															<Col sm={2} className='gray800-14'>
-																Uploader
+															<Col sm={2}>
+																<span className='gray800-14'>Authors</span>
 															</Col>
 															<Col sm={10} className='gray800-14 overflowWrap'>
-																{toolData.uploader}
+																{toolData.authorsNew}
 															</Col>
 														</Row>
 													) : (
 														''
 													)}
+													<Row className='mt-3'>
+														<Col sm={2}>
+															<span className='gray800-14'>Uploaders</span>
+														</Col>
+														<Col sm={10} className='gray800-14 overflowWrap'>
+															{toolData.persons.map(uploader => (
+																<span key={uploader.id}>
+																	<Uploader key={uploader.id} uploader={uploader} />
+																</span>
+															))}
+														</Col>
+													</Row>
 													<Row className='mt-2'>
 														<Col sm={2} className='gray800-14'>
 															Type
@@ -544,22 +556,6 @@ export const ToolDetail = props => {
 																})
 															)}
 														</Col>
-													</Row>
-												</div>
-											</Col>
-										</Row>
-										<Row className='mt-2'>
-											<Col sm={12} className='mb-5'>
-												<div className='rectangle'>
-													<Row className='gray800-14-bold'>
-														<Col sm={12}>Authors</Col>
-													</Row>
-													<Row className='mt-3'>
-														{toolData.persons.map(author => (
-															<Col sm={6} key={author.id}>
-																<Creators key={author.id} author={author} />
-															</Col>
-														))}
 													</Row>
 												</div>
 											</Col>


### PR DESCRIPTION
Users can now add authors who are not registered on the Gateway to a tool/project/paper.

Only people listed as Uploaders (stored in authors in B/E) will have edit rights on an entity.

**Authors** will be stored as a String in the backend in a new field called **_authorsNew_**.
**Uploaders** will remain stored in the **_authors_** field as an array of numbers.
The original uploader will remain stored in the Number field **_uploader_**.

Any uploaders who had previously not listed themselves as authors will not lose edit privileges as there was a data fix to add those uploaders into the authors array for these cases.  See [IG-1961](https://hdruk.atlassian.net/browse/IG-1961) 

See [IG-1766](https://hdruk.atlassian.net/browse/IG-1766) for implementation rationale. 