### PR TITLE
SUPP - DAR: Fixed issue where applicant could submit incomplete requested updates causing error on next load

### DIFF
--- a/src/pages/DataAccessRequest/DataAccessRequest.js
+++ b/src/pages/DataAccessRequest/DataAccessRequest.js
@@ -410,10 +410,8 @@ class DataAccessRequest extends Component {
 			showSubmit = true;
 		} else if (
 			activeParty === 'applicant' &&
-			(applicationStatus === DarHelper.darStatus.inReview || applicationStatus === DarHelper.darStatus.submitted)(
-				(applicationStatus === DarHelper.darStatus.inReview && answeredAmendments > 0 && unansweredAmendments === 0) ||
-					applicationStatus === DarHelper.darStatus.submitted
-			)
+			((applicationStatus === DarHelper.darStatus.inReview && answeredAmendments > 0 && unansweredAmendments === 0) ||
+				applicationStatus === DarHelper.darStatus.submitted)
 		) {
 			showSubmit = true;
 			submitButtonText = 'Submit updates';

--- a/src/pages/DataAccessRequest/DataAccessRequest.js
+++ b/src/pages/DataAccessRequest/DataAccessRequest.js
@@ -408,11 +408,15 @@ class DataAccessRequest extends Component {
 		// 6. Hide show submit application
 		if (applicationStatus === DarHelper.darStatus.inProgress) {
 			showSubmit = true;
-		} else if (applicationStatus === DarHelper.darStatus.inReview || applicationStatus === DarHelper.darStatus.submitted) {
-			if (activeParty === 'applicant' && answeredAmendments > 0) {
-				showSubmit = true;
-				submitButtonText = 'Submit updates';
-			}
+		} else if (
+			activeParty === 'applicant' &&
+			(applicationStatus === DarHelper.darStatus.inReview || applicationStatus === DarHelper.darStatus.submitted)(
+				(applicationStatus === DarHelper.darStatus.inReview && answeredAmendments > 0 && unansweredAmendments === 0) ||
+					applicationStatus === DarHelper.darStatus.submitted
+			)
+		) {
+			showSubmit = true;
+			submitButtonText = 'Submit updates';
 		}
 
 		// 7. Set initial panel as selected and scroll to top of view port
@@ -569,7 +573,7 @@ class DataAccessRequest extends Component {
 					{
 						unansweredAmendments,
 						answeredAmendments,
-						showSubmit: applicationStatus === DarHelper.darStatus.inProgress || answeredAmendments > 0,
+						showSubmit: applicationStatus === DarHelper.darStatus.inProgress || unansweredAmendments === 0,
 						jsonSchema,
 					},
 					_.isNil
@@ -903,6 +907,9 @@ class DataAccessRequest extends Component {
 				answeredAmendments,
 				unansweredAmendments,
 				amendmentIterations,
+				showSubmit:
+					this.state.applicationStatus === DarHelper.darStatus.inProgress ||
+					(unansweredAmendments === 0 && answeredAmendments > 0 && this.state.userType === DarHelper.userTypes.APPLICANT),
 			},
 			_.isNil
 		);


### PR DESCRIPTION
**Description**

When submitting an access request which has requested updates returned to the applicant, if the applicant used the revert answer functionality then submitted the application with the answer blank, an error was thrown when loading the application again.

**Development**

The fix was to prevent the submit button being available unless all requested updates have been completed.

- Updated showSubmit logic which controls appearance of the submit updates button to only show when the applicant has completed all requested updates.