### PR TITLE
SUPP-649 - File upload validation failure

### DIFF
--- a/src/pages/DataAccessRequest/components/Uploads/Uploads.js
+++ b/src/pages/DataAccessRequest/components/Uploads/Uploads.js
@@ -86,7 +86,7 @@ const Uploads = ({ id, files, onFilesUpdate, readOnly }) => {
 	const onDescriptionChange = event => {
 		event.preventDefault();
 		let { name, value } = event.currentTarget;
-		let [uniqueId = ''] = name.split('_');
+		let [, uniqueId = ''] = name.split('_');
 		if (!_.isEmpty(uniqueId)) {
 			const allFiles = [...uploadFiles].map(file => {
 				if (file.fileId === uniqueId) return Object.assign(file, { ...file, description: value });


### PR DESCRIPTION
**Issue**

Data access request file upload not working due to failing validation logic.  Issue was caused by an LGTM correction that changed the output of the parameter used for validation.

**Development**

- Corrected regression issue in file description extract as shown in files changed. 