### PR TITLE
IG-2155 - DAR - Application submit button error when no answers set

### DIFF
--- a/src/utils/DarValidation.util.js
+++ b/src/utils/DarValidation.util.js
@@ -1,6 +1,6 @@
 import _ from 'lodash';
 
-let getQuestionPanelInvalidQuestions = (Winterfell, questionSets, questionAnswers) => {
+let getQuestionPanelInvalidQuestions = (Winterfell, questionSets, questionAnswers = {}) => {
     return Winterfell.validation.default.getQuestionPanelInvalidQuestions(questionSets, questionAnswers);
 }
 


### PR DESCRIPTION
**Issue**

Rare problem occurring for some users where an attempt to submit a totally empty application form throws a javascript error in the console instead of performing validation and redirecting the user to the next validation error. 

**Development**

1. Added default empty object values to questionAnswers parameter before passing to Winterfell library for validation.