### PR TITLE
feature/GAT-855

### DIFF
--- a/src/pages/DatasetOnboarding/components/DatePickerCustom/DatepickerCustom.js
+++ b/src/pages/DatasetOnboarding/components/DatePickerCustom/DatepickerCustom.js
@@ -10,6 +10,9 @@ class DatePickerCustom extends React.Component {
 		if (moment(this.props.value, 'DD/MM/YYYY').isValid()) {
 			date = moment(this.props.value, 'DD/MM/YYYY').toDate();
 		}
+		if (moment(this.props.value, moment.ISO_8601).isValid()) {
+			date = moment(this.props.value, moment.ISO_8601).toDate();
+		}
 		this.state = {
 			date,
 		};
@@ -20,7 +23,8 @@ class DatePickerCustom extends React.Component {
 	componentWillReceiveProps(nextProps) {
 		let { value } = nextProps;
 
-		if (!_.isNil(value)) value = moment(value, 'DD/MM/YYYY').toDate();
+		if (!_.isNil(value) && moment(value, 'DD/MM/YYYY').isValid()) value = moment(value, 'DD/MM/YYYY').toDate();
+		if (!_.isNil(value) && moment(value, moment.ISO_8601).isValid()) value = moment(value, moment.ISO_8601).toDate();
 
 		if (this.props.value !== value) this.setState({ date: value });
 	}


### PR DESCRIPTION
The custom DatePicker Winterfell type modified to accept ISO-8601 dates e.g., 2022-03-24 in addition to 24/03/2022. Currently it only includes dates which are in the DD/MM/YYYY format. However, out v2 schema, which will validate FMA data, specifies that data should be in the ISO-8601 standard. This modification means we can have both types in the UI, without any breaking changes.