### PR TITLE
GAT-918 - disable clicking of greyed out filters

### DIFF
--- a/src/pages/search/components/Filter.js
+++ b/src/pages/search/components/Filter.js
@@ -28,6 +28,7 @@ const CheckboxWrapper = ({ node = {}, highlighted = [], parentKey = '', onHandle
             label={<span className={!highlight && 'checkbox-text'}>{node.label}</span>}
             checked={node.checked}
             onChange={onHandleChange}
+            disabled={!highlight}
         />
     );
 };

--- a/src/pages/search/components/FilterTree/FilterTree.js
+++ b/src/pages/search/components/FilterTree/FilterTree.js
@@ -54,6 +54,8 @@ const FilterTree = ({ node, filters, highlighted, checked, expanded, onCheck, se
                     <span className='checkbox-text'>{clonedItem.label}</span>
                 );
 
+                clonedItem.disabled = highlighted.includes(clonedItem.value) ? false : true;
+
                 data[i] = clonedItem;
 
                 data[i].children = formatLabels(data[i].children);


### PR DESCRIPTION
Disabled in two places: 

src/pages/search/components/Filter.js for the majority of filters.

src/pages/search/components/FilterTree/FilterTree.js for the spatial filter tree.

Only issue is that when filter tree nodes are disabled, a different cursor icon is shown on hover...