### PR TITLE
SUPP-598 + SUPP-599 (Display issue on DAR first message and user flow fixes)

### DIFF
--- a/src/pages/commonComponents/userMessages/UserMessages.scss
+++ b/src/pages/commonComponents/userMessages/UserMessages.scss
@@ -117,11 +117,6 @@
 
 		&-desc {
 			width: 100%;
-			h1 {
-				white-space: nowrap;
-				overflow: hidden;
-				text-overflow: ellipsis;
-			}
 		}
 
 		&-action {

--- a/src/pages/dataset/components/DatasetAboutCard.js
+++ b/src/pages/dataset/components/DatasetAboutCard.js
@@ -1,5 +1,4 @@
 import React from 'react';
-import { Link } from 'react-router-dom';
 import { Col, Row, Table } from 'react-bootstrap';
 import '../Dataset.scss';
 import AboutCardElement from './AboutCardElement';

--- a/src/pages/dataset/components/DatasetAboutCard.js
+++ b/src/pages/dataset/components/DatasetAboutCard.js
@@ -368,14 +368,14 @@ const DatasetAboutCard = ({ v2data, section, showEmpty, requiresModal, toggleMod
 												How to request access
 											</span>
 										) : (
-											<Link
+											<span
 												className='purple-14 pointer float-right'
-												to={{
-													pathname: `/data-access-request/dataset/${datasetid}`,
-												}}
-												onClick={() => Event('Buttons', 'Click', 'Request Access')}>
+												onClick={() => {
+													Event('Buttons', 'Click', 'Request Access');
+													toggleModal();
+												}}>
 												Request access
-											</Link>
+											</span>
 										)}
 									</Col>
 								</Row>


### PR DESCRIPTION
**Issues**

There is a display issue with the message drawer when attempting to contact a custodian with a long name while using a regular/small resolution size. This causes the message form to be unusable in some cases, with inputs appearing outside the viewport.

There are two buttons on the dataset page which should link to an application form/opportunity to message the custodian. Only one button was updated to reflect the make an enquiry user flow change we previously.

**Development**

Removed CSS on header containing custodian name which was preventing the element from wrapping and not working as expected with ellipsis (should have truncated the text)
Updated user flow to match designs and existing 'How to request access' button