### PR TITLE
feature/GAT-899-fix

### DIFF
--- a/src/pages/DatasetOnboarding/DatasetOnboarding.js
+++ b/src/pages/DatasetOnboarding/DatasetOnboarding.js
@@ -38,15 +38,13 @@ import BeforeYouBegin from './components/BeforeYouBegin/BeforeYouBegin';
 import Guidance from './components/Guidance/Guidance';
 import StructuralMetadata from './components/StructuralMetadata/StructuralMetadata';
 import StatusDisplay from '../commonComponents/StatusDisplay';
-
 import ActionModal from './components/ActionModal/ActionModal';
-
 import Dropdown from 'react-bootstrap/Dropdown';
-
 import { formSchema } from './formSchema';
 import DatasetOnboardingHelperUtil from '../../utils/DatasetOnboardingHelper.util';
 import ActionBarStatus from '../../components/ActionBarStatus';
 import ErrorModal from '../commonComponents/errorModal';
+import datasetOnboardingServices from '../../services/dataset-onboarding';
 
 /* export const DatasetOnboarding = props => {
     const [id] = useState('');
@@ -176,6 +174,13 @@ class DatasetOnboarding extends Component {
 						listOfDatasets,
 					},
 				} = response;
+
+				let {
+					data: { publisher: publisherDetails },
+				} = await datasetOnboardingServices.getPublisherDetails(data.dataset.datasetv2.summary.publisher.identifier);
+				
+				if (!_.isEmpty(publisherDetails.federation) && publisherDetails.federation.active) this.setState({ isFederated: true });
+
 				// 3. Set up the DAR
 				this.setScreenData({
 					...data,
@@ -240,7 +245,6 @@ class DatasetOnboarding extends Component {
 		let showArchive = false;
 		let showUnArchive = false;
 		let showDeleteDraft = false;
-		let isFederated = false;
 
 		let publisher = dataset.datasetv2.summary.publisher.identifier;
 
@@ -269,11 +273,6 @@ class DatasetOnboarding extends Component {
 			readOnly = true;
 		}
 
-		if (dataSource === 'federation') {
-			isFederated = true;
-			readOnly = true;
-		}
-
 		let initialPanel = jsonSchema.formPanels[0].panelId;
 
 		// 9. Set state
@@ -294,7 +293,7 @@ class DatasetOnboarding extends Component {
 			datasetVersion,
 			activeflag,
 			publisher,
-			readOnly,
+			readOnly: this.state.isFederated ? true : readOnly,
 			answeredAmendments,
 			unansweredAmendments,
 			userType,
@@ -306,7 +305,6 @@ class DatasetOnboarding extends Component {
 			showDeleteDraft,
 			inReviewMode,
 			reviewSections,
-			isFederated,
 		});
 	};
 

--- a/src/pages/DatasetOnboarding/DatasetOnboarding.js
+++ b/src/pages/DatasetOnboarding/DatasetOnboarding.js
@@ -190,7 +190,6 @@ class DatasetOnboarding extends Component {
 					listOfDatasets,
 					jsonSchema: { ...formSchema },
 					applicationStatus: data.dataset.activeflag,
-					dataSource: data.dataset.source,
 				});
 			} catch (error) {
 				this.setState({ isLoading: false });
@@ -234,7 +233,6 @@ class DatasetOnboarding extends Component {
 			answeredAmendments = 0,
 			inReviewMode = false,
 			reviewSections = [],
-			dataSource,
 		} = context;
 
 		let { name, datasetVersion, activeflag } = dataset;
@@ -275,6 +273,10 @@ class DatasetOnboarding extends Component {
 
 		let initialPanel = jsonSchema.formPanels[0].panelId;
 
+		if (this.state.isFederated) {
+			readOnly = true
+		}
+
 		// 9. Set state
 		this.setState({
 			jsonSchema: { ...jsonSchema, ...classSchema },
@@ -293,7 +295,7 @@ class DatasetOnboarding extends Component {
 			datasetVersion,
 			activeflag,
 			publisher,
-			readOnly: this.state.isFederated ? true : readOnly,
+			readOnly,
 			answeredAmendments,
 			unansweredAmendments,
 			userType,

--- a/src/services/dataset-onboarding/dataset-onboarding.js
+++ b/src/services/dataset-onboarding/dataset-onboarding.js
@@ -21,6 +21,10 @@ const getPublisher = (_id, options) => {
     return getRequest(`${apiURL}/dataset-onboarding/publisher/${_id}`, options);
 };
 
+const getPublisherDetails = (_id, options) => {
+    return getRequest(`${apiURL}/publishers/${_id}`, options);
+};
+
 const postDatasetOnboarding = (data, options) => {
     return postRequest(`${apiURL}/dataset-onboarding`, data, options);
 };
@@ -106,6 +110,7 @@ export default {
     getDatasetOnboardings,
     getDatasetOnboarding,
     getPublisher,
+    getPublisherDetails,
     postDatasetOnboarding,
     postDuplicate,
     putDatasetOnboarding,


### PR DESCRIPTION
Fix for 899, federation flag on the publisher should disable UI options, not the $.source flag on the dataset, as was the case previously.