### PR TITLE
SUPP-643 - DAR - Fixed First Message not including non 5 safes datasets

### DIFF
--- a/src/pages/DataAccessRequest/components/TypeaheadDataset/TypeaheadDataset.js
+++ b/src/pages/DataAccessRequest/components/TypeaheadDataset/TypeaheadDataset.js
@@ -39,7 +39,7 @@ class TypeaheadDataset extends React.Component {
 	}
 
 	getData() {
-		const { selectedDatasets, allowAllCustodians } = this.props;
+		const { selectedDatasets, allowAllCustodians, only5Safes } = this.props;
 		let { publisher } = this.state;
 
 		if (selectedDatasets && selectedDatasets.length > 0) {
@@ -60,7 +60,7 @@ class TypeaheadDataset extends React.Component {
 							fields: 'datasetid,name,description,datasetfields.abstract,_id,datasetfields.publisher,datasetfields.contactPoint',
 							populate: 'publisher',
 							sort: 'datasetfields.publisher, name',
-							is5Safes: true,
+							...(only5Safes ? { is5Safes: true } : {}),
 							...(publisher ? { ['datasetfields.publisher']: publisher } : {}),
 						},
 					})

--- a/src/pages/commonComponents/userMessages/components/EnquiryMessage.js
+++ b/src/pages/commonComponents/userMessages/components/EnquiryMessage.js
@@ -294,6 +294,7 @@ export const EnquiryMessage = ({ topic, onDatasetsRequested, onFirstMessageSubmi
 									selectedDatasets={topic.tags}
 									readOnly={false}
 									allowAllCustodians={false}
+									only5Safes={false}
 									onHandleDataSetChange={selected => {
 										onHandleDataSetChange(selected, 'datasetsRequested', setFieldValue);
 									}}


### PR DESCRIPTION
**Issue reported by user**

'I tried to select multiple datasets in a first message. When I do this for CPRD, no additional datasets come up in addition to the one pre-selected. When I do this for NHSD, only few datasets come up (but there should be many more). When I do this for SAIL datasets, all relevant datasets come up and I can add more than one (which is good).'

**Investigation**

This issue was caused by the reuse of the dataset typeahead used in the 5 safes application form which was filtering out non 5 safes datasets.

**Development**

- Added typeahead configuration prop to allow the inclusion or exclusion of non 5 safe datasets

