### PR TITLE
story/GAT-917 - disable clicking of greyed-out filters

### DIFF
--- a/src/components/CheckboxTree/CheckboxTree.styles.js
+++ b/src/components/CheckboxTree/CheckboxTree.styles.js
@@ -109,5 +109,20 @@ export const root =
             input:disabled + .rct-checkbox .rct-icon::after {
                 ${mixins.disabled({ colors, variants, variant })}
             }
+
+            label:hover input ~ *,
+            label:hover input ~ * * {
+                cursor: pointer;
+            }
+
+            label:hover,
+            label:hover input:disabled ~ *,
+            label:hover input:disabled ~ * * {
+                cursor: default;
+            }
+
+            label:hover input:disabled + .rct-checkbox .rct-icon-uncheck::before {
+                background: none;
+            }
         `;
     };

--- a/src/components/CheckboxTree/CheckboxTree.styles.js
+++ b/src/components/CheckboxTree/CheckboxTree.styles.js
@@ -115,9 +115,14 @@ export const root =
                 cursor: pointer;
             }
 
-            label:hover,
+            .rct-disabled label {
+                cursor: default;
+            }
+
             label:hover input:disabled ~ *,
-            label:hover input:disabled ~ * * {
+            label:hover input:disabled ~ * *,
+            label:hover input:disabled + .rct-checkbox .rct-icon::after,
+            label:hover input:disabled + .rct-checkbox .rct-icon::before {
                 cursor: default;
             }
 

--- a/src/pages/search/components/Filter.js
+++ b/src/pages/search/components/Filter.js
@@ -28,6 +28,7 @@ const CheckboxWrapper = ({ node = {}, highlighted = [], parentKey = '', onHandle
             label={<span className={!highlight && 'checkbox-text'}>{node.label}</span>}
             checked={node.checked}
             onChange={onHandleChange}
+            disabled={!highlight}
         />
     );
 };

--- a/src/pages/search/components/FilterTree/FilterTree.js
+++ b/src/pages/search/components/FilterTree/FilterTree.js
@@ -54,6 +54,8 @@ const FilterTree = ({ node, filters, highlighted, checked, expanded, onCheck, se
                     <span className='checkbox-text'>{clonedItem.label}</span>
                 );
 
+                clonedItem.disabled = highlighted.includes(clonedItem.value) ? false : true;
+
                 data[i] = clonedItem;
 
                 data[i].children = formatLabels(data[i].children);

--- a/src/pages/search/components/FilterTree/FilterTree.js
+++ b/src/pages/search/components/FilterTree/FilterTree.js
@@ -54,7 +54,7 @@ const FilterTree = ({ node, filters, highlighted, checked, expanded, onCheck, se
                     <span className='checkbox-text'>{clonedItem.label}</span>
                 );
 
-                clonedItem.disabled = highlighted.includes(clonedItem.value) ? false : true;
+                clonedItem.disabled = !highlighted.includes(clonedItem.value);
 
                 data[i] = clonedItem;
 


### PR DESCRIPTION
Disable the clicking of greyed-out filters, both for the "normal" filters and the checkbox tree for the spatial filters.