### PR TITLE
release-fix/GAT-681 - child filters not highlighting in spatial filters

### DIFF
--- a/src/pages/search/components/FilterTree/FilterTree.js
+++ b/src/pages/search/components/FilterTree/FilterTree.js
@@ -55,7 +55,7 @@ const FilterTree = ({ node, filters, highlighted, checked, expanded, onCheck, se
 
 				data[i] = clonedItem;
 
-				formatLabels(data[i].children);
+				data[i].children = formatLabels(data[i].children);
 			});
 
 			return data;


### PR DESCRIPTION
release-fix/GAT-681 - child filters not highlighting in spatial filters