### PR TITLE
Update to the UAT cloudbuild yaml to increase the timeout for the build

### DIFF
--- a/cloudbuild_uat.yaml
+++ b/cloudbuild_uat.yaml
@@ -19,4 +19,4 @@ steps:
       ]
 images:
   - gcr.io/$PROJECT_ID/${_APP_NAME}:uat
-timeout: 900s
+timeout: 1200s


### PR DESCRIPTION
Update to the UAT cloudbuild yaml to increase the timeout for the build