### PR TITLE
SUPP-632 - Contextual messaging fixed share application flow - hotfix

### DIFF
--- a/src/pages/DataAccessRequest/DataAccessRequest.js
+++ b/src/pages/DataAccessRequest/DataAccessRequest.js
@@ -2044,6 +2044,7 @@ class DataAccessRequest extends Component {
 									isShared={this.state.isShared}
 									updateCount={this.updateCount}
 									publisher={datasets[0].datasetv2.summary.publisher.name}
+									applicationStatus={applicationStatus}
 								/>
 							</div>
 						</div>

--- a/src/pages/DataAccessRequest/components/Messages/Messages.js
+++ b/src/pages/DataAccessRequest/components/Messages/Messages.js
@@ -6,11 +6,13 @@ import ShareFormModal from './ShareFormModal';
 import Loading from '../../../commonComponents/Loading';
 import './Messages.scss';
 import { baseURL } from '../../../../configs/url.config';
+import DarHelper from '../../../../utils/DarHelper.util';
 
 const Messages = ({
 	applicationId,
 	settings,
 	applicationShared = false,
+	applicationStatus,
 	toggleDrawer,
 	setMessageDescription,
 	userState,
@@ -48,7 +50,7 @@ const Messages = ({
 		if (!message) {
 			return;
 		}
-		if (!isBoolean(applicationIsShared) || !applicationIsShared) {
+		if ((!isBoolean(applicationIsShared) || !applicationIsShared) && applicationStatus === DarHelper.darStatus.inProgress) {
 			onShowShareFormModal();
 		} else {
 			sendMessage(message);

--- a/src/pages/DataAccessRequest/components/QuestionActionTabs.js
+++ b/src/pages/DataAccessRequest/components/QuestionActionTabs.js
@@ -21,6 +21,7 @@ const QuestionActionTabs = ({
 	isShared,
 	updateCount,
 	publisher,
+	applicationStatus
 }) => {
 	const [activeSettings, setActiveSettings] = useState({ key: '', questionSetId: '', questionId: '' });
 
@@ -69,6 +70,7 @@ const QuestionActionTabs = ({
 									userState={userState}
 									settings={settings}
 									applicationShared={isShared}
+									applicationStatus={applicationStatus}
 									toggleDrawer={toggleDrawer}
 									setMessageDescription={setMessageDescription}
 									userType={userType}


### PR DESCRIPTION
**Problem**

Share application modal is showing when a custodian member tries to start a conversation on an application. This should only be appearing for the applicant when they want to start a conversation before submission. Once submitted, the custodian can view the application and it therefore does not need to be shared.

**Development**

- Passed application status into messaging component to determine when to correctly show the 'share application' modal. This should only be visible when the application is in presubmission and is not visible to the custodian. It should never show for the custodian either, so in the case that the application has not be shared but it is submitted, the new IF clause will still avoid showing the modal.
- Updated IF statement that conditionally shows the 'share application' modal as above to correct logic