### PR TITLE
Release fix/gat 881 - missing input type for research dropdown

### DIFF
--- a/src/pages/DataAccessRequest/DataAccessRequest.js
+++ b/src/pages/DataAccessRequest/DataAccessRequest.js
@@ -1936,6 +1936,8 @@ class DataAccessRequest extends Component {
         Winterfell.addInputType('typeaheadUser', TypeaheadUser);
         Winterfell.addInputType('textareaInputCustom', TextareaInputCustom);
         Winterfell.addInputType('dropdownCustom', DropdownCustom);
+        Winterfell.addInputType('doubleDropdownCustom', DoubleDropdownCustom);
+
         Winterfell.validation.default.addValidationMethods({
             isCustomDate: value => {
                 if (_.isEmpty(value) || _.isNil(value) || moment(value, 'DD/MM/YYYY').isValid()) {


### PR DESCRIPTION
Release fix/gat 881 - missing input type for research dropdown. Winterfell not finding type of field when generating form from schema