### PR TITLE
SUPP-603 - Search failing on paper page

### DIFF
--- a/src/pages/paper/PaperPage.js
+++ b/src/pages/paper/PaperPage.js
@@ -121,7 +121,7 @@ export const PaperDetail = props => {
 
 	const doSearch = e => {
 		//fires on enter on searchbar
-		if (e.key === 'Enter') window.location.href = `/search?search=${encodeURIComponent(this.state.searchString)}`;
+		if (e.key === 'Enter') window.location.href = `/search?search=${encodeURIComponent(searchString)}`;
 	};
 
 	const updateSearchString = searchString => {


### PR DESCRIPTION
**Issue**

Search function not firing from search bar when the user is in the paper page.

**Fix**

Bug found where a reference to previous class based component existed, which needed updated to React hook state for the searchString parameter.  A javascript exception was occurring because 'this.state' does not exist in a functional component.