### PR TITLE
IG-2090 - Names of authors on search results are stacking instead of appearing in one line

### DIFF
--- a/src/pages/commonComponents/relatedObject/RelatedObject.js
+++ b/src/pages/commonComponents/relatedObject/RelatedObject.js
@@ -379,37 +379,18 @@ class RelatedObject extends React.Component {
 												<span className='gray800-14'>Author not listed</span>
 											) : (
 												data.persons.map((person, index) => {
-													if (index > 0) {
-														if (activeLink === true) {
-															return (
-																<div key={`perosn-${index}`}>
-																	<span className='reviewTitleGap gray800-14'>·</span>
-																	<a className='gray800-14' href={'/person/' + person.id}>
-																		{person.firstname} {person.lastname}
-																	</a>
-																</div>
-															);
-														} else {
-															return (
-																<span className='gray800-14' key={`perosn-${index}`}>
-																	, {person.firstname} {person.lastname}
-																</span>
-															);
-														}
+													if (activeLink === true) {
+														return (
+															<a className='gray800-14' href={'/person/' + person.id} key={`perosn-${index}`}>
+																{person.firstname} {person.lastname}{data.persons.length === index + 1 ? '' : ', '}
+															</a>
+														);
 													} else {
-														if (activeLink === true) {
-															return (
-																<a className='gray800-14' href={'/person/' + person.id} key={`perosn-${index}`}>
-																	{person.firstname} {person.lastname}
-																</a>
-															);
-														} else {
-															return (
-																<span className='gray800-14' key={`perosn-${index}`}>
-																	{person.firstname} {person.lastname}
-																</span>
-															);
-														}
+														return (
+															<span className='gray800-14' key={`perosn-${index}`}>
+																{person.firstname} {person.lastname}{data.persons.length === index + 1 ? '' : ', '}
+															</span>
+														);
 													}
 												})
 											)}

--- a/src/pages/commonComponents/relatedObject/RelatedObject.js
+++ b/src/pages/commonComponents/relatedObject/RelatedObject.js
@@ -194,37 +194,18 @@ class RelatedObject extends React.Component {
 												<span className='gray800-14'>Author not listed</span>
 											) : (
 												data.persons.map((person, index) => {
-													if (index > 0) {
-														if (activeLink === true) {
-															return (
-																<div key={`person-${index}`}>
-																	<span className='reviewTitleGap gray800-14'>·</span>
-																	<a className='gray800-14' href={'/person/' + person.id}>
-																		{person.firstname} {person.lastname}
-																	</a>
-																</div>
-															);
-														} else {
-															return (
-																<span className='gray800-14' key={`person-${index}`}>
-																	, {person.firstname} {person.lastname}{' '}
-																</span>
-															);
-														}
+													if (activeLink === true) {
+														return (
+															<a className='gray800-14' href={'/person/' + person.id} key={`perosn-${index}`}>
+																{person.firstname} {person.lastname}{data.persons.length === index + 1 ? '' : ', '}
+															</a>
+														);
 													} else {
-														if (activeLink === true) {
-															return (
-																<a className='gray800-14' href={'/person/' + person.id} key={`person-${index}`}>
-																	{person.firstname} {person.lastname}
-																</a>
-															);
-														} else {
-															return (
-																<span className='gray800-14' key={`person-${index}`}>
-																	{person.firstname} {person.lastname}
-																</span>
-															);
-														}
+														return (
+															<span className='gray800-14' key={`perosn-${index}`}>
+																{person.firstname} {person.lastname}{data.persons.length === index + 1 ? '' : ', '}
+															</span>
+														);
 													}
 												})
 											)}
@@ -510,37 +491,18 @@ class RelatedObject extends React.Component {
 												<span className='gray800-14'>Author not listed</span>
 											) : (
 												data.persons.map((person, index) => {
-													if (index > 0) {
-														if (activeLink === true) {
-															return (
-																<div key={`dataPerson-${index}`}>
-																	<span className='reviewTitleGap gray800-14'>·</span>
-																	<a className='gray800-14' href={'/person/' + person.id}>
-																		{person.firstname} {person.lastname}
-																	</a>
-																</div>
-															);
-														} else {
-															return (
-																<span className='gray800-14' key={`dataPerson-${index}`}>
-																	, {person.firstname} {person.lastname}
-																</span>
-															);
-														}
+													if (activeLink === true) {
+														return (
+															<a className='gray800-14' href={'/person/' + person.id} key={`perosn-${index}`}>
+																{person.firstname} {person.lastname}{data.persons.length === index + 1 ? '' : ', '}
+															</a>
+														);
 													} else {
-														if (activeLink === true) {
-															return (
-																<a className='gray800-14' href={'/person/' + person.id} key={`dataPerson-${index}`}>
-																	{person.firstname} {person.lastname}
-																</a>
-															);
-														} else {
-															return (
-																<span className='gray800-14' key={`dataPerson-${index}`}>
-																	{person.firstname} {person.lastname}
-																</span>
-															);
-														}
+														return (
+															<span className='gray800-14' key={`perosn-${index}`}>
+																{person.firstname} {person.lastname}{data.persons.length === index + 1 ? '' : ', '}
+															</span>
+														);
 													}
 												})
 											)}


### PR DESCRIPTION
# Ticket number
[IG-2090](https://hdruk.atlassian.net/browse/IG-2090)

## Notes
Removing previous formatting that was putting authors in bulleted list
Added turnery expression to make sure the last author doesn't have a comma put after it 

## Screenshot
![Screenshot 2021-07-01 at 12 14 04](https://user-images.githubusercontent.com/73879534/124115582-e4328400-da65-11eb-8e2d-6e678abc7210.png)
