### PR TITLE
Disable enforce focus

### DIFF
--- a/src/pages/commonComponents/AdvancedSearchModal/AdvancedSearchModal.js
+++ b/src/pages/commonComponents/AdvancedSearchModal/AdvancedSearchModal.js
@@ -114,6 +114,7 @@ const AdvancedSearchModal = ({ open, closed, userProps }) => {
 			<Modal
 				show={open}
 				onHide={handleClose}
+				enforceFocus={false}
 				className='advanced-search-modal'
 				size='lg'
 				aria-labelledby='contained-modal-title-vcenter'


### PR DESCRIPTION
As the login model overlaps the advanced search modal, I set enforced focus to false 