### PR TITLE
GAT-1769/GAT-1768: Refactoring related resources tab

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -98,6 +98,7 @@
             "devDependencies": {
                 "@babel/preset-env": "^7.10.2",
                 "@emotion/jest": "^11.10.0",
+                "@faker-js/faker": "^7.6.0",
                 "@storybook/addon-actions": "^6.3.8",
                 "@storybook/addon-essentials": "^6.3.8",
                 "@storybook/addon-links": "^6.3.8",
@@ -2291,7 +2292,7 @@
             "version": "0.4.3",
             "resolved": "https://registry.npmjs.org/@eslint/eslintrc/-/eslintrc-0.4.3.tgz",
             "integrity": "sha512-J6KFFz5QCYUJq3pf0mjEcCJVERbzv71PUIDczuh9JkwGEzced6CO5ADLHB1rbf/+oPBtoPfMYNOpGDzCANlbXw==",
-            "dev": true,
+            "devOptional": true,
             "dependencies": {
                 "ajv": "^6.12.4",
                 "debug": "^4.1.1",
@@ -2311,7 +2312,7 @@
             "version": "13.17.0",
             "resolved": "https://registry.npmjs.org/globals/-/globals-13.17.0.tgz",
             "integrity": "sha512-1C+6nQRb1GwGMKm2dH/E7enFAMxGTmGI7/dEdhy/DNelv85w9B72t3uc5frtMNXIbzrarJJ/lTCjcaZwbLJmyw==",
-            "dev": true,
+            "devOptional": true,
             "dependencies": {
                 "type-fest": "^0.20.2"
             },
@@ -2320,6 +2321,16 @@
             },
             "funding": {
                 "url": "https://github.com/sponsors/sindresorhus"
+            }
+        },
+        "node_modules/@faker-js/faker": {
+            "version": "7.6.0",
+            "resolved": "https://registry.npmjs.org/@faker-js/faker/-/faker-7.6.0.tgz",
+            "integrity": "sha512-XK6BTq1NDMo9Xqw/YkYyGjSsg44fbNwYRx7QK2CuoQgyy+f1rrTDHoExVM5PsyXCtfl2vs2vVJ0MN0yN6LppRw==",
+            "dev": true,
+            "engines": {
+                "node": ">=14.0.0",
+                "npm": ">=6.0.0"
             }
         },
         "node_modules/@gar/promisify": {
@@ -2376,7 +2387,7 @@
             "version": "0.5.0",
             "resolved": "https://registry.npmjs.org/@humanwhocodes/config-array/-/config-array-0.5.0.tgz",
             "integrity": "sha512-FagtKFz74XrTl7y6HCzQpwDfXP0yhxe9lHLD1UZxjvZIcbyRz8zTFF/yYNfSfzU414eDwZ1SrO0Qvtyf+wFMQg==",
-            "dev": true,
+            "devOptional": true,
             "dependencies": {
                 "@humanwhocodes/object-schema": "^1.2.0",
                 "debug": "^4.1.1",
@@ -2390,7 +2401,7 @@
             "version": "1.2.1",
             "resolved": "https://registry.npmjs.org/@humanwhocodes/object-schema/-/object-schema-1.2.1.tgz",
             "integrity": "sha512-ZnQMnLV4e7hDlUvw8H+U8ASL02SS2Gn6+9Ac3wGGLIe7+je2AeAOxPY+izIPJDfFDb7eDjev0Us8MO1iFRN8hA==",
-            "dev": true
+            "devOptional": true
         },
         "node_modules/@hypnosphi/create-react-context": {
             "version": "0.3.1",
@@ -8166,7 +8177,7 @@
             "version": "7.4.1",
             "resolved": "https://registry.npmjs.org/acorn/-/acorn-7.4.1.tgz",
             "integrity": "sha512-nQyp0o1/mNdbTO1PO6kHkwSrmgZ0MT/jCCpNiwbUjGoRN4dlBhqJtoQuCnEOKzgTVwg0ZWiCoQy6SxMebQVh8A==",
-            "dev": true,
+            "devOptional": true,
             "bin": {
                 "acorn": "bin/acorn"
             },
@@ -8209,7 +8220,7 @@
             "version": "5.3.2",
             "resolved": "https://registry.npmjs.org/acorn-jsx/-/acorn-jsx-5.3.2.tgz",
             "integrity": "sha512-rq9s+JNhf0IChjtDXxllJ7g41oZk5SlXtp0LHwyA5cejwn7vKmKp4pPri6YEePv2PU65sAsegbXtIinmDFDXgQ==",
-            "dev": true,
+            "devOptional": true,
             "peerDependencies": {
                 "acorn": "^6.0.0 || ^7.0.0 || ^8.0.0"
             }
@@ -8367,7 +8378,7 @@
             "version": "4.1.3",
             "resolved": "https://registry.npmjs.org/ansi-colors/-/ansi-colors-4.1.3.tgz",
             "integrity": "sha512-/6w/C21Pm1A7aZitlI5Ni/2J6FFQN8i1Cvz3kHABAAbw93v/NlvKdVOqz7CCWz/3iv/JplRSEEZ83XION15ovw==",
-            "dev": true,
+            "devOptional": true,
             "engines": {
                 "node": ">=6"
             }
@@ -10089,7 +10100,6 @@
             "version": "1.5.0",
             "resolved": "https://registry.npmjs.org/bindings/-/bindings-1.5.0.tgz",
             "integrity": "sha512-p2q/t/mhvuOj/UeLlV6566GD/guowlr0hHxClI0W9m7MWYkL1F0hLo+0Aexs9HSPCtR1SXQ0TD3MMKrXZajbiQ==",
-            "dev": true,
             "optional": true,
             "dependencies": {
                 "file-uri-to-path": "1.0.0"
@@ -12863,7 +12873,7 @@
             "version": "0.1.4",
             "resolved": "https://registry.npmjs.org/deep-is/-/deep-is-0.1.4.tgz",
             "integrity": "sha512-oIPzksmTg4/MriiaYGO+okXDT7ztn/w3Eptv/+gSIdMdKsJo0u4CfYNFJPy+4SKMuCqGw2wxnA+URMg3t8a/bQ==",
-            "dev": true
+            "devOptional": true
         },
         "node_modules/deepdash-es": {
             "version": "5.3.9",
@@ -13792,7 +13802,7 @@
             "version": "2.3.6",
             "resolved": "https://registry.npmjs.org/enquirer/-/enquirer-2.3.6.tgz",
             "integrity": "sha512-yjNnPr315/FjS4zIsUxYguYUPP2e1NK4d7E7ZOLiyYCcbFBiTMyID+2wvm2w6+pZ/odMA7cRkjhsPbltwBOrLg==",
-            "dev": true,
+            "devOptional": true,
             "dependencies": {
                 "ansi-colors": "^4.1.1"
             },
@@ -14159,7 +14169,7 @@
             "version": "7.32.0",
             "resolved": "https://registry.npmjs.org/eslint/-/eslint-7.32.0.tgz",
             "integrity": "sha512-VHZ8gX+EDfz+97jGcgyGCyRia/dPOd6Xh9yPv8Bl1+SoaIwD+a/vlrOmGRUyOYu7MwUhc7CxqeaDZU13S4+EpA==",
-            "dev": true,
+            "devOptional": true,
             "dependencies": {
                 "@babel/code-frame": "7.12.11",
                 "@eslint/eslintrc": "^0.4.3",
@@ -14734,7 +14744,7 @@
             "version": "5.1.1",
             "resolved": "https://registry.npmjs.org/eslint-scope/-/eslint-scope-5.1.1.tgz",
             "integrity": "sha512-2NxwbF/hZ0KpepYN0cNbo+FN6XoK7GaHlQhgx/hIZl6Va0bF45RQOOwhLIy8lQDbuCiadSLCBnH2CFYquit5bw==",
-            "dev": true,
+            "devOptional": true,
             "dependencies": {
                 "esrecurse": "^4.3.0",
                 "estraverse": "^4.1.1"
@@ -14747,7 +14757,7 @@
             "version": "4.3.0",
             "resolved": "https://registry.npmjs.org/estraverse/-/estraverse-4.3.0.tgz",
             "integrity": "sha512-39nnKffWz8xN1BU/2c79n9nB9HDzo0niYUqx6xyqUnyoAnQyyWpOTdZEeiCch8BBu515t4wp9ZmgVfVhn9EBpw==",
-            "dev": true,
+            "devOptional": true,
             "engines": {
                 "node": ">=4.0"
             }
@@ -14756,7 +14766,7 @@
             "version": "2.1.0",
             "resolved": "https://registry.npmjs.org/eslint-utils/-/eslint-utils-2.1.0.tgz",
             "integrity": "sha512-w94dQYoauyvlDc43XnGB8lU3Zt713vNChgt4EWwhXAP2XkBvndfxF0AgIqKOOasjPIPzj9JqgwkwbCYD0/V3Zg==",
-            "dev": true,
+            "devOptional": true,
             "dependencies": {
                 "eslint-visitor-keys": "^1.1.0"
             },
@@ -14771,7 +14781,7 @@
             "version": "1.3.0",
             "resolved": "https://registry.npmjs.org/eslint-visitor-keys/-/eslint-visitor-keys-1.3.0.tgz",
             "integrity": "sha512-6J72N8UNa462wa/KFODt/PJ3IU60SDpC3QXC1Hjc1BXXpfL2C9R5+AU7jhe0F6GREqVMh4Juu+NY7xn+6dipUQ==",
-            "dev": true,
+            "devOptional": true,
             "engines": {
                 "node": ">=4"
             }
@@ -14780,7 +14790,7 @@
             "version": "2.1.0",
             "resolved": "https://registry.npmjs.org/eslint-visitor-keys/-/eslint-visitor-keys-2.1.0.tgz",
             "integrity": "sha512-0rSmRBzXgDzIsD6mGdJgevzgezI534Cer5L/vyMX0kHzT/jiB43jRhd9YUlMGYLQy2zprNmoT8qasCGtY+QaKw==",
-            "dev": true,
+            "devOptional": true,
             "engines": {
                 "node": ">=10"
             }
@@ -14789,7 +14799,7 @@
             "version": "7.12.11",
             "resolved": "https://registry.npmjs.org/@babel/code-frame/-/code-frame-7.12.11.tgz",
             "integrity": "sha512-Zt1yodBx1UcyiePMSkWnU4hPqhwq7hGi2nFL1LeA3EUl+q2LQx16MISgJ0+z7dnmgvP9QtIleuETGOiOH1RcIw==",
-            "dev": true,
+            "devOptional": true,
             "dependencies": {
                 "@babel/highlight": "^7.10.4"
             }
@@ -14798,7 +14808,7 @@
             "version": "4.3.0",
             "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-4.3.0.tgz",
             "integrity": "sha512-zbB9rCJAT1rbjiVDb2hqKFHNYLxgtk8NURxZ3IZwD3F6NtxbXZQCnnSi1Lkx+IDohdPlFp222wVALIheZJQSEg==",
-            "dev": true,
+            "devOptional": true,
             "dependencies": {
                 "color-convert": "^2.0.1"
             },
@@ -14813,7 +14823,7 @@
             "version": "4.1.2",
             "resolved": "https://registry.npmjs.org/chalk/-/chalk-4.1.2.tgz",
             "integrity": "sha512-oKnbhFyRIXpUuez8iBMmyEa4nbj4IOQyuhc/wy9kY7/WVPcwIO9VA668Pu8RkO7+0G76SLROeyw9CpQ061i4mA==",
-            "dev": true,
+            "devOptional": true,
             "dependencies": {
                 "ansi-styles": "^4.1.0",
                 "supports-color": "^7.1.0"
@@ -14829,7 +14839,7 @@
             "version": "2.0.1",
             "resolved": "https://registry.npmjs.org/color-convert/-/color-convert-2.0.1.tgz",
             "integrity": "sha512-RRECPsj7iu/xb5oKYcsFHSppFNnsj/52OVTRKb4zP5onXwVF3zVmmToNcOfGC+CRDpfK/U584fMg38ZHCaElKQ==",
-            "dev": true,
+            "devOptional": true,
             "dependencies": {
                 "color-name": "~1.1.4"
             },
@@ -14841,13 +14851,13 @@
             "version": "1.1.4",
             "resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.4.tgz",
             "integrity": "sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA==",
-            "dev": true
+            "devOptional": true
         },
         "node_modules/eslint/node_modules/globals": {
             "version": "13.17.0",
             "resolved": "https://registry.npmjs.org/globals/-/globals-13.17.0.tgz",
             "integrity": "sha512-1C+6nQRb1GwGMKm2dH/E7enFAMxGTmGI7/dEdhy/DNelv85w9B72t3uc5frtMNXIbzrarJJ/lTCjcaZwbLJmyw==",
-            "dev": true,
+            "devOptional": true,
             "dependencies": {
                 "type-fest": "^0.20.2"
             },
@@ -14862,7 +14872,7 @@
             "version": "4.0.0",
             "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-4.0.0.tgz",
             "integrity": "sha512-EykJT/Q1KjTWctppgIAgfSO0tKVuZUjhgMr17kqTumMl6Afv3EISleU7qZUzoXDFTAHTDC4NOoG/ZxU3EvlMPQ==",
-            "dev": true,
+            "devOptional": true,
             "engines": {
                 "node": ">=8"
             }
@@ -14871,7 +14881,7 @@
             "version": "0.9.1",
             "resolved": "https://registry.npmjs.org/optionator/-/optionator-0.9.1.tgz",
             "integrity": "sha512-74RlY5FCnhq4jRxVUPKDaRwrVNXMqsGsiW6AJw4XK8hmtm10wC0ypZBLw5IIp85NZMr91+qd1RvvENwg7jjRFw==",
-            "dev": true,
+            "devOptional": true,
             "dependencies": {
                 "deep-is": "^0.1.3",
                 "fast-levenshtein": "^2.0.6",
@@ -14888,7 +14898,7 @@
             "version": "7.3.7",
             "resolved": "https://registry.npmjs.org/semver/-/semver-7.3.7.tgz",
             "integrity": "sha512-QlYTucUYOews+WeEujDoEGziz4K6c47V/Bd+LjSSYcA94p+DmINdf7ncaUinThfvZyu13lN9OY1XDxt8C0Tw0g==",
-            "dev": true,
+            "devOptional": true,
             "dependencies": {
                 "lru-cache": "^6.0.0"
             },
@@ -14903,7 +14913,7 @@
             "version": "7.2.0",
             "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-7.2.0.tgz",
             "integrity": "sha512-qpCAvRl9stuOHveKsn7HncJRvv501qIacKzQlO/+Lwxc9+0q2wLyv4Dfvt80/DPn2pqOBsJdDiogXGR9+OvwRw==",
-            "dev": true,
+            "devOptional": true,
             "dependencies": {
                 "has-flag": "^4.0.0"
             },
@@ -14915,7 +14925,7 @@
             "version": "7.3.1",
             "resolved": "https://registry.npmjs.org/espree/-/espree-7.3.1.tgz",
             "integrity": "sha512-v3JCNCE64umkFpmkFGqzVKsOT0tN1Zr+ueqLZfpV1Ob8e+CEgPWa+OxCoGH3tnhimMKIaBm4m/vaRpJ/krRz2g==",
-            "dev": true,
+            "devOptional": true,
             "dependencies": {
                 "acorn": "^7.4.0",
                 "acorn-jsx": "^5.3.1",
@@ -14929,7 +14939,7 @@
             "version": "1.3.0",
             "resolved": "https://registry.npmjs.org/eslint-visitor-keys/-/eslint-visitor-keys-1.3.0.tgz",
             "integrity": "sha512-6J72N8UNa462wa/KFODt/PJ3IU60SDpC3QXC1Hjc1BXXpfL2C9R5+AU7jhe0F6GREqVMh4Juu+NY7xn+6dipUQ==",
-            "dev": true,
+            "devOptional": true,
             "engines": {
                 "node": ">=4"
             }
@@ -14950,7 +14960,7 @@
             "version": "1.4.0",
             "resolved": "https://registry.npmjs.org/esquery/-/esquery-1.4.0.tgz",
             "integrity": "sha512-cCDispWt5vHHtwMY2YrAQ4ibFkAL8RbH5YGBnZBc90MolvvfkkQcJro/aZiAQUlQ3qgrYS6D6v8Gc5G5CQsc9w==",
-            "dev": true,
+            "devOptional": true,
             "dependencies": {
                 "estraverse": "^5.1.0"
             },
@@ -15620,7 +15630,7 @@
             "version": "2.0.6",
             "resolved": "https://registry.npmjs.org/fast-levenshtein/-/fast-levenshtein-2.0.6.tgz",
             "integrity": "sha512-DCXu6Ifhqcks7TZKY3Hxp3y6qphY5SJZmrWMDrKcERSOXWQdMhU9Ig/PYrzyw/ul9jOIyh0N4M0tbC5hodg8dw==",
-            "dev": true
+            "devOptional": true
         },
         "node_modules/fast-shallow-equal": {
             "version": "1.0.0",
@@ -15730,7 +15740,7 @@
             "version": "6.0.1",
             "resolved": "https://registry.npmjs.org/file-entry-cache/-/file-entry-cache-6.0.1.tgz",
             "integrity": "sha512-7Gps/XWymbLk2QLYK4NzpMOrYjMhdIxXuIvy2QBsLE6ljuodKvdkWs/cpyJJ3CVIVpH0Oi1Hvg1ovbMzLdFBBg==",
-            "dev": true,
+            "devOptional": true,
             "dependencies": {
                 "flat-cache": "^3.0.4"
             },
@@ -15818,7 +15828,6 @@
             "version": "1.0.0",
             "resolved": "https://registry.npmjs.org/file-uri-to-path/-/file-uri-to-path-1.0.0.tgz",
             "integrity": "sha512-0Zt+s3L7Vf1biwWZ29aARiVYLx7iMGnEUl9x33fbB/j3jR81u/O2LbqK+Bm1CDSNDKVtJ/YjwY7TUd5SkeLQLw==",
-            "dev": true,
             "optional": true
         },
         "node_modules/filesize": {
@@ -15983,7 +15992,7 @@
             "version": "3.0.4",
             "resolved": "https://registry.npmjs.org/flat-cache/-/flat-cache-3.0.4.tgz",
             "integrity": "sha512-dm9s5Pw7Jc0GvMYbshN6zchCA9RgQlzzEZX3vylR9IqFfS8XciblUXOKfW6SiuJ0e13eDYZoZV5wdrev7P3Nwg==",
-            "dev": true,
+            "devOptional": true,
             "dependencies": {
                 "flatted": "^3.1.0",
                 "rimraf": "^3.0.2"
@@ -15996,7 +16005,7 @@
             "version": "3.2.7",
             "resolved": "https://registry.npmjs.org/flatted/-/flatted-3.2.7.tgz",
             "integrity": "sha512-5nqDSxl8nn5BSNxyR3n4I6eDmbolI6WT+QqR547RwxQapgjQBmtktdP+HTBb/a/zLsbzERTONyUB5pefh5TtjQ==",
-            "dev": true
+            "devOptional": true
         },
         "node_modules/flatten": {
             "version": "1.0.3",
@@ -16517,7 +16526,7 @@
             "version": "1.0.1",
             "resolved": "https://registry.npmjs.org/functional-red-black-tree/-/functional-red-black-tree-1.0.1.tgz",
             "integrity": "sha512-dsKNQNdj6xA3T+QlADDA7mOSlX0qiMINjn0cgr+eGHGsbSHzTabcIogz2+p/iqP1Xs6EP/sS2SbqH+brGTbq0g==",
-            "dev": true
+            "devOptional": true
         },
         "node_modules/functions-have-names": {
             "version": "1.2.3",
@@ -18194,7 +18203,7 @@
             "version": "4.0.6",
             "resolved": "https://registry.npmjs.org/ignore/-/ignore-4.0.6.tgz",
             "integrity": "sha512-cyFDKrqc/YdcWFniJhzI42+AzS+gNwmUzOSFcRCQYwySuBBBy/KjuxWLZ/FHEH6Moq1NizMOBWyTcv8O4OZIMg==",
-            "dev": true,
+            "devOptional": true,
             "engines": {
                 "node": ">= 4"
             }
@@ -25080,7 +25089,7 @@
             "version": "1.0.1",
             "resolved": "https://registry.npmjs.org/json-stable-stringify-without-jsonify/-/json-stable-stringify-without-jsonify-1.0.1.tgz",
             "integrity": "sha512-Bdboy+l7tA3OGW6FjyFHWkP5LuByj1Tk33Ljyq0axyzdk9//JSi2u3fP1QSmd1KNwq6VOKYGlAu87CisVir6Pw==",
-            "dev": true
+            "devOptional": true
         },
         "node_modules/json-stringify-safe": {
             "version": "5.0.1",
@@ -25339,7 +25348,7 @@
             "version": "0.4.1",
             "resolved": "https://registry.npmjs.org/levn/-/levn-0.4.1.tgz",
             "integrity": "sha512-+bT2uH4E5LGE7h/n3evcS/sQlJXCpIp6ym8OWJ5eV6+67Dsql/LaaT7qJBAt2rzfoa/5QBGBhxDix1dMt2kQKQ==",
-            "dev": true,
+            "devOptional": true,
             "dependencies": {
                 "prelude-ls": "^1.2.1",
                 "type-check": "~0.4.0"
@@ -25569,7 +25578,7 @@
             "version": "4.6.2",
             "resolved": "https://registry.npmjs.org/lodash.merge/-/lodash.merge-4.6.2.tgz",
             "integrity": "sha512-0KpjqXRVvrYyCsX1swR/XTK0va6VQkQM6MNo7PqW77ByjAhoARA8EfrP1N4+KlKj8YS0ZUCtRT/YUuhyYDujIQ==",
-            "dev": true
+            "devOptional": true
         },
         "node_modules/lodash.sortby": {
             "version": "4.7.0",
@@ -25600,7 +25609,7 @@
             "version": "4.4.2",
             "resolved": "https://registry.npmjs.org/lodash.truncate/-/lodash.truncate-4.4.2.tgz",
             "integrity": "sha512-jttmRe7bRse52OsWIMDLaXxWqRAmtIUccAQ3garviCqJjafXOfNMO0yMfNpdD6zbGaTU0P5Nz7e7gAT6cKmJRw==",
-            "dev": true
+            "devOptional": true
         },
         "node_modules/lodash.uniq": {
             "version": "4.5.0",
@@ -27009,7 +27018,6 @@
             "version": "2.16.0",
             "resolved": "https://registry.npmjs.org/nan/-/nan-2.16.0.tgz",
             "integrity": "sha512-UdAqHyFngu7TfQKsCBgAA6pWDkT8MAO7d0jyOecVhN5354xbLqdn8mV9Tat9gepAupm0bt2DbeaSC8vS52MuFA==",
-            "dev": true,
             "optional": true
         },
         "node_modules/nano-css": {
@@ -27109,7 +27117,7 @@
             "version": "1.4.0",
             "resolved": "https://registry.npmjs.org/natural-compare/-/natural-compare-1.4.0.tgz",
             "integrity": "sha512-OWND8ei3VtNC9h7V60qff3SVobHr996CTwgxubgyQYEpg290h9J0buyECNNJexkFm5sOajh5G116RYA1c8ZMSw==",
-            "dev": true
+            "devOptional": true
         },
         "node_modules/nearley": {
             "version": "2.20.1",
@@ -30008,7 +30016,7 @@
             "version": "1.2.1",
             "resolved": "https://registry.npmjs.org/prelude-ls/-/prelude-ls-1.2.1.tgz",
             "integrity": "sha512-vkcDPrRZo1QZLbn5RLGPpg/WmIQ65qoWWhcGKf/b5eplkkarX0m9z8ppCat4mlOqUsWpyNuYgO3VRyrYHSzX5g==",
-            "dev": true,
+            "devOptional": true,
             "engines": {
                 "node": ">= 0.8.0"
             }
@@ -30136,7 +30144,7 @@
             "version": "2.0.3",
             "resolved": "https://registry.npmjs.org/progress/-/progress-2.0.3.tgz",
             "integrity": "sha512-7PiHtLll5LdnKIMw100I+8xJXR5gW2QwWYkT6iJva0bXitZKa/XMrSbdmg3r2Xnaidz9Qumd0VPaMrZlF9V9sA==",
-            "dev": true,
+            "devOptional": true,
             "engines": {
                 "node": ">=0.4.0"
             }
@@ -36078,7 +36086,7 @@
             "version": "3.2.0",
             "resolved": "https://registry.npmjs.org/regexpp/-/regexpp-3.2.0.tgz",
             "integrity": "sha512-pq2bWo9mVD43nbts2wGv17XLiNLya+GklZ8kaDLV2Z08gDCsGpnKn9BFMepvWuHCbyVvY7J5o5+BVvoQbmlJLg==",
-            "dev": true,
+            "devOptional": true,
             "engines": {
                 "node": ">=8"
             },
@@ -37511,7 +37519,7 @@
             "version": "2.0.2",
             "resolved": "https://registry.npmjs.org/require-from-string/-/require-from-string-2.0.2.tgz",
             "integrity": "sha512-Xf0nWe6RseziFMu+Ap9biiUbmplq6S9/p+7w7YXP/JBHhrUDDUhwa+vANyubuqfZWTveU//DYVGsDG7RKL/vEw==",
-            "dev": true,
+            "devOptional": true,
             "engines": {
                 "node": ">=0.10.0"
             }
@@ -38698,7 +38706,7 @@
             "version": "4.0.0",
             "resolved": "https://registry.npmjs.org/slice-ansi/-/slice-ansi-4.0.0.tgz",
             "integrity": "sha512-qMCMfhY040cVHT43K9BFygqYbUPFZKHOg7K73mtTWJRb8pyP3fzf4Ixd5SzdEJQ6MRUg/WBnOLxghZtKKurENQ==",
-            "dev": true,
+            "devOptional": true,
             "dependencies": {
                 "ansi-styles": "^4.0.0",
                 "astral-regex": "^2.0.0",
@@ -38715,7 +38723,7 @@
             "version": "4.3.0",
             "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-4.3.0.tgz",
             "integrity": "sha512-zbB9rCJAT1rbjiVDb2hqKFHNYLxgtk8NURxZ3IZwD3F6NtxbXZQCnnSi1Lkx+IDohdPlFp222wVALIheZJQSEg==",
-            "dev": true,
+            "devOptional": true,
             "dependencies": {
                 "color-convert": "^2.0.1"
             },
@@ -38730,7 +38738,7 @@
             "version": "2.0.0",
             "resolved": "https://registry.npmjs.org/astral-regex/-/astral-regex-2.0.0.tgz",
             "integrity": "sha512-Z7tMw1ytTXt5jqMcOP+OQteU1VuNK9Y02uuJtKQ1Sv69jXQKKg5cibLwGJow8yzZP+eAc18EmLGPal0bp36rvQ==",
-            "dev": true,
+            "devOptional": true,
             "engines": {
                 "node": ">=8"
             }
@@ -38739,7 +38747,7 @@
             "version": "2.0.1",
             "resolved": "https://registry.npmjs.org/color-convert/-/color-convert-2.0.1.tgz",
             "integrity": "sha512-RRECPsj7iu/xb5oKYcsFHSppFNnsj/52OVTRKb4zP5onXwVF3zVmmToNcOfGC+CRDpfK/U584fMg38ZHCaElKQ==",
-            "dev": true,
+            "devOptional": true,
             "dependencies": {
                 "color-name": "~1.1.4"
             },
@@ -38751,7 +38759,7 @@
             "version": "1.1.4",
             "resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.4.tgz",
             "integrity": "sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA==",
-            "dev": true
+            "devOptional": true
         },
         "node_modules/snapdragon": {
             "version": "0.8.2",
@@ -39792,7 +39800,7 @@
             "version": "3.1.1",
             "resolved": "https://registry.npmjs.org/strip-json-comments/-/strip-json-comments-3.1.1.tgz",
             "integrity": "sha512-6fPc+R4ihwqP6N/aIv2f1gMH8lOVtWQHoqC4yK6oSDVVocumAsfCqjkXnqiYMhmMwS/mEHLp7Vehlt3ql6lEig==",
-            "dev": true,
+            "devOptional": true,
             "engines": {
                 "node": ">=8"
             },
@@ -40051,7 +40059,7 @@
             "version": "6.8.0",
             "resolved": "https://registry.npmjs.org/table/-/table-6.8.0.tgz",
             "integrity": "sha512-s/fitrbVeEyHKFa7mFdkuQMWlH1Wgw/yEXMt5xACT4ZpzWFluehAxRtUUQKPuWhaLAWhFcVx6w3oC8VKaUfPGA==",
-            "dev": true,
+            "devOptional": true,
             "dependencies": {
                 "ajv": "^8.0.1",
                 "lodash.truncate": "^4.4.2",
@@ -40067,7 +40075,7 @@
             "version": "8.11.0",
             "resolved": "https://registry.npmjs.org/ajv/-/ajv-8.11.0.tgz",
             "integrity": "sha512-wGgprdCvMalC0BztXvitD2hC04YffAvtsUn93JbGXYLAtCUO4xd17mCCZQxUOItiBwZvJScWo8NIvQMQ71rdpg==",
-            "dev": true,
+            "devOptional": true,
             "dependencies": {
                 "fast-deep-equal": "^3.1.1",
                 "json-schema-traverse": "^1.0.0",
@@ -40083,7 +40091,7 @@
             "version": "1.0.0",
             "resolved": "https://registry.npmjs.org/json-schema-traverse/-/json-schema-traverse-1.0.0.tgz",
             "integrity": "sha512-NM8/P9n3XjXhIZn1lLhkFaACTOURQXjWhV4BA/RnOv8xvgqtqpAX9IO4mRQxSx1Rlo4tqzeqb0sOlruaOy3dug==",
-            "dev": true
+            "devOptional": true
         },
         "node_modules/tapable": {
             "version": "1.1.3",
@@ -40438,7 +40446,7 @@
             "version": "0.2.0",
             "resolved": "https://registry.npmjs.org/text-table/-/text-table-0.2.0.tgz",
             "integrity": "sha512-N+8UisAXDGk8PFXP4HAzVR9nbfmVJ3zYLAWiTIoqC5v5isinhr+r5uaO8+7r3BMfuNIufIsA7RdpVgacC2cSpw==",
-            "dev": true
+            "devOptional": true
         },
         "node_modules/throat": {
             "version": "5.0.0",
@@ -40833,7 +40841,7 @@
             "version": "0.4.0",
             "resolved": "https://registry.npmjs.org/type-check/-/type-check-0.4.0.tgz",
             "integrity": "sha512-XleUoc9uwGXqjWwXaUTZAmzMcFZ5858QA2vvx1Ur5xIcixXIP+8LnFDgRplU30us6teqdlskFfu+ae4K79Ooew==",
-            "dev": true,
+            "devOptional": true,
             "dependencies": {
                 "prelude-ls": "^1.2.1"
             },
@@ -40854,7 +40862,7 @@
             "version": "0.20.2",
             "resolved": "https://registry.npmjs.org/type-fest/-/type-fest-0.20.2.tgz",
             "integrity": "sha512-Ne+eE4r0/iWnpAxD852z3A+N0Bt5RN//NjJwRd2VFHEmrywxf5vsZlh4R6lixl6B+wz/8d+maTSAkN1FIkI3LQ==",
-            "dev": true,
+            "devOptional": true,
             "engines": {
                 "node": ">=10"
             },
@@ -41590,7 +41598,7 @@
             "version": "2.3.0",
             "resolved": "https://registry.npmjs.org/v8-compile-cache/-/v8-compile-cache-2.3.0.tgz",
             "integrity": "sha512-l8lCEmLcLYZh4nbunNZvQCJc5pv7+RCwa8q/LdUx8u7lsWvPDKmpodJAJNwkAhJC//dFY48KuIEmjtd4RViDrA==",
-            "dev": true
+            "devOptional": true
         },
         "node_modules/v8-to-istanbul": {
             "version": "4.1.4",
@@ -41908,7 +41916,6 @@
             "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-1.2.13.tgz",
             "integrity": "sha512-oWb1Z6mkHIskLzEJ/XWX0srkpkTQ7vaopMQkyaEIoq0fmtFVxOthb8cCxeT+p3ynTdkk/RZwbgG4brR5BeWECw==",
             "deprecated": "fsevents 1 will break on node v14+ and could be using insecure binaries. Upgrade to fsevents 2.",
-            "dev": true,
             "hasInstallScript": true,
             "optional": true,
             "os": [
@@ -43467,7 +43474,7 @@
             "version": "1.2.3",
             "resolved": "https://registry.npmjs.org/word-wrap/-/word-wrap-1.2.3.tgz",
             "integrity": "sha512-Hz/mrNwitNRh/HUAtM/VT/5VH+ygD6DV7mYKZAtHOrbs8U7lvPS6xf7EJKMF0uW1KJCl0H701g3ZGus+muE5vQ==",
-            "dev": true,
+            "devOptional": true,
             "engines": {
                 "node": ">=0.10.0"
             }
@@ -45455,7 +45462,7 @@
             "version": "0.4.3",
             "resolved": "https://registry.npmjs.org/@eslint/eslintrc/-/eslintrc-0.4.3.tgz",
             "integrity": "sha512-J6KFFz5QCYUJq3pf0mjEcCJVERbzv71PUIDczuh9JkwGEzced6CO5ADLHB1rbf/+oPBtoPfMYNOpGDzCANlbXw==",
-            "dev": true,
+            "devOptional": true,
             "requires": {
                 "ajv": "^6.12.4",
                 "debug": "^4.1.1",
@@ -45472,12 +45479,18 @@
                     "version": "13.17.0",
                     "resolved": "https://registry.npmjs.org/globals/-/globals-13.17.0.tgz",
                     "integrity": "sha512-1C+6nQRb1GwGMKm2dH/E7enFAMxGTmGI7/dEdhy/DNelv85w9B72t3uc5frtMNXIbzrarJJ/lTCjcaZwbLJmyw==",
-                    "dev": true,
+                    "devOptional": true,
                     "requires": {
                         "type-fest": "^0.20.2"
                     }
                 }
             }
+        },
+        "@faker-js/faker": {
+            "version": "7.6.0",
+            "resolved": "https://registry.npmjs.org/@faker-js/faker/-/faker-7.6.0.tgz",
+            "integrity": "sha512-XK6BTq1NDMo9Xqw/YkYyGjSsg44fbNwYRx7QK2CuoQgyy+f1rrTDHoExVM5PsyXCtfl2vs2vVJ0MN0yN6LppRw==",
+            "dev": true
         },
         "@gar/promisify": {
             "version": "1.1.3",
@@ -45528,7 +45541,7 @@
             "version": "0.5.0",
             "resolved": "https://registry.npmjs.org/@humanwhocodes/config-array/-/config-array-0.5.0.tgz",
             "integrity": "sha512-FagtKFz74XrTl7y6HCzQpwDfXP0yhxe9lHLD1UZxjvZIcbyRz8zTFF/yYNfSfzU414eDwZ1SrO0Qvtyf+wFMQg==",
-            "dev": true,
+            "devOptional": true,
             "requires": {
                 "@humanwhocodes/object-schema": "^1.2.0",
                 "debug": "^4.1.1",
@@ -45539,7 +45552,7 @@
             "version": "1.2.1",
             "resolved": "https://registry.npmjs.org/@humanwhocodes/object-schema/-/object-schema-1.2.1.tgz",
             "integrity": "sha512-ZnQMnLV4e7hDlUvw8H+U8ASL02SS2Gn6+9Ac3wGGLIe7+je2AeAOxPY+izIPJDfFDb7eDjev0Us8MO1iFRN8hA==",
-            "dev": true
+            "devOptional": true
         },
         "@hypnosphi/create-react-context": {
             "version": "0.3.1",
@@ -46871,7 +46884,8 @@
         "@mdx-js/react": {
             "version": "1.6.22",
             "resolved": "https://registry.npmjs.org/@mdx-js/react/-/react-1.6.22.tgz",
-            "integrity": "sha512-TDoPum4SHdfPiGSAaRBw7ECyI8VaHpK8GJugbJIJuqyh6kzw9ZLJZW3HGL3NNrJGxcAixUvqROm+YuQOo5eXtg=="
+            "integrity": "sha512-TDoPum4SHdfPiGSAaRBw7ECyI8VaHpK8GJugbJIJuqyh6kzw9ZLJZW3HGL3NNrJGxcAixUvqROm+YuQOo5eXtg==",
+            "requires": {}
         },
         "@mdx-js/util": {
             "version": "1.6.22",
@@ -47018,7 +47032,8 @@
         "@restart/context": {
             "version": "2.1.4",
             "resolved": "https://registry.npmjs.org/@restart/context/-/context-2.1.4.tgz",
-            "integrity": "sha512-INJYZQJP7g+IoDUh/475NlGiTeMfwTXUEr3tmRneckHIxNolGOW9CTq83S8cxq0CgJwwcMzMJFchxvlwe7Rk8Q=="
+            "integrity": "sha512-INJYZQJP7g+IoDUh/475NlGiTeMfwTXUEr3tmRneckHIxNolGOW9CTq83S8cxq0CgJwwcMzMJFchxvlwe7Rk8Q==",
+            "requires": {}
         },
         "@restart/hooks": {
             "version": "0.4.7",
@@ -49047,7 +49062,8 @@
             "version": "14.4.3",
             "resolved": "https://registry.npmjs.org/@testing-library/user-event/-/user-event-14.4.3.tgz",
             "integrity": "sha512-kCUc5MEwaEMakkO5x7aoD+DLi02ehmEM2QCGWvNqAS1dV/fAvORWEjnjsEIvml59M7Y5kCkWN6fCCyPOe8OL6Q==",
-            "dev": true
+            "dev": true,
+            "requires": {}
         },
         "@tootallnate/once": {
             "version": "1.1.2",
@@ -49861,7 +49877,7 @@
             "version": "7.4.1",
             "resolved": "https://registry.npmjs.org/acorn/-/acorn-7.4.1.tgz",
             "integrity": "sha512-nQyp0o1/mNdbTO1PO6kHkwSrmgZ0MT/jCCpNiwbUjGoRN4dlBhqJtoQuCnEOKzgTVwg0ZWiCoQy6SxMebQVh8A==",
-            "dev": true
+            "devOptional": true
         },
         "acorn-globals": {
             "version": "4.3.4",
@@ -49891,7 +49907,8 @@
             "version": "5.3.2",
             "resolved": "https://registry.npmjs.org/acorn-jsx/-/acorn-jsx-5.3.2.tgz",
             "integrity": "sha512-rq9s+JNhf0IChjtDXxllJ7g41oZk5SlXtp0LHwyA5cejwn7vKmKp4pPri6YEePv2PU65sAsegbXtIinmDFDXgQ==",
-            "dev": true
+            "devOptional": true,
+            "requires": {}
         },
         "acorn-walk": {
             "version": "7.2.0",
@@ -49989,12 +50006,14 @@
         "ajv-errors": {
             "version": "1.0.1",
             "resolved": "https://registry.npmjs.org/ajv-errors/-/ajv-errors-1.0.1.tgz",
-            "integrity": "sha512-DCRfO/4nQ+89p/RK43i8Ezd41EqdGIU4ld7nGF8OQ14oc/we5rEntLCUa7+jrn3nn83BosfwZA0wb4pon2o8iQ=="
+            "integrity": "sha512-DCRfO/4nQ+89p/RK43i8Ezd41EqdGIU4ld7nGF8OQ14oc/we5rEntLCUa7+jrn3nn83BosfwZA0wb4pon2o8iQ==",
+            "requires": {}
         },
         "ajv-keywords": {
             "version": "3.5.2",
             "resolved": "https://registry.npmjs.org/ajv-keywords/-/ajv-keywords-3.5.2.tgz",
-            "integrity": "sha512-5p6WTN0DdTGVQk6VjcEju19IgaHudalcfabD7yhDGeA6bcQnmL+CpveLJq/3hvfwd1aof6L386Ougkx6RfyMIQ=="
+            "integrity": "sha512-5p6WTN0DdTGVQk6VjcEju19IgaHudalcfabD7yhDGeA6bcQnmL+CpveLJq/3hvfwd1aof6L386Ougkx6RfyMIQ==",
+            "requires": {}
         },
         "alphanum-sort": {
             "version": "1.0.2",
@@ -50015,7 +50034,7 @@
             "version": "4.1.3",
             "resolved": "https://registry.npmjs.org/ansi-colors/-/ansi-colors-4.1.3.tgz",
             "integrity": "sha512-/6w/C21Pm1A7aZitlI5Ni/2J6FFQN8i1Cvz3kHABAAbw93v/NlvKdVOqz7CCWz/3iv/JplRSEEZ83XION15ovw==",
-            "dev": true
+            "devOptional": true
         },
         "ansi-escapes": {
             "version": "4.3.2",
@@ -50879,7 +50898,8 @@
             "version": "0.3.8",
             "resolved": "https://registry.npmjs.org/babel-plugin-named-asset-import/-/babel-plugin-named-asset-import-0.3.8.tgz",
             "integrity": "sha512-WXiAc++qo7XcJ1ZnTYGtLxmBCVbddAml3CEXgWaBzNzLNoxtQ8AiGEFDMOhot9XjTCQbvP5E77Fj9Gk924f00Q==",
-            "dev": true
+            "dev": true,
+            "requires": {}
         },
         "babel-plugin-polyfill-corejs2": {
             "version": "0.3.2",
@@ -51360,7 +51380,6 @@
             "version": "1.5.0",
             "resolved": "https://registry.npmjs.org/bindings/-/bindings-1.5.0.tgz",
             "integrity": "sha512-p2q/t/mhvuOj/UeLlV6566GD/guowlr0hHxClI0W9m7MWYkL1F0hLo+0Aexs9HSPCtR1SXQ0TD3MMKrXZajbiQ==",
-            "dev": true,
             "optional": true,
             "requires": {
                 "file-uri-to-path": "1.0.0"
@@ -51464,7 +51483,8 @@
         "bootstrap": {
             "version": "4.6.2",
             "resolved": "https://registry.npmjs.org/bootstrap/-/bootstrap-4.6.2.tgz",
-            "integrity": "sha512-51Bbp/Uxr9aTuy6ca/8FbFloBUJZLHwnhTcnjIeRn2suQWsWzcuJhGjKDB5eppVte/8oCdOL3VuwxvZDUggwGQ=="
+            "integrity": "sha512-51Bbp/Uxr9aTuy6ca/8FbFloBUJZLHwnhTcnjIeRn2suQWsWzcuJhGjKDB5eppVte/8oCdOL3VuwxvZDUggwGQ==",
+            "requires": {}
         },
         "boxen": {
             "version": "5.1.2",
@@ -53550,7 +53570,7 @@
             "version": "0.1.4",
             "resolved": "https://registry.npmjs.org/deep-is/-/deep-is-0.1.4.tgz",
             "integrity": "sha512-oIPzksmTg4/MriiaYGO+okXDT7ztn/w3Eptv/+gSIdMdKsJo0u4CfYNFJPy+4SKMuCqGw2wxnA+URMg3t8a/bQ==",
-            "dev": true
+            "devOptional": true
         },
         "deepdash-es": {
             "version": "5.3.9",
@@ -54107,7 +54127,8 @@
         "draftjs-utils": {
             "version": "0.10.2",
             "resolved": "https://registry.npmjs.org/draftjs-utils/-/draftjs-utils-0.10.2.tgz",
-            "integrity": "sha512-EstHqr3R3JVcilJrBaO/A+01GvwwKmC7e4TCjC7S94ZeMh4IVmf60OuQXtHHpwItK8C2JCi3iljgN5KHkJboUg=="
+            "integrity": "sha512-EstHqr3R3JVcilJrBaO/A+01GvwwKmC7e4TCjC7S94ZeMh4IVmf60OuQXtHHpwItK8C2JCi3iljgN5KHkJboUg==",
+            "requires": {}
         },
         "duplexer": {
             "version": "0.1.2",
@@ -54326,7 +54347,7 @@
             "version": "2.3.6",
             "resolved": "https://registry.npmjs.org/enquirer/-/enquirer-2.3.6.tgz",
             "integrity": "sha512-yjNnPr315/FjS4zIsUxYguYUPP2e1NK4d7E7ZOLiyYCcbFBiTMyID+2wvm2w6+pZ/odMA7cRkjhsPbltwBOrLg==",
-            "dev": true,
+            "devOptional": true,
             "requires": {
                 "ansi-colors": "^4.1.1"
             }
@@ -54618,7 +54639,7 @@
             "version": "7.32.0",
             "resolved": "https://registry.npmjs.org/eslint/-/eslint-7.32.0.tgz",
             "integrity": "sha512-VHZ8gX+EDfz+97jGcgyGCyRia/dPOd6Xh9yPv8Bl1+SoaIwD+a/vlrOmGRUyOYu7MwUhc7CxqeaDZU13S4+EpA==",
-            "dev": true,
+            "devOptional": true,
             "requires": {
                 "@babel/code-frame": "7.12.11",
                 "@eslint/eslintrc": "^0.4.3",
@@ -54666,7 +54687,7 @@
                     "version": "7.12.11",
                     "resolved": "https://registry.npmjs.org/@babel/code-frame/-/code-frame-7.12.11.tgz",
                     "integrity": "sha512-Zt1yodBx1UcyiePMSkWnU4hPqhwq7hGi2nFL1LeA3EUl+q2LQx16MISgJ0+z7dnmgvP9QtIleuETGOiOH1RcIw==",
-                    "dev": true,
+                    "devOptional": true,
                     "requires": {
                         "@babel/highlight": "^7.10.4"
                     }
@@ -54675,7 +54696,7 @@
                     "version": "4.3.0",
                     "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-4.3.0.tgz",
                     "integrity": "sha512-zbB9rCJAT1rbjiVDb2hqKFHNYLxgtk8NURxZ3IZwD3F6NtxbXZQCnnSi1Lkx+IDohdPlFp222wVALIheZJQSEg==",
-                    "dev": true,
+                    "devOptional": true,
                     "requires": {
                         "color-convert": "^2.0.1"
                     }
@@ -54684,7 +54705,7 @@
                     "version": "4.1.2",
                     "resolved": "https://registry.npmjs.org/chalk/-/chalk-4.1.2.tgz",
                     "integrity": "sha512-oKnbhFyRIXpUuez8iBMmyEa4nbj4IOQyuhc/wy9kY7/WVPcwIO9VA668Pu8RkO7+0G76SLROeyw9CpQ061i4mA==",
-                    "dev": true,
+                    "devOptional": true,
                     "requires": {
                         "ansi-styles": "^4.1.0",
                         "supports-color": "^7.1.0"
@@ -54694,7 +54715,7 @@
                     "version": "2.0.1",
                     "resolved": "https://registry.npmjs.org/color-convert/-/color-convert-2.0.1.tgz",
                     "integrity": "sha512-RRECPsj7iu/xb5oKYcsFHSppFNnsj/52OVTRKb4zP5onXwVF3zVmmToNcOfGC+CRDpfK/U584fMg38ZHCaElKQ==",
-                    "dev": true,
+                    "devOptional": true,
                     "requires": {
                         "color-name": "~1.1.4"
                     }
@@ -54703,13 +54724,13 @@
                     "version": "1.1.4",
                     "resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.4.tgz",
                     "integrity": "sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA==",
-                    "dev": true
+                    "devOptional": true
                 },
                 "globals": {
                     "version": "13.17.0",
                     "resolved": "https://registry.npmjs.org/globals/-/globals-13.17.0.tgz",
                     "integrity": "sha512-1C+6nQRb1GwGMKm2dH/E7enFAMxGTmGI7/dEdhy/DNelv85w9B72t3uc5frtMNXIbzrarJJ/lTCjcaZwbLJmyw==",
-                    "dev": true,
+                    "devOptional": true,
                     "requires": {
                         "type-fest": "^0.20.2"
                     }
@@ -54718,13 +54739,13 @@
                     "version": "4.0.0",
                     "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-4.0.0.tgz",
                     "integrity": "sha512-EykJT/Q1KjTWctppgIAgfSO0tKVuZUjhgMr17kqTumMl6Afv3EISleU7qZUzoXDFTAHTDC4NOoG/ZxU3EvlMPQ==",
-                    "dev": true
+                    "devOptional": true
                 },
                 "optionator": {
                     "version": "0.9.1",
                     "resolved": "https://registry.npmjs.org/optionator/-/optionator-0.9.1.tgz",
                     "integrity": "sha512-74RlY5FCnhq4jRxVUPKDaRwrVNXMqsGsiW6AJw4XK8hmtm10wC0ypZBLw5IIp85NZMr91+qd1RvvENwg7jjRFw==",
-                    "dev": true,
+                    "devOptional": true,
                     "requires": {
                         "deep-is": "^0.1.3",
                         "fast-levenshtein": "^2.0.6",
@@ -54738,7 +54759,7 @@
                     "version": "7.3.7",
                     "resolved": "https://registry.npmjs.org/semver/-/semver-7.3.7.tgz",
                     "integrity": "sha512-QlYTucUYOews+WeEujDoEGziz4K6c47V/Bd+LjSSYcA94p+DmINdf7ncaUinThfvZyu13lN9OY1XDxt8C0Tw0g==",
-                    "dev": true,
+                    "devOptional": true,
                     "requires": {
                         "lru-cache": "^6.0.0"
                     }
@@ -54747,7 +54768,7 @@
                     "version": "7.2.0",
                     "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-7.2.0.tgz",
                     "integrity": "sha512-qpCAvRl9stuOHveKsn7HncJRvv501qIacKzQlO/+Lwxc9+0q2wLyv4Dfvt80/DPn2pqOBsJdDiogXGR9+OvwRw==",
-                    "dev": true,
+                    "devOptional": true,
                     "requires": {
                         "has-flag": "^4.0.0"
                     }
@@ -54780,7 +54801,8 @@
             "version": "8.5.0",
             "resolved": "https://registry.npmjs.org/eslint-config-prettier/-/eslint-config-prettier-8.5.0.tgz",
             "integrity": "sha512-obmWKLUNCnhtQRKc+tmnYuQl0pFU1ibYJQ5BGhTVB08bHe9wC8qUeG7c08dj9XX+AuPj1YSGSQIHl1pnDHZR0Q==",
-            "dev": true
+            "dev": true,
+            "requires": {}
         },
         "eslint-config-react-app": {
             "version": "5.2.1",
@@ -55124,13 +55146,14 @@
             "version": "1.7.0",
             "resolved": "https://registry.npmjs.org/eslint-plugin-react-hooks/-/eslint-plugin-react-hooks-1.7.0.tgz",
             "integrity": "sha512-iXTCFcOmlWvw4+TOE8CLWj6yX1GwzT0Y6cUfHHZqWnSk144VmVIRcVGtUAzrLES7C798lmvnt02C7rxaOX1HNA==",
-            "dev": true
+            "dev": true,
+            "requires": {}
         },
         "eslint-scope": {
             "version": "5.1.1",
             "resolved": "https://registry.npmjs.org/eslint-scope/-/eslint-scope-5.1.1.tgz",
             "integrity": "sha512-2NxwbF/hZ0KpepYN0cNbo+FN6XoK7GaHlQhgx/hIZl6Va0bF45RQOOwhLIy8lQDbuCiadSLCBnH2CFYquit5bw==",
-            "dev": true,
+            "devOptional": true,
             "requires": {
                 "esrecurse": "^4.3.0",
                 "estraverse": "^4.1.1"
@@ -55140,7 +55163,7 @@
                     "version": "4.3.0",
                     "resolved": "https://registry.npmjs.org/estraverse/-/estraverse-4.3.0.tgz",
                     "integrity": "sha512-39nnKffWz8xN1BU/2c79n9nB9HDzo0niYUqx6xyqUnyoAnQyyWpOTdZEeiCch8BBu515t4wp9ZmgVfVhn9EBpw==",
-                    "dev": true
+                    "devOptional": true
                 }
             }
         },
@@ -55148,7 +55171,7 @@
             "version": "2.1.0",
             "resolved": "https://registry.npmjs.org/eslint-utils/-/eslint-utils-2.1.0.tgz",
             "integrity": "sha512-w94dQYoauyvlDc43XnGB8lU3Zt713vNChgt4EWwhXAP2XkBvndfxF0AgIqKOOasjPIPzj9JqgwkwbCYD0/V3Zg==",
-            "dev": true,
+            "devOptional": true,
             "requires": {
                 "eslint-visitor-keys": "^1.1.0"
             },
@@ -55157,7 +55180,7 @@
                     "version": "1.3.0",
                     "resolved": "https://registry.npmjs.org/eslint-visitor-keys/-/eslint-visitor-keys-1.3.0.tgz",
                     "integrity": "sha512-6J72N8UNa462wa/KFODt/PJ3IU60SDpC3QXC1Hjc1BXXpfL2C9R5+AU7jhe0F6GREqVMh4Juu+NY7xn+6dipUQ==",
-                    "dev": true
+                    "devOptional": true
                 }
             }
         },
@@ -55165,13 +55188,13 @@
             "version": "2.1.0",
             "resolved": "https://registry.npmjs.org/eslint-visitor-keys/-/eslint-visitor-keys-2.1.0.tgz",
             "integrity": "sha512-0rSmRBzXgDzIsD6mGdJgevzgezI534Cer5L/vyMX0kHzT/jiB43jRhd9YUlMGYLQy2zprNmoT8qasCGtY+QaKw==",
-            "dev": true
+            "devOptional": true
         },
         "espree": {
             "version": "7.3.1",
             "resolved": "https://registry.npmjs.org/espree/-/espree-7.3.1.tgz",
             "integrity": "sha512-v3JCNCE64umkFpmkFGqzVKsOT0tN1Zr+ueqLZfpV1Ob8e+CEgPWa+OxCoGH3tnhimMKIaBm4m/vaRpJ/krRz2g==",
-            "dev": true,
+            "devOptional": true,
             "requires": {
                 "acorn": "^7.4.0",
                 "acorn-jsx": "^5.3.1",
@@ -55182,7 +55205,7 @@
                     "version": "1.3.0",
                     "resolved": "https://registry.npmjs.org/eslint-visitor-keys/-/eslint-visitor-keys-1.3.0.tgz",
                     "integrity": "sha512-6J72N8UNa462wa/KFODt/PJ3IU60SDpC3QXC1Hjc1BXXpfL2C9R5+AU7jhe0F6GREqVMh4Juu+NY7xn+6dipUQ==",
-                    "dev": true
+                    "devOptional": true
                 }
             }
         },
@@ -55195,7 +55218,7 @@
             "version": "1.4.0",
             "resolved": "https://registry.npmjs.org/esquery/-/esquery-1.4.0.tgz",
             "integrity": "sha512-cCDispWt5vHHtwMY2YrAQ4ibFkAL8RbH5YGBnZBc90MolvvfkkQcJro/aZiAQUlQ3qgrYS6D6v8Gc5G5CQsc9w==",
-            "dev": true,
+            "devOptional": true,
             "requires": {
                 "estraverse": "^5.1.0"
             }
@@ -55727,7 +55750,7 @@
             "version": "2.0.6",
             "resolved": "https://registry.npmjs.org/fast-levenshtein/-/fast-levenshtein-2.0.6.tgz",
             "integrity": "sha512-DCXu6Ifhqcks7TZKY3Hxp3y6qphY5SJZmrWMDrKcERSOXWQdMhU9Ig/PYrzyw/ul9jOIyh0N4M0tbC5hodg8dw==",
-            "dev": true
+            "devOptional": true
         },
         "fast-shallow-equal": {
             "version": "1.0.0",
@@ -55823,7 +55846,7 @@
             "version": "6.0.1",
             "resolved": "https://registry.npmjs.org/file-entry-cache/-/file-entry-cache-6.0.1.tgz",
             "integrity": "sha512-7Gps/XWymbLk2QLYK4NzpMOrYjMhdIxXuIvy2QBsLE6ljuodKvdkWs/cpyJJ3CVIVpH0Oi1Hvg1ovbMzLdFBBg==",
-            "dev": true,
+            "devOptional": true,
             "requires": {
                 "flat-cache": "^3.0.4"
             }
@@ -55891,7 +55914,6 @@
             "version": "1.0.0",
             "resolved": "https://registry.npmjs.org/file-uri-to-path/-/file-uri-to-path-1.0.0.tgz",
             "integrity": "sha512-0Zt+s3L7Vf1biwWZ29aARiVYLx7iMGnEUl9x33fbB/j3jR81u/O2LbqK+Bm1CDSNDKVtJ/YjwY7TUd5SkeLQLw==",
-            "dev": true,
             "optional": true
         },
         "filesize": {
@@ -56018,7 +56040,7 @@
             "version": "3.0.4",
             "resolved": "https://registry.npmjs.org/flat-cache/-/flat-cache-3.0.4.tgz",
             "integrity": "sha512-dm9s5Pw7Jc0GvMYbshN6zchCA9RgQlzzEZX3vylR9IqFfS8XciblUXOKfW6SiuJ0e13eDYZoZV5wdrev7P3Nwg==",
-            "dev": true,
+            "devOptional": true,
             "requires": {
                 "flatted": "^3.1.0",
                 "rimraf": "^3.0.2"
@@ -56028,7 +56050,7 @@
             "version": "3.2.7",
             "resolved": "https://registry.npmjs.org/flatted/-/flatted-3.2.7.tgz",
             "integrity": "sha512-5nqDSxl8nn5BSNxyR3n4I6eDmbolI6WT+QqR547RwxQapgjQBmtktdP+HTBb/a/zLsbzERTONyUB5pefh5TtjQ==",
-            "dev": true
+            "devOptional": true
         },
         "flatten": {
             "version": "1.0.3",
@@ -56424,7 +56446,7 @@
             "version": "1.0.1",
             "resolved": "https://registry.npmjs.org/functional-red-black-tree/-/functional-red-black-tree-1.0.1.tgz",
             "integrity": "sha512-dsKNQNdj6xA3T+QlADDA7mOSlX0qiMINjn0cgr+eGHGsbSHzTabcIogz2+p/iqP1Xs6EP/sS2SbqH+brGTbq0g==",
-            "dev": true
+            "devOptional": true
         },
         "functions-have-names": {
             "version": "1.2.3",
@@ -57050,7 +57072,8 @@
         "hdruk-react-core": {
             "version": "0.2.47",
             "resolved": "https://registry.npmjs.org/hdruk-react-core/-/hdruk-react-core-0.2.47.tgz",
-            "integrity": "sha512-w6jrTsn8lzcqOAVcOUfCPB/Ye6u4Sds+TJ6fZm4NFhVynz2+Q+KvkgQLQau96CxNBTGSouHpa8B57fUEqeOh7Q=="
+            "integrity": "sha512-w6jrTsn8lzcqOAVcOUfCPB/Ye6u4Sds+TJ6fZm4NFhVynz2+Q+KvkgQLQau96CxNBTGSouHpa8B57fUEqeOh7Q==",
+            "requires": {}
         },
         "he": {
             "version": "1.2.0",
@@ -57251,7 +57274,8 @@
         "html-to-draftjs": {
             "version": "1.5.0",
             "resolved": "https://registry.npmjs.org/html-to-draftjs/-/html-to-draftjs-1.5.0.tgz",
-            "integrity": "sha512-kggLXBNciKDwKf+KYsuE+V5gw4dZ7nHyGMX9m0wy7urzWjKGWyNFetmArRLvRV0VrxKN70WylFsJvMTJx02OBQ=="
+            "integrity": "sha512-kggLXBNciKDwKf+KYsuE+V5gw4dZ7nHyGMX9m0wy7urzWjKGWyNFetmArRLvRV0VrxKN70WylFsJvMTJx02OBQ==",
+            "requires": {}
         },
         "html-to-react": {
             "version": "1.5.0",
@@ -57698,7 +57722,7 @@
             "version": "4.0.6",
             "resolved": "https://registry.npmjs.org/ignore/-/ignore-4.0.6.tgz",
             "integrity": "sha512-cyFDKrqc/YdcWFniJhzI42+AzS+gNwmUzOSFcRCQYwySuBBBy/KjuxWLZ/FHEH6Moq1NizMOBWyTcv8O4OZIMg==",
-            "dev": true
+            "devOptional": true
         },
         "ignore-by-default": {
             "version": "1.0.1",
@@ -59790,7 +59814,8 @@
                     "version": "7.5.9",
                     "resolved": "https://registry.npmjs.org/ws/-/ws-7.5.9.tgz",
                     "integrity": "sha512-F+P9Jil7UiSKSkppIiD94dN07AwvFixvLIj1Og1Rl9GGMuNipJnV9JzjD6XuqmAeiswGvUmNLjr5cFuXwNS77Q==",
-                    "dev": true
+                    "dev": true,
+                    "requires": {}
                 }
             }
         },
@@ -61556,7 +61581,8 @@
             "version": "1.2.2",
             "resolved": "https://registry.npmjs.org/jest-pnp-resolver/-/jest-pnp-resolver-1.2.2.tgz",
             "integrity": "sha512-olV41bKSMm8BdnuMsewT4jqlZ8+3TCARAXjZGT9jcoSnrfUnRCqnMoF9XEeoWjbzObpqF9dRhHQj0Xb9QdF6/w==",
-            "dev": true
+            "dev": true,
+            "requires": {}
         },
         "jest-regex-util": {
             "version": "26.0.0",
@@ -62999,7 +63025,8 @@
                     "version": "7.5.9",
                     "resolved": "https://registry.npmjs.org/ws/-/ws-7.5.9.tgz",
                     "integrity": "sha512-F+P9Jil7UiSKSkppIiD94dN07AwvFixvLIj1Og1Rl9GGMuNipJnV9JzjD6XuqmAeiswGvUmNLjr5cFuXwNS77Q==",
-                    "dev": true
+                    "dev": true,
+                    "requires": {}
                 }
             }
         },
@@ -63042,7 +63069,7 @@
             "version": "1.0.1",
             "resolved": "https://registry.npmjs.org/json-stable-stringify-without-jsonify/-/json-stable-stringify-without-jsonify-1.0.1.tgz",
             "integrity": "sha512-Bdboy+l7tA3OGW6FjyFHWkP5LuByj1Tk33Ljyq0axyzdk9//JSi2u3fP1QSmd1KNwq6VOKYGlAu87CisVir6Pw==",
-            "dev": true
+            "devOptional": true
         },
         "json-stringify-safe": {
             "version": "5.0.1",
@@ -63258,7 +63285,7 @@
             "version": "0.4.1",
             "resolved": "https://registry.npmjs.org/levn/-/levn-0.4.1.tgz",
             "integrity": "sha512-+bT2uH4E5LGE7h/n3evcS/sQlJXCpIp6ym8OWJ5eV6+67Dsql/LaaT7qJBAt2rzfoa/5QBGBhxDix1dMt2kQKQ==",
-            "dev": true,
+            "devOptional": true,
             "requires": {
                 "prelude-ls": "^1.2.1",
                 "type-check": "~0.4.0"
@@ -63453,7 +63480,7 @@
             "version": "4.6.2",
             "resolved": "https://registry.npmjs.org/lodash.merge/-/lodash.merge-4.6.2.tgz",
             "integrity": "sha512-0KpjqXRVvrYyCsX1swR/XTK0va6VQkQM6MNo7PqW77ByjAhoARA8EfrP1N4+KlKj8YS0ZUCtRT/YUuhyYDujIQ==",
-            "dev": true
+            "devOptional": true
         },
         "lodash.sortby": {
             "version": "4.7.0",
@@ -63484,7 +63511,7 @@
             "version": "4.4.2",
             "resolved": "https://registry.npmjs.org/lodash.truncate/-/lodash.truncate-4.4.2.tgz",
             "integrity": "sha512-jttmRe7bRse52OsWIMDLaXxWqRAmtIUccAQ3garviCqJjafXOfNMO0yMfNpdD6zbGaTU0P5Nz7e7gAT6cKmJRw==",
-            "dev": true
+            "devOptional": true
         },
         "lodash.uniq": {
             "version": "4.5.0",
@@ -64422,7 +64449,8 @@
             "version": "0.4.0",
             "resolved": "https://registry.npmjs.org/moxios/-/moxios-0.4.0.tgz",
             "integrity": "sha512-r+7DOsTcoTAwY6TGIDtjeTEBXMW8aGgk74MfASOC1tgYXD8Kq+cnqQHUdMnvfjf/CK7Pg/Wo52ohqy5zlyv9XQ==",
-            "dev": true
+            "dev": true,
+            "requires": {}
         },
         "ms": {
             "version": "2.1.2",
@@ -64565,7 +64593,6 @@
             "version": "2.16.0",
             "resolved": "https://registry.npmjs.org/nan/-/nan-2.16.0.tgz",
             "integrity": "sha512-UdAqHyFngu7TfQKsCBgAA6pWDkT8MAO7d0jyOecVhN5354xbLqdn8mV9Tat9gepAupm0bt2DbeaSC8vS52MuFA==",
-            "dev": true,
             "optional": true
         },
         "nano-css": {
@@ -64648,7 +64675,7 @@
             "version": "1.4.0",
             "resolved": "https://registry.npmjs.org/natural-compare/-/natural-compare-1.4.0.tgz",
             "integrity": "sha512-OWND8ei3VtNC9h7V60qff3SVobHr996CTwgxubgyQYEpg290h9J0buyECNNJexkFm5sOajh5G116RYA1c8ZMSw==",
-            "dev": true
+            "devOptional": true
         },
         "nearley": {
             "version": "2.20.1",
@@ -66990,7 +67017,7 @@
             "version": "1.2.1",
             "resolved": "https://registry.npmjs.org/prelude-ls/-/prelude-ls-1.2.1.tgz",
             "integrity": "sha512-vkcDPrRZo1QZLbn5RLGPpg/WmIQ65qoWWhcGKf/b5eplkkarX0m9z8ppCat4mlOqUsWpyNuYgO3VRyrYHSzX5g==",
-            "dev": true
+            "devOptional": true
         },
         "prepend-http": {
             "version": "1.0.4",
@@ -67078,7 +67105,7 @@
             "version": "2.0.3",
             "resolved": "https://registry.npmjs.org/progress/-/progress-2.0.3.tgz",
             "integrity": "sha512-7PiHtLll5LdnKIMw100I+8xJXR5gW2QwWYkT6iJva0bXitZKa/XMrSbdmg3r2Xnaidz9Qumd0VPaMrZlF9V9sA==",
-            "dev": true
+            "devOptional": true
         },
         "promise": {
             "version": "7.3.1",
@@ -67530,7 +67557,8 @@
         "react-context-toolbox": {
             "version": "2.0.2",
             "resolved": "https://registry.npmjs.org/react-context-toolbox/-/react-context-toolbox-2.0.2.tgz",
-            "integrity": "sha512-tY4j0imkYC3n5ZlYSgFkaw7fmlCp3IoQQ6DxpqeNHzcD0hf+6V+/HeJxviLUZ1Rv1Yn3N3xyO2EhkkZwHn0m1A=="
+            "integrity": "sha512-tY4j0imkYC3n5ZlYSgFkaw7fmlCp3IoQQ6DxpqeNHzcD0hf+6V+/HeJxviLUZ1Rv1Yn3N3xyO2EhkkZwHn0m1A==",
+            "requires": {}
         },
         "react-countup": {
             "version": "4.4.0",
@@ -68042,7 +68070,8 @@
             "version": "2.2.2",
             "resolved": "https://registry.npmjs.org/react-docgen-typescript/-/react-docgen-typescript-2.2.2.tgz",
             "integrity": "sha512-tvg2ZtOpOi6QDwsb3GZhOjDkkX0h8Z2gipvTg6OVMUyoYoURhEiRNePT8NZItTVCDh39JJHnLdfCOkzoLbFnTg==",
-            "dev": true
+            "dev": true,
+            "requires": {}
         },
         "react-docgen-typescript-plugin": {
             "version": "1.0.1",
@@ -68130,7 +68159,8 @@
                     "version": "1.22.0",
                     "resolved": "https://registry.npmjs.org/react-docgen-typescript/-/react-docgen-typescript-1.22.0.tgz",
                     "integrity": "sha512-MPLbF8vzRwAG3GcjdL+OHQlhgtWsLTXs+7uJiHfEeT3Ur7IsZaNYqRTLQ9sj2nB6M6jylcPCeCmH7qbszJmecg==",
-                    "dev": true
+                    "dev": true,
+                    "requires": {}
                 },
                 "tslib": {
                     "version": "2.4.0",
@@ -68221,12 +68251,14 @@
         "react-from-dom": {
             "version": "0.6.2",
             "resolved": "https://registry.npmjs.org/react-from-dom/-/react-from-dom-0.6.2.tgz",
-            "integrity": "sha512-qvWWTL/4xw4k/Dywd41RBpLQUSq97csuv15qrxN+izNeLYlD9wn5W8LspbfYe5CWbaSdkZ72BsaYBPQf2x4VbQ=="
+            "integrity": "sha512-qvWWTL/4xw4k/Dywd41RBpLQUSq97csuv15qrxN+izNeLYlD9wn5W8LspbfYe5CWbaSdkZ72BsaYBPQf2x4VbQ==",
+            "requires": {}
         },
         "react-ga": {
             "version": "2.7.0",
             "resolved": "https://registry.npmjs.org/react-ga/-/react-ga-2.7.0.tgz",
-            "integrity": "sha512-AjC7UOZMvygrWTc2hKxTDvlMXEtbmA0IgJjmkhgmQQ3RkXrWR11xEagLGFGaNyaPnmg24oaIiaNPnEoftUhfXA=="
+            "integrity": "sha512-AjC7UOZMvygrWTc2hKxTDvlMXEtbmA0IgJjmkhgmQQ3RkXrWR11xEagLGFGaNyaPnmg24oaIiaNPnEoftUhfXA==",
+            "requires": {}
         },
         "react-gtm-module": {
             "version": "2.0.11",
@@ -68425,7 +68457,8 @@
         "react-moment": {
             "version": "0.9.7",
             "resolved": "https://registry.npmjs.org/react-moment/-/react-moment-0.9.7.tgz",
-            "integrity": "sha512-ifzUrUGF6KRsUN2pRG5k56kO0mJBr8kRkWb0wNvtFIsBIxOuPxhUpL1YlXwpbQCbHq23hUu6A0VEk64HsFxk9g=="
+            "integrity": "sha512-ifzUrUGF6KRsUN2pRG5k56kO0mJBr8kRkWb0wNvtFIsBIxOuPxhUpL1YlXwpbQCbHq23hUu6A0VEk64HsFxk9g==",
+            "requires": {}
         },
         "react-notification-badge": {
             "version": "1.5.1",
@@ -68456,7 +68489,8 @@
         "react-onclickoutside": {
             "version": "6.12.2",
             "resolved": "https://registry.npmjs.org/react-onclickoutside/-/react-onclickoutside-6.12.2.tgz",
-            "integrity": "sha512-NMXGa223OnsrGVp5dJHkuKxQ4czdLmXSp5jSV9OqiCky9LOpPATn3vLldc+q5fK3gKbEHvr7J1u0yhBh/xYkpA=="
+            "integrity": "sha512-NMXGa223OnsrGVp5dJHkuKxQ4czdLmXSp5jSV9OqiCky9LOpPATn3vLldc+q5fK3gKbEHvr7J1u0yhBh/xYkpA==",
+            "requires": {}
         },
         "react-overlays": {
             "version": "5.2.0",
@@ -68606,7 +68640,8 @@
         "react-schemaorg": {
             "version": "1.3.3",
             "resolved": "https://registry.npmjs.org/react-schemaorg/-/react-schemaorg-1.3.3.tgz",
-            "integrity": "sha512-yPoJgw05+QsK+T3CvBY4gtBw5HpHYyNi5EqPUbYlOFcw/+rzKdOAWyxufmBZ6RCQ3dWK1drNXURhwApDi44pwA=="
+            "integrity": "sha512-yPoJgw05+QsK+T3CvBY4gtBw5HpHYyNi5EqPUbYlOFcw/+rzKdOAWyxufmBZ6RCQ3dWK1drNXURhwApDi44pwA==",
+            "requires": {}
         },
         "react-scripts": {
             "version": "3.4.4",
@@ -71579,7 +71614,8 @@
         "react-universal-interface": {
             "version": "0.6.2",
             "resolved": "https://registry.npmjs.org/react-universal-interface/-/react-universal-interface-0.6.2.tgz",
-            "integrity": "sha512-dg8yXdcQmvgR13RIlZbTRQOoUrDciFVoSBZILwjE2LFISxZZ8loVJKAkuzswl5js8BHda79bIb2b84ehU8IjXw=="
+            "integrity": "sha512-dg8yXdcQmvgR13RIlZbTRQOoUrDciFVoSBZILwjE2LFISxZZ8loVJKAkuzswl5js8BHda79bIb2b84ehU8IjXw==",
+            "requires": {}
         },
         "react-use": {
             "version": "17.4.0",
@@ -71617,7 +71653,8 @@
         "react-web-tabs": {
             "version": "1.0.1",
             "resolved": "https://registry.npmjs.org/react-web-tabs/-/react-web-tabs-1.0.1.tgz",
-            "integrity": "sha512-Cg5B2515iLTvown5Tby+f69hT3+3HXetvsGr/Akou1ltREX57E3b3xra4lBjuUay42epMZ/2rfq/e+tTwOgBTQ=="
+            "integrity": "sha512-Cg5B2515iLTvown5Tby+f69hT3+3HXetvsGr/Akou1ltREX57E3b3xra4lBjuUay42epMZ/2rfq/e+tTwOgBTQ==",
+            "requires": {}
         },
         "read-excel-file": {
             "version": "5.4.5",
@@ -71844,7 +71881,7 @@
             "version": "3.2.0",
             "resolved": "https://registry.npmjs.org/regexpp/-/regexpp-3.2.0.tgz",
             "integrity": "sha512-pq2bWo9mVD43nbts2wGv17XLiNLya+GklZ8kaDLV2Z08gDCsGpnKn9BFMepvWuHCbyVvY7J5o5+BVvoQbmlJLg==",
-            "dev": true
+            "devOptional": true
         },
         "regexpu-core": {
             "version": "5.1.0",
@@ -72872,7 +72909,7 @@
             "version": "2.0.2",
             "resolved": "https://registry.npmjs.org/require-from-string/-/require-from-string-2.0.2.tgz",
             "integrity": "sha512-Xf0nWe6RseziFMu+Ap9biiUbmplq6S9/p+7w7YXP/JBHhrUDDUhwa+vANyubuqfZWTveU//DYVGsDG7RKL/vEw==",
-            "dev": true
+            "devOptional": true
         },
         "require-main-filename": {
             "version": "2.0.0",
@@ -73835,7 +73872,7 @@
             "version": "4.0.0",
             "resolved": "https://registry.npmjs.org/slice-ansi/-/slice-ansi-4.0.0.tgz",
             "integrity": "sha512-qMCMfhY040cVHT43K9BFygqYbUPFZKHOg7K73mtTWJRb8pyP3fzf4Ixd5SzdEJQ6MRUg/WBnOLxghZtKKurENQ==",
-            "dev": true,
+            "devOptional": true,
             "requires": {
                 "ansi-styles": "^4.0.0",
                 "astral-regex": "^2.0.0",
@@ -73846,7 +73883,7 @@
                     "version": "4.3.0",
                     "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-4.3.0.tgz",
                     "integrity": "sha512-zbB9rCJAT1rbjiVDb2hqKFHNYLxgtk8NURxZ3IZwD3F6NtxbXZQCnnSi1Lkx+IDohdPlFp222wVALIheZJQSEg==",
-                    "dev": true,
+                    "devOptional": true,
                     "requires": {
                         "color-convert": "^2.0.1"
                     }
@@ -73855,13 +73892,13 @@
                     "version": "2.0.0",
                     "resolved": "https://registry.npmjs.org/astral-regex/-/astral-regex-2.0.0.tgz",
                     "integrity": "sha512-Z7tMw1ytTXt5jqMcOP+OQteU1VuNK9Y02uuJtKQ1Sv69jXQKKg5cibLwGJow8yzZP+eAc18EmLGPal0bp36rvQ==",
-                    "dev": true
+                    "devOptional": true
                 },
                 "color-convert": {
                     "version": "2.0.1",
                     "resolved": "https://registry.npmjs.org/color-convert/-/color-convert-2.0.1.tgz",
                     "integrity": "sha512-RRECPsj7iu/xb5oKYcsFHSppFNnsj/52OVTRKb4zP5onXwVF3zVmmToNcOfGC+CRDpfK/U584fMg38ZHCaElKQ==",
-                    "dev": true,
+                    "devOptional": true,
                     "requires": {
                         "color-name": "~1.1.4"
                     }
@@ -73870,7 +73907,7 @@
                     "version": "1.1.4",
                     "resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.4.tgz",
                     "integrity": "sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA==",
-                    "dev": true
+                    "devOptional": true
                 }
             }
         },
@@ -74725,7 +74762,7 @@
             "version": "3.1.1",
             "resolved": "https://registry.npmjs.org/strip-json-comments/-/strip-json-comments-3.1.1.tgz",
             "integrity": "sha512-6fPc+R4ihwqP6N/aIv2f1gMH8lOVtWQHoqC4yK6oSDVVocumAsfCqjkXnqiYMhmMwS/mEHLp7Vehlt3ql6lEig==",
-            "dev": true
+            "devOptional": true
         },
         "style-loader": {
             "version": "1.3.0",
@@ -74933,7 +74970,7 @@
             "version": "6.8.0",
             "resolved": "https://registry.npmjs.org/table/-/table-6.8.0.tgz",
             "integrity": "sha512-s/fitrbVeEyHKFa7mFdkuQMWlH1Wgw/yEXMt5xACT4ZpzWFluehAxRtUUQKPuWhaLAWhFcVx6w3oC8VKaUfPGA==",
-            "dev": true,
+            "devOptional": true,
             "requires": {
                 "ajv": "^8.0.1",
                 "lodash.truncate": "^4.4.2",
@@ -74946,7 +74983,7 @@
                     "version": "8.11.0",
                     "resolved": "https://registry.npmjs.org/ajv/-/ajv-8.11.0.tgz",
                     "integrity": "sha512-wGgprdCvMalC0BztXvitD2hC04YffAvtsUn93JbGXYLAtCUO4xd17mCCZQxUOItiBwZvJScWo8NIvQMQ71rdpg==",
-                    "dev": true,
+                    "devOptional": true,
                     "requires": {
                         "fast-deep-equal": "^3.1.1",
                         "json-schema-traverse": "^1.0.0",
@@ -74958,7 +74995,7 @@
                     "version": "1.0.0",
                     "resolved": "https://registry.npmjs.org/json-schema-traverse/-/json-schema-traverse-1.0.0.tgz",
                     "integrity": "sha512-NM8/P9n3XjXhIZn1lLhkFaACTOURQXjWhV4BA/RnOv8xvgqtqpAX9IO4mRQxSx1Rlo4tqzeqb0sOlruaOy3dug==",
-                    "dev": true
+                    "devOptional": true
                 }
             }
         },
@@ -75221,7 +75258,7 @@
             "version": "0.2.0",
             "resolved": "https://registry.npmjs.org/text-table/-/text-table-0.2.0.tgz",
             "integrity": "sha512-N+8UisAXDGk8PFXP4HAzVR9nbfmVJ3zYLAWiTIoqC5v5isinhr+r5uaO8+7r3BMfuNIufIsA7RdpVgacC2cSpw==",
-            "dev": true
+            "devOptional": true
         },
         "throat": {
             "version": "5.0.0",
@@ -75542,7 +75579,7 @@
             "version": "0.4.0",
             "resolved": "https://registry.npmjs.org/type-check/-/type-check-0.4.0.tgz",
             "integrity": "sha512-XleUoc9uwGXqjWwXaUTZAmzMcFZ5858QA2vvx1Ur5xIcixXIP+8LnFDgRplU30us6teqdlskFfu+ae4K79Ooew==",
-            "dev": true,
+            "devOptional": true,
             "requires": {
                 "prelude-ls": "^1.2.1"
             }
@@ -75557,7 +75594,7 @@
             "version": "0.20.2",
             "resolved": "https://registry.npmjs.org/type-fest/-/type-fest-0.20.2.tgz",
             "integrity": "sha512-Ne+eE4r0/iWnpAxD852z3A+N0Bt5RN//NjJwRd2VFHEmrywxf5vsZlh4R6lixl6B+wz/8d+maTSAkN1FIkI3LQ==",
-            "dev": true
+            "devOptional": true
         },
         "type-is": {
             "version": "1.6.18",
@@ -76043,12 +76080,14 @@
         "use-composed-ref": {
             "version": "1.3.0",
             "resolved": "https://registry.npmjs.org/use-composed-ref/-/use-composed-ref-1.3.0.tgz",
-            "integrity": "sha512-GLMG0Jc/jiKov/3Ulid1wbv3r54K9HlMW29IWcDFPEqFkSO2nS0MuefWgMJpeHQ9YJeXDL3ZUF+P3jdXlZX/cQ=="
+            "integrity": "sha512-GLMG0Jc/jiKov/3Ulid1wbv3r54K9HlMW29IWcDFPEqFkSO2nS0MuefWgMJpeHQ9YJeXDL3ZUF+P3jdXlZX/cQ==",
+            "requires": {}
         },
         "use-isomorphic-layout-effect": {
             "version": "1.1.2",
             "resolved": "https://registry.npmjs.org/use-isomorphic-layout-effect/-/use-isomorphic-layout-effect-1.1.2.tgz",
-            "integrity": "sha512-49L8yCO3iGT/ZF9QttjwLF/ZD9Iwto5LnH5LmEdk/6cFmXddqi2ulF0edxTwjj+7mqvpVVGQWvbXZdn32wRSHA=="
+            "integrity": "sha512-49L8yCO3iGT/ZF9QttjwLF/ZD9Iwto5LnH5LmEdk/6cFmXddqi2ulF0edxTwjj+7mqvpVVGQWvbXZdn32wRSHA==",
+            "requires": {}
         },
         "use-latest": {
             "version": "1.2.1",
@@ -76114,7 +76153,7 @@
             "version": "2.3.0",
             "resolved": "https://registry.npmjs.org/v8-compile-cache/-/v8-compile-cache-2.3.0.tgz",
             "integrity": "sha512-l8lCEmLcLYZh4nbunNZvQCJc5pv7+RCwa8q/LdUx8u7lsWvPDKmpodJAJNwkAhJC//dFY48KuIEmjtd4RViDrA==",
-            "dev": true
+            "devOptional": true
         },
         "v8-to-istanbul": {
             "version": "4.1.4",
@@ -76380,7 +76419,6 @@
                     "version": "1.2.13",
                     "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-1.2.13.tgz",
                     "integrity": "sha512-oWb1Z6mkHIskLzEJ/XWX0srkpkTQ7vaopMQkyaEIoq0fmtFVxOthb8cCxeT+p3ynTdkk/RZwbgG4brR5BeWECw==",
-                    "dev": true,
                     "optional": true,
                     "requires": {
                         "bindings": "^1.5.0",
@@ -77427,7 +77465,8 @@
             "version": "1.2.1",
             "resolved": "https://registry.npmjs.org/webpack-filter-warnings-plugin/-/webpack-filter-warnings-plugin-1.2.1.tgz",
             "integrity": "sha512-Ez6ytc9IseDMLPo0qCuNNYzgtUl8NovOqjIq4uAU8LTD4uoa1w1KpZyyzFtLTEMZpkkOkLfL9eN+KGYdk1Qtwg==",
-            "dev": true
+            "dev": true,
+            "requires": {}
         },
         "webpack-hot-middleware": {
             "version": "2.25.2",
@@ -77654,7 +77693,7 @@
             "version": "1.2.3",
             "resolved": "https://registry.npmjs.org/word-wrap/-/word-wrap-1.2.3.tgz",
             "integrity": "sha512-Hz/mrNwitNRh/HUAtM/VT/5VH+ygD6DV7mYKZAtHOrbs8U7lvPS6xf7EJKMF0uW1KJCl0H701g3ZGus+muE5vQ==",
-            "dev": true
+            "devOptional": true
         },
         "wordwrap": {
             "version": "1.0.0",
@@ -77933,7 +77972,8 @@
             "version": "8.8.1",
             "resolved": "https://registry.npmjs.org/ws/-/ws-8.8.1.tgz",
             "integrity": "sha512-bGy2JzvzkPowEJV++hF07hAD6niYSr0JzBNo/J29WsB57A2r7Wlc1UFcTR9IzrPvuNVO4B8LGqF8qcpsVOhJCA==",
-            "dev": true
+            "dev": true,
+            "requires": {}
         },
         "x-default-browser": {
             "version": "0.4.0",

--- a/package.json
+++ b/package.json
@@ -139,6 +139,7 @@
     "devDependencies": {
         "@babel/preset-env": "^7.10.2",
         "@emotion/jest": "^11.10.0",
+        "@faker-js/faker": "^7.6.0",
         "@storybook/addon-actions": "^6.3.8",
         "@storybook/addon-essentials": "^6.3.8",
         "@storybook/addon-links": "^6.3.8",

--- a/src/configs/url.config.js
+++ b/src/configs/url.config.js
@@ -100,4 +100,6 @@ export const baseURL = _buildUrl('http');
 export const cmsURL = _buildUrl('cms');
 export const apiPath = `api/${process.env.REACT_APP_API_VERSION || 'v1'}`;
 export const apiURL = `${baseURL}/${apiPath}`;
+
+export const apiV1Url = `${baseURL}/api/v1`;
 export const apiV2URL = `${baseURL}/api/v2`;

--- a/src/modules/RelatedResourcesTab/RelatedResourcesTab.components.jsx
+++ b/src/modules/RelatedResourcesTab/RelatedResourcesTab.components.jsx
@@ -1,0 +1,48 @@
+import React from 'react';
+import { Col, Dropdown, Row } from 'react-bootstrap/';
+import PropTypes from 'prop-types';
+import SVGIcon from '../../images/SVGIcon';
+import { getFilterLabel } from './RelatedResourcesTab.utils';
+
+const FilterRow = ({ item, filterType, relatedObjects }) => {
+    return (
+        <Row
+            key={`ddl-item-${item}`}
+            className={
+                filterType === item
+                    ? 'sort-dropdown-item sort-dropdown-item-selected sortingDropdown'
+                    : 'sort-dropdown-item sortingDropdown'
+            }>
+            <Col xs={12} className='p-0'>
+                <Dropdown.Item eventKey={item} className='gray800-14'>
+                    {getFilterLabel(item, relatedObjects)}
+                </Dropdown.Item>
+            </Col>
+            <div className='p-0 sortingCheckmark'>
+                {filterType === item ? (
+                    <SVGIcon
+                        name='check'
+                        width={20}
+                        height={20}
+                        visble='true'
+                        style={{
+                            float: 'right',
+                            fill: '#3db28c',
+                            marginTop: '5px',
+                        }}
+                        fill='#3db28c'
+                        stroke='none'
+                    />
+                ) : null}
+            </div>
+        </Row>
+    );
+};
+
+FilterRow.propTypes = {
+    item: PropTypes.string.isRequired,
+    filterType: PropTypes.string.isRequired,
+    relatedObjects: PropTypes.arrayOf(PropTypes.shape({ objectType: PropTypes.string, objectId: PropTypes.string })).isRequired,
+};
+
+export { FilterRow };

--- a/src/modules/RelatedResourcesTab/RelatedResourcesTab.jsx
+++ b/src/modules/RelatedResourcesTab/RelatedResourcesTab.jsx
@@ -1,0 +1,136 @@
+import React, { useState, useMemo, useEffect } from 'react';
+import { Col, Dropdown, Row } from 'react-bootstrap/';
+import PropTypes from 'prop-types';
+import MessageNotFound from '../../pages/commonComponents/MessageNotFound';
+import RelatedObject from '../../pages/commonComponents/relatedObject/RelatedObject';
+import SVGIcon from '../../images/SVGIcon';
+import googleAnalytics from '../../tracking';
+
+import {
+    getFilterLabel,
+    getResourcesFromApi,
+    filterBySearchValue,
+    FILTER_SHOW_ALL,
+    getResourcesBySearch,
+} from './RelatedResourcesTab.utils';
+import { FilterRow } from './RelatedResourcesTab.components';
+
+const RelatedResourcesTab = ({ authorId, relatedObjects }) => {
+    const [searchValue, setSearchValue] = useState('');
+    const [filterType, setFilterType] = useState(FILTER_SHOW_ALL);
+
+    const [resourcesFilteredByType, setResourcesFilteredByType] = useState([]);
+    const [resourcesOnLoad, setResourcesOnLoad] = useState([]);
+
+    const resourcesFilteredBySearch = useMemo(() => getResourcesBySearch(searchValue, resourcesOnLoad), [searchValue, resourcesOnLoad]);
+    const filterTypeLabel = useMemo(() => getFilterLabel(filterType, resourcesFilteredBySearch), [filterType, resourcesFilteredBySearch]);
+
+    const populateResources = async () => {
+        const activeAndInReview = await getResourcesFromApi(relatedObjects, authorId);
+
+        setResourcesOnLoad(activeAndInReview);
+        setResourcesFilteredByType(activeAndInReview);
+    };
+
+    useEffect(() => {
+        populateResources();
+    }, [relatedObjects]);
+
+    const updateSearchValue = e => {
+        setSearchValue(e.target.value);
+    };
+
+    const searchOnEnter = e => {
+        if (e.key !== 'Enter') return;
+
+        setFilterType(FILTER_SHOW_ALL);
+        const filteredBySearchValue = filterBySearchValue(resourcesOnLoad, searchValue);
+        setResourcesFilteredByType(filteredBySearchValue);
+    };
+
+    const handleFilterByType = async selectedFilter => {
+        googleAnalytics.recordEvent('Related Objects', `Filter related resources by ${selectedFilter}`, 'Filter dropdown option changed');
+
+        const filter =
+            selectedFilter === FILTER_SHOW_ALL
+                ? resourcesFilteredBySearch
+                : resourcesFilteredBySearch.filter(resource => resource.objectType === selectedFilter);
+
+        setFilterType(selectedFilter);
+        setResourcesFilteredByType(filter);
+    };
+
+    return (
+        <>
+            <Row>
+                <Col lg={8}>
+                    <span className='collectionsSearchBar form-control'>
+                        <span className='collectionsSearchIcon'>
+                            <SVGIcon name='searchicon' width={20} height={20} fill='#2c8267' stroke='none' type='submit' />
+                        </span>
+                        <span>
+                            <input
+                                id='collectionsSearchBarInput'
+                                type='text'
+                                placeholder='Search within related resources'
+                                onChange={updateSearchValue}
+                                value={searchValue}
+                                onKeyDown={searchOnEnter}
+                            />
+                        </span>
+                    </span>
+                </Col>
+                <Col lg={4} className='text-right'>
+                    <Dropdown className='sorting-dropdown' alignRight onSelect={handleFilterByType}>
+                        <Dropdown.Toggle variant='info' id='dropdown-menu-align-right' className='gray800-14'>
+                            {filterTypeLabel}
+                        </Dropdown.Toggle>
+                        <Dropdown.Menu>
+                            <FilterRow item={FILTER_SHOW_ALL} filterType={filterType} relatedObjects={resourcesFilteredBySearch} />
+                            {['dataset', 'tool', 'dataUseRegister', 'paper', 'course', 'person'].map(item => {
+                                return (
+                                    resourcesFilteredBySearch.filter(relatedObject => relatedObject.objectType === item).length > 0 && (
+                                        <FilterRow
+                                            key={item}
+                                            item={item}
+                                            filterType={filterType}
+                                            relatedObjects={resourcesFilteredBySearch}
+                                        />
+                                    )
+                                );
+                            })}
+                        </Dropdown.Menu>
+                    </Dropdown>
+                </Col>
+            </Row>
+            {resourcesFilteredByType.length <= 0 ? (
+                <MessageNotFound word='related resources' />
+            ) : (
+                resourcesFilteredByType.map(object => (
+                    <span key={object.id}>
+                        <RelatedObject
+                            relatedObject={object}
+                            objectType={object.objectType}
+                            activeLink
+                            shouldFetchObjectsFromApi={false}
+                            showRelationshipAnswer
+                            datasetPublisher={object.datasetPublisher}
+                            datasetLogo={object.datasetLogo}
+                        />
+                    </span>
+                ))
+            )}
+        </>
+    );
+};
+
+RelatedResourcesTab.propTypes = {
+    authorId: PropTypes.number.isRequired,
+    relatedObjects: PropTypes.arrayOf(PropTypes.shape({ objectType: PropTypes.string, objectId: PropTypes.string })),
+};
+
+RelatedResourcesTab.defaultProps = {
+    relatedObjects: [],
+};
+
+export default RelatedResourcesTab;

--- a/src/modules/RelatedResourcesTab/RelatedResourcesTab.test.js
+++ b/src/modules/RelatedResourcesTab/RelatedResourcesTab.test.js
@@ -1,0 +1,212 @@
+import React from 'react';
+import { render, screen, cleanup, waitFor, act, fireEvent } from 'testUtils';
+import RelatedResourcesTab from './RelatedResourcesTab';
+import '@testing-library/jest-dom/extend-expect';
+import { server } from '../../services/mockServer';
+import { getRelatedObjectV1, generateMockRelatedObjectV1 } from '../../../test/handlers';
+import { generateMockUuid } from '../../../test/mocks/generateData';
+
+describe('RelatedResourcesTab', () => {
+    beforeAll(() => {
+        server.listen();
+    });
+
+    afterEach(() => {
+        server.resetHandlers();
+        cleanup();
+    });
+
+    afterAll(() => {
+        server.close();
+    });
+
+    it('should render "No related resources found" when none are passed in', async () => {
+        act(() => {
+            render(<RelatedResourcesTab relatedObjects={[]} authorId={76482376438726} />);
+        });
+        await waitFor(() => {
+            expect(screen.getByText('No related resources found')).toBeInTheDocument();
+        });
+    });
+
+    it('should render "active" related resource', async () => {
+        const uuid = generateMockUuid();
+        const mockRelatedObjectV1 = generateMockRelatedObjectV1({ id: uuid, activeflag: 'active', type: 'tool' });
+        const mockRelatedObjects = [
+            {
+                objectId: uuid,
+                objectType: 'tool',
+            },
+        ];
+        server.use(getRelatedObjectV1(mockRelatedObjectV1));
+        act(() => {
+            render(<RelatedResourcesTab relatedObjects={mockRelatedObjects} authorId={mockRelatedObjectV1.authors[0]} />);
+        });
+        await waitFor(() => {
+            expect(screen.getByText(mockRelatedObjectV1.name)).toBeInTheDocument();
+        });
+    });
+
+    it('should not render "rejected" related resource', async () => {
+        const uuid = generateMockUuid();
+        const mockRelatedObjectV1 = generateMockRelatedObjectV1({ id: uuid, activeflag: 'rejected', type: 'tool' });
+        const mockRelatedObjects = [
+            {
+                objectId: uuid,
+                objectType: 'tool',
+            },
+        ];
+        server.use(getRelatedObjectV1(mockRelatedObjectV1));
+        act(() => {
+            render(<RelatedResourcesTab relatedObjects={mockRelatedObjects} authorId={mockRelatedObjectV1.authors[0]} />);
+        });
+        await waitFor(() => {
+            expect(screen.getByText('No related resources found')).toBeInTheDocument();
+        });
+    });
+
+    it('should render "review" related resource when author id matches', async () => {
+        const uuid = generateMockUuid();
+        const mockRelatedObjectV1 = generateMockRelatedObjectV1({ id: uuid, activeflag: 'review', type: 'tool' });
+        const mockRelatedObjects = [
+            {
+                objectId: uuid,
+                objectType: 'tool',
+            },
+        ];
+        server.use(getRelatedObjectV1(mockRelatedObjectV1));
+        act(() => {
+            render(<RelatedResourcesTab relatedObjects={mockRelatedObjects} authorId={mockRelatedObjectV1.authors[0]} />);
+        });
+        await waitFor(() => {
+            expect(screen.getByText(mockRelatedObjectV1.name)).toBeInTheDocument();
+        });
+    });
+
+    it('should not render "review" related resource if author id does not match', async () => {
+        const uuid = generateMockUuid();
+        const mockRelatedObjectV1 = generateMockRelatedObjectV1({ id: uuid, activeflag: 'review', type: 'tool' });
+        const mockRelatedObjects = [
+            {
+                objectId: uuid,
+                objectType: 'tool',
+            },
+        ];
+        server.use(getRelatedObjectV1(mockRelatedObjectV1));
+        act(() => {
+            render(<RelatedResourcesTab relatedObjects={mockRelatedObjects} authorId={76482376438726} />);
+        });
+        await waitFor(() => {
+            expect(screen.queryByText(mockRelatedObjectV1.name)).not.toBeInTheDocument();
+        });
+    });
+
+    describe('Filter by type', () => {
+        let mockRelatedObjects = [];
+        let mockRelatedObjectV1;
+        let mockRelatedObjectV2;
+        let mockRelatedObjectV3;
+
+        beforeEach(() => {
+            const uuid1 = generateMockUuid();
+            const uuid2 = generateMockUuid();
+            const uuid3 = generateMockUuid();
+
+            mockRelatedObjectV1 = generateMockRelatedObjectV1({ id: uuid1, activeflag: 'active', type: 'tool' });
+            mockRelatedObjectV2 = generateMockRelatedObjectV1({ id: uuid2, activeflag: 'active', type: 'dataUseRegister' });
+            mockRelatedObjectV3 = generateMockRelatedObjectV1({ id: uuid3, activeflag: 'active', type: 'tool' });
+
+            mockRelatedObjects = [
+                {
+                    objectId: uuid1,
+                    objectType: 'tool',
+                },
+                {
+                    objectId: uuid2,
+                    objectType: 'dataUseRegister',
+                },
+                {
+                    objectId: uuid3,
+                    objectType: 'tool',
+                },
+            ];
+            server.use(getRelatedObjectV1(mockRelatedObjectV1));
+            server.use(getRelatedObjectV1(mockRelatedObjectV2));
+            server.use(getRelatedObjectV1(mockRelatedObjectV3));
+        });
+        it('should display count of each type within dropdown when expanded', async () => {
+            act(() => {
+                render(<RelatedResourcesTab relatedObjects={mockRelatedObjects} authorId={76482376438726} />);
+            });
+
+            await waitFor(() => {
+                expect(screen.getByText('Show all resources (3)')).toBeInTheDocument();
+            });
+
+            act(() => {
+                screen.getByText('Show all resources (3)').click();
+            });
+
+            expect(screen.getByText('Show data uses (1)')).toBeInTheDocument();
+            expect(screen.getByText('Show tools (2)')).toBeInTheDocument();
+        });
+        it('should filter related resources by type', async () => {
+            act(() => {
+                render(<RelatedResourcesTab relatedObjects={mockRelatedObjects} authorId={76482376438726} />);
+            });
+
+            await waitFor(() => {
+                expect(screen.getByText('Show all resources (3)')).toBeInTheDocument();
+            });
+
+            act(() => {
+                screen.getByText('Show all resources (3)').click();
+            });
+
+            expect(screen.getAllByText('Show data uses (1)')).toHaveLength(1);
+            expect(screen.getAllByText('Data use')).toHaveLength(1);
+            expect(screen.getAllByText('Tool')).toHaveLength(2);
+
+            act(() => {
+                screen.getByText('Show data uses (1)').click();
+            });
+
+            expect(screen.getAllByText('Show data uses (1)')).toHaveLength(2);
+            expect(screen.getAllByText('Data use')).toHaveLength(1);
+            expect(screen.queryAllByText('Tool')).toHaveLength(0);
+        });
+    });
+
+    it('should filter related resources by search value', async () => {
+        let wrapper;
+        const uuid = generateMockUuid();
+        const mockRelatedObjectV1 = generateMockRelatedObjectV1({ id: uuid, activeflag: 'active', type: 'tool' });
+        const mockRelatedObjects = [
+            {
+                objectId: uuid,
+                objectType: 'tool',
+            },
+        ];
+        server.use(getRelatedObjectV1(mockRelatedObjectV1));
+
+        act(() => {
+            wrapper = render(<RelatedResourcesTab relatedObjects={mockRelatedObjects} authorId={76482376438726} />);
+        });
+
+        await waitFor(() => {
+            expect(screen.getByText('Tool')).toBeInTheDocument();
+            expect(screen.getByText('Show all resources (1)')).toBeInTheDocument();
+        });
+
+        const input = wrapper.container.querySelector('input');
+
+        act(() => {
+            fireEvent.change(input, { target: { value: 'value not in name' } });
+            fireEvent.keyDown(input, { key: 'Enter', code: 'Enter', charCode: 13 });
+        });
+
+        await waitFor(() => {
+            expect(screen.getByText('Show all resources (0)')).toBeInTheDocument();
+        });
+    });
+});

--- a/src/modules/RelatedResourcesTab/RelatedResourcesTab.utils.jsx
+++ b/src/modules/RelatedResourcesTab/RelatedResourcesTab.utils.jsx
@@ -1,0 +1,67 @@
+import relatedObjectService from '../../services/related-objects';
+
+const FILTER_SHOW_ALL = 'showAll';
+
+const filterBySearchValue = (objects, searchValue) => {
+    return objects.filter(object => {
+        return ['name', 'title', 'firstname', 'lastname', 'projectTitle'].some(propName =>
+            object[propName]?.toLowerCase()?.includes(searchValue.toLowerCase())
+        );
+    });
+};
+
+const filterOnlyActiveAndInReview = (objects, authorId) => {
+    return objects.filter(object => {
+        return object.activeflag === 'active' || (object.activeflag === 'review' && object.authors?.includes(authorId));
+    });
+};
+
+const getResourcesFromApi = async (relatedObjects, authorId) => {
+    const populatedRelatedObjects = [];
+
+    await Promise.all(
+        relatedObjects.map(async object => {
+            if (['course', 'dataUseRegister'].includes(object.objectType)) {
+                return relatedObjectService.getRelatedObjectByType(object.objectId, object.objectType).then(res => {
+                    populatedRelatedObjects.push({
+                        ...res.data.data[0],
+                        id: object.objectId,
+                        objectType: object.objectType,
+                    });
+                });
+            }
+            return relatedObjectService.getRelatedObject(object.objectId).then(res => {
+                populatedRelatedObjects.push({
+                    ...res.data.data[0],
+                    id: object.objectId,
+                    objectType: object.objectType,
+                });
+            });
+        })
+    );
+
+    return filterOnlyActiveAndInReview(populatedRelatedObjects, authorId);
+};
+
+const getResourcesBySearch = (searchValue, relatedObjectsAll) => {
+    return filterBySearchValue(relatedObjectsAll, searchValue);
+};
+
+const getFilterLabel = (filterType, relatedObjectsAll) => {
+    if (filterType === FILTER_SHOW_ALL) {
+        return `Show all resources (${relatedObjectsAll.length})`;
+    }
+
+    let label = `${filterType}s`;
+
+    if (filterType === 'dataUseRegister') {
+        label = 'data uses';
+    }
+    if (filterType === 'people') {
+        label = 'people';
+    }
+
+    return `Show ${label} (${relatedObjectsAll.filter(relatedObject => relatedObject.objectType === filterType).length})`;
+};
+
+export { getResourcesBySearch, getFilterLabel, filterBySearchValue, filterOnlyActiveAndInReview, getResourcesFromApi, FILTER_SHOW_ALL };

--- a/src/modules/RelatedResourcesTab/index.js
+++ b/src/modules/RelatedResourcesTab/index.js
@@ -1,0 +1,3 @@
+import RelatedResourcesTab from './RelatedResourcesTab';
+
+export default RelatedResourcesTab;

--- a/src/pages/commonComponents/relatedObject/RelatedObject.js
+++ b/src/pages/commonComponents/relatedObject/RelatedObject.js
@@ -39,17 +39,23 @@ class RelatedObject extends React.Component {
             this.state.inCollection = props.inCollection;
         }
         // what the hell is going on here
-        if (props.data) {
-            this.state.isCohortDiscovery = props.data.isCohortDiscovery || false;
-            this.state.data = props.data || [];
-            this.state.isLoading = false;
-        } else if (props.objectId) {
-            this.state.relatedObject = props.relatedObject;
-            this.state.reason = props.reason;
-            this.getRelatedObjectFromApi(props.objectId, props.objectType);
+        if (props.shouldFetchObjectsFromApi) {
+            if (props.data) {
+                this.state.isCohortDiscovery = props.data.isCohortDiscovery || false;
+                this.state.data = props.data || [];
+                this.state.isLoading = false;
+            } else if (props.objectId) {
+                this.state.relatedObject = props.relatedObject;
+                this.state.reason = props.reason;
+                this.getRelatedObjectFromApi(props.objectId, props.objectType);
+            } else {
+                this.state.relatedObject = props.relatedObject;
+                this.getRelatedObjectFromApi(this.state.relatedObject.objectId, this.state.relatedObject.objectType);
+            }
         } else {
-            this.state.relatedObject = props.relatedObject;
-            this.getRelatedObjectFromApi(this.state.relatedObject.objectId, this.state.relatedObject.objectType);
+            this.state.isCohortDiscovery = props.relatedObject?.isCohortDiscovery || false;
+            this.state.data = props.relatedObject || {};
+            this.state.isLoading = false;
         }
     }
 
@@ -77,7 +83,6 @@ class RelatedObject extends React.Component {
     getRelatedObjectFromApi = (id, type) => {
         //need to handle error if no id is found
         this.setState({ isLoading: true });
-
         relatedObjectService.getRelatedObjectByType(id, type).then(res => {
             this.setState({
                 data: res.data.data[0],
@@ -382,6 +387,7 @@ class RelatedObject extends React.Component {
 
 RelatedObject.defaultProps = {
     onClick: () => {},
+    shouldFetchObjectsFromApi: true,
 };
 
 export default RelatedObject;

--- a/src/pages/dataset/DatasetPage.js
+++ b/src/pages/dataset/DatasetPage.js
@@ -1,12 +1,11 @@
 /** @jsx jsx */
 import { jsx } from '@emotion/react';
-import { cx } from '@emotion/css';
 import * as Sentry from '@sentry/react';
 import axios from 'axios';
-import { has, isEmpty, isNil, isUndefined } from 'lodash';
+import { has, isEmpty, isNil } from 'lodash';
 import React, { Component, Fragment } from 'react';
 import { Button, Box, Typography } from 'hdruk-react-core';
-import { Col, Container, Dropdown, Row, Tab, Tabs } from 'react-bootstrap/';
+import { Col, Container, Row, Tab, Tabs } from 'react-bootstrap/';
 import Linkify from 'react-linkify';
 import 'react-tabs/style/react-tabs.css';
 import Alert from '../../components/Alert';
@@ -24,7 +23,6 @@ import DataSetModal from '../commonComponents/dataSetModal/DataSetModal';
 import ErrorModal from '../commonComponents/errorModal/ErrorModal';
 import Loading from '../commonComponents/Loading';
 import MessageNotFound from '../commonComponents/MessageNotFound';
-import RelatedObject from '../commonComponents/relatedObject/RelatedObject';
 import ResourcePageButtons from '../commonComponents/resourcePageButtons/ResourcePageButtons';
 import SearchBar from '../commonComponents/searchBar/SearchBar';
 import SideDrawer from '../commonComponents/sidedrawer/SideDrawer';
@@ -41,8 +39,9 @@ import Icon from '../../components/Icon';
 import { ReactComponent as Shield } from '../../images/shield.svg';
 import './Dataset.scss';
 import DatasetSchema from './DatasetSchema';
+import RelatedResourcesTab from 'modules/RelatedResourcesTab';
 
-var baseURL = require('../commonComponents/BaseURL').getURL();
+const baseURL = require('../commonComponents/BaseURL').getURL();
 var cmsURL = require('../commonComponents/BaseURL').getCMSURL();
 const env = require('../commonComponents/BaseURL').getURLEnv();
 
@@ -55,7 +54,6 @@ class DatasetDetail extends Component {
         technicalMetadata: [],
         collections: [],
         dataClassOpen: -1,
-        relatedObjects: [],
         isLoading: true,
         userState: [
             {
@@ -101,10 +99,6 @@ class DatasetDetail extends Component {
         cohortProfiling: [],
         datasetHasCohortProfiling: false,
         isCohortDiscovery: false,
-        relatedObjectsFiltered: [],
-        relatedResourcesSort: [],
-        relatedObjectsSearchValue: '',
-        sorting: 'showAll',
     };
 
     topicContext = {};
@@ -146,8 +140,8 @@ class DatasetDetail extends Component {
                     isLatestVersion: res.data.isLatestVersion,
                     isDatasetArchived: res.data.isDatasetArchived,
                 });
-                await this.getTechnicalMetadata();
                 this.getCollections();
+                await this.getTechnicalMetadata();
                 if (!isEmpty(res.data.data.datasetv2)) {
                     this.updateV2Flags(res.data.data.datasetv2);
                     this.getEmptyFieldsCount(res.data.data.datasetv2);
@@ -172,10 +166,6 @@ class DatasetDetail extends Component {
                 };
 
                 this.updateCounter(this.state.data.datasetid, counter);
-
-                if (!isUndefined(res.data.data.relatedObjects)) {
-                    this.getAdditionalObjectInfo(res.data.data.relatedObjects);
-                }
 
                 if (!isEmpty(this.topicContext.title)) {
                     const publisherId = this.topicContext.title;
@@ -533,68 +523,6 @@ class DatasetDetail extends Component {
         };
     }
 
-    getAdditionalObjectInfo = async data => {
-        let tempObjects = [];
-        const promises = data.map(async (object, index) => {
-            if (object.objectType === 'course') {
-                await axios.get(baseURL + '/api/v1/relatedobject/course/' + object.objectId).then(res => {
-                    tempObjects.push({
-                        name: res.data.data[0].title,
-                        id: object.objectId,
-                        activeflag: res.data.data[0].activeflag,
-                    });
-                });
-            } else if (object.objectType === 'dataUseRegister') {
-                await axios.get(baseURL + '/api/v1/relatedobject/dataUseRegister/' + object.objectId).then(res => {
-                    tempObjects.push({
-                        id: object.objectId,
-                        activeflag: res.data.data[0].activeflag,
-                        projectTitle: res.data.data[0].projectTitle,
-                    });
-                });
-            } else {
-                await axios.get(baseURL + '/api/v1/relatedobject/' + object.objectId).then(res => {
-                    tempObjects.push({
-                        name: res.data.data[0].name,
-                        firstname: res.data.data[0].firstname || '',
-                        lastname: res.data.data[0].lastname || '',
-                        id: object.objectId,
-                        authors: res.data.data[0].authors,
-                        activeflag: res.data.data[0].activeflag,
-                    });
-                });
-            }
-        });
-        await Promise.all(promises);
-        this.setState({ objects: tempObjects });
-
-        this.getRelatedObjects();
-    };
-
-    getRelatedObjects = () => {
-        let tempRelatedObjects = [];
-        this.state.data.relatedObjects.map(object =>
-            this.state.objects.forEach(item => {
-                if (object.objectId === item.id && item.activeflag === 'active') {
-                    object['name'] = item.name || '';
-                    object['firstname'] = item.firstname || '';
-                    object['lastname'] = item.lastname || '';
-                    object['projectTitle'] = item.projectTitle || '';
-                    tempRelatedObjects.push(object);
-                }
-
-                if (object.objectId === item.id && item.activeflag === 'review' && item.authors.includes(this.state.userState[0].id)) {
-                    tempRelatedObjects.push(object);
-                }
-            })
-        );
-        this.setState({
-            relatedObjects: tempRelatedObjects,
-            relatedObjectsFiltered: tempRelatedObjects,
-            relatedResourcesSort: tempRelatedObjects,
-        });
-    };
-
     updateDiscoursePostCount = count => {
         this.setState({ discoursePostCount: count });
     };
@@ -698,55 +626,6 @@ class DatasetDetail extends Component {
         this.setState({ showCitationSuccess: true });
     };
 
-    onRelatedObjectsSearch = e => {
-        this.setState({ relatedObjectsSearchValue: e.target.value });
-    };
-
-    doRelatedObjectsSearch = async e => {
-        // Fires on enter on searchbar
-        if (e.key === 'Enter') {
-            this.setState({ relatedObjectsFiltered: [], relatedResourcesSort: [], sorting: 'showAll' });
-
-            const filteredRelatedResourceItems = await this.filterRelatedResourceItems(
-                this.state.relatedObjects,
-                this.state.relatedObjectsSearchValue
-            );
-
-            let tempFilteredData = filteredRelatedResourceItems.filter(dat => {
-                return dat !== '';
-            });
-            this.setState({ relatedObjectsFiltered: tempFilteredData, relatedResourcesSort: tempFilteredData });
-        }
-    };
-
-    filterRelatedResourceItems = (objectData, relatedObjectsSearchValue) =>
-        objectData.map(object => {
-            // Searching functionality - searches through object data and returns true if there is a match with the search term
-            if (
-                (has(object, 'name') ? object.name.toLowerCase().includes(relatedObjectsSearchValue.toLowerCase()) : false) ||
-                (has(object, 'title') ? object.title.toLowerCase().includes(relatedObjectsSearchValue.toLowerCase()) : false) ||
-                (has(object, 'firstname') ? object.firstname.toLowerCase().includes(relatedObjectsSearchValue.toLowerCase()) : false) ||
-                (has(object, 'lastname') ? object.lastname.toLowerCase().includes(relatedObjectsSearchValue.toLowerCase()) : false) ||
-                (has(object, 'projectTitle') ? object.projectTitle.toLowerCase().includes(relatedObjectsSearchValue.toLowerCase()) : false)
-            ) {
-                return object;
-            } else {
-                return '';
-            }
-        });
-
-    handleSort = async sort => {
-        this.setState({ relatedObjectsFiltered: [] });
-        googleAnalytics.recordEvent('Collections', `Sorted related resources by ${sort}`, 'Sort dropdown option changed');
-        let tempFilteredData = [];
-        if (sort === 'showAll') {
-            tempFilteredData = await this.state.relatedResourcesSort;
-        } else {
-            tempFilteredData = await this.state.relatedResourcesSort.filter(dat => dat.objectType === sort);
-        }
-        this.setState({ sorting: sort, relatedObjectsFiltered: tempFilteredData });
-    };
-
     render() {
         const {
             searchString,
@@ -757,7 +636,6 @@ class DatasetDetail extends Component {
             userState,
             alert = null,
             dataClassOpen,
-            relatedObjects,
             discoursePostCount,
             showDrawer,
             showModal,
@@ -777,10 +655,6 @@ class DatasetDetail extends Component {
             emptyFieldsCount,
             linkedDatasets,
             publisherLogoURL,
-            sorting,
-            relatedResourcesSort,
-            relatedObjectsFiltered,
-            relatedObjectsSearchValue,
         } = this.state;
 
         let publisherLogo = !isEmpty(v2data) && !isEmpty(v2data.summary.publisher.logo) ? v2data.summary.publisher.logo : publisherLogoURL;
@@ -802,9 +676,6 @@ class DatasetDetail extends Component {
             );
         }
 
-        if (isNil(data.relatedObjects)) {
-            data.relatedObjects = [];
-        }
         if (has(data, 'datasetfields.phenotypes') && data.datasetfields.phenotypes.length > 0) {
             data.datasetfields.phenotypes.sort((a, b) =>
                 a.name.toLowerCase() > b.name.toLowerCase() ? 1 : b.name.toLowerCase() > a.name.toLowerCase() ? -1 : 0
@@ -1501,158 +1372,13 @@ class DatasetDetail extends Component {
                                             />
                                         </Tab>
 
-                                        <Tab eventKey='Related resources' title={'Related resources (' + relatedObjects.length + ')'}>
-                                            <>
-                                                <Row>
-                                                    <Col lg={8}>
-                                                        <span className='collectionsSearchBar form-control'>
-                                                            <span className='collectionsSearchIcon'>
-                                                                <SVGIcon
-                                                                    name='searchicon'
-                                                                    width={20}
-                                                                    height={20}
-                                                                    fill={'#2c8267'}
-                                                                    stroke='none'
-                                                                    type='submit'
-                                                                />
-                                                            </span>
-                                                            <span>
-                                                                <input
-                                                                    id='collectionsSearchBarInput'
-                                                                    type='text'
-                                                                    placeholder='Search within related resources'
-                                                                    onChange={this.onRelatedObjectsSearch}
-                                                                    value={relatedObjectsSearchValue}
-                                                                    onKeyDown={this.doRelatedObjectsSearch}
-                                                                />
-                                                            </span>
-                                                        </span>
-                                                    </Col>
-
-                                                    <Col lg={4} className='text-right'>
-                                                        <Dropdown className='sorting-dropdown' alignRight onSelect={this.handleSort}>
-                                                            <Dropdown.Toggle
-                                                                variant='info'
-                                                                id='dropdown-menu-align-right'
-                                                                className='gray800-14'>
-                                                                {(() => {
-                                                                    if (sorting !== 'showAll')
-                                                                        return `Show ${
-                                                                            sorting === 'dataUseRegister'
-                                                                                ? `data uses`
-                                                                                : sorting === 'people'
-                                                                                ? sorting
-                                                                                : `${sorting}s`
-                                                                        } (
-
-																	${relatedResourcesSort.filter(dat => dat.objectType === sorting).length})`;
-                                                                    else return `Show all resources (${relatedResourcesSort.length})`;
-                                                                })()}
-                                                                &nbsp;&nbsp;&nbsp;&nbsp;&nbsp;
-                                                            </Dropdown.Toggle>
-                                                            <Dropdown.Menu>
-                                                                <Row
-                                                                    key={`ddl-item-showall`}
-                                                                    className={
-                                                                        sorting === 'showAll'
-                                                                            ? 'sort-dropdown-item sort-dropdown-item-selected sortingDropdown'
-                                                                            : 'sort-dropdown-item sortingDropdown'
-                                                                    }>
-                                                                    <Col xs={12} className='p-0'>
-                                                                        <Dropdown.Item eventKey={'showAll'} className='gray800-14'>
-                                                                            Show all resources ({relatedResourcesSort.length})
-                                                                        </Dropdown.Item>
-                                                                    </Col>
-                                                                    <div className='p-0 sortingCheckmark'>
-                                                                        {sorting === 'showAll' ? (
-                                                                            <SVGIcon
-                                                                                name='check'
-                                                                                width={20}
-                                                                                height={20}
-                                                                                visble='true'
-                                                                                style={{
-                                                                                    float: 'right',
-                                                                                    fill: '#3db28c',
-                                                                                    marginTop: '5px',
-                                                                                }}
-                                                                                fill={'#3db28c'}
-                                                                                stroke='none'
-                                                                            />
-                                                                        ) : null}
-                                                                    </div>
-                                                                </Row>
-                                                                {['dataset', 'tool', 'dataUseRegister', 'paper', 'course', 'person'].map(
-                                                                    item => {
-                                                                        return relatedResourcesSort.filter(dat => dat.objectType === item)
-                                                                            .length > 0 ? (
-                                                                            <Row
-                                                                                key={`ddl-item-${item}`}
-                                                                                className={
-                                                                                    sorting === item
-                                                                                        ? 'sort-dropdown-item sort-dropdown-item-selected sortingDropdown'
-                                                                                        : 'sort-dropdown-item sortingDropdown'
-                                                                                }>
-                                                                                <Col xs={12} className='p-0'>
-                                                                                    <Dropdown.Item eventKey={item} className='gray800-14'>
-                                                                                        Show{' '}
-                                                                                        {item === 'dataUseRegister'
-                                                                                            ? `data uses`
-                                                                                            : item === 'people'
-                                                                                            ? item
-                                                                                            : `${item}s`}{' '}
-                                                                                        (
-                                                                                        {
-                                                                                            relatedResourcesSort.filter(
-                                                                                                dat => dat.objectType === item
-                                                                                            ).length
-                                                                                        }
-                                                                                        )
-                                                                                    </Dropdown.Item>
-                                                                                </Col>
-                                                                                <div className='p-0 sortingCheckmark'>
-                                                                                    {sorting === item ? (
-                                                                                        <SVGIcon
-                                                                                            name='check'
-                                                                                            width={20}
-                                                                                            height={20}
-                                                                                            visble='true'
-                                                                                            style={{
-                                                                                                float: 'right',
-                                                                                                fill: '#3db28c',
-                                                                                                marginTop: '5px',
-                                                                                            }}
-                                                                                            fill={'#3db28c'}
-                                                                                            stroke='none'
-                                                                                        />
-                                                                                    ) : null}
-                                                                                </div>
-                                                                            </Row>
-                                                                        ) : (
-                                                                            ''
-                                                                        );
-                                                                    }
-                                                                )}
-                                                            </Dropdown.Menu>
-                                                        </Dropdown>
-                                                    </Col>
-                                                </Row>
-                                                {relatedObjectsFiltered.length <= 0 ? (
-                                                    <MessageNotFound word='related resources' />
-                                                ) : (
-                                                    relatedObjectsFiltered.map((object, index) => (
-                                                        <span key={index}>
-                                                            <RelatedObject
-                                                                relatedObject={object}
-                                                                objectType={object.objectType}
-                                                                activeLink={true}
-                                                                showRelationshipAnswer={true}
-                                                                datasetPublisher={object.datasetPublisher}
-                                                                datasetLogo={object.datasetLogo}
-                                                            />
-                                                        </span>
-                                                    ))
-                                                )}
-                                            </>
+                                        <Tab
+                                            eventKey='Related resources'
+                                            title={'Related resources (' + this.state.data?.relatedObjects?.length + ')'}>
+                                            <RelatedResourcesTab
+                                                relatedObjects={this.state.data?.relatedObjects}
+                                                authorId={this.state.userState[0].id}
+                                            />
                                         </Tab>
 
                                         <Tab eventKey='Collections' title={'Collections (' + collections.length + ')'}>

--- a/src/services/mockServer.js
+++ b/src/services/mockServer.js
@@ -8,6 +8,7 @@ import mswDatasetOnboarding from './dataset-onboarding/mockMsw';
 import mswDatasets from './datasets/mockMsw';
 import mswGetLocations from './locations/mockMsw';
 import mswGetUsers from './users/mockMsw';
+import { getRelatedObjectV1, getRelatedObjectTypeV1 } from '../../test/handlers/relatedResources/v1/handlers';
 
 const mswGetEnTranslations = rest.get(`http://localhost/locales/en/translation.json`, (req, res, ctx) => {
     return res(ctx.status(200), ctx.json(translations));
@@ -33,6 +34,8 @@ const handlers = [
     mswGetEnTranslations,
     mswGetEnGbTranslations,
     mswGetIcon,
+    getRelatedObjectV1(),
+    getRelatedObjectTypeV1(),
 ];
 
 export const server = setupServer(...handlers);

--- a/test/handlers/index.js
+++ b/test/handlers/index.js
@@ -1,0 +1,1 @@
+export * from './relatedResources/v1';

--- a/test/handlers/relatedResources/v1/data.js
+++ b/test/handlers/relatedResources/v1/data.js
@@ -1,0 +1,22 @@
+import { faker } from '@faker-js/faker';
+
+faker.seed(5);
+
+const generateMockRelatedObjectV1 = (data = {}) => {
+    return {
+        id: faker.datatype.uuid(),
+        activeflag: faker.helpers.arrayElement(['active', 'review']),
+        type: faker.helpers.arrayElement(['dataset', 'tool', 'dataUseRegister', 'paper', 'course', 'person']),
+        authors: [parseInt(faker.random.numeric(10), 10)],
+        name: faker.lorem.sentence(),
+        projectTitle: faker.lorem.sentence(),
+        datasetfields: { phenotypes: [] },
+        categories: {},
+        tags: {},
+        gatewayDatasetsInfo: [],
+        keywords: [],
+        ...data,
+    };
+};
+
+export { generateMockRelatedObjectV1 };

--- a/test/handlers/relatedResources/v1/handlers.js
+++ b/test/handlers/relatedResources/v1/handlers.js
@@ -1,0 +1,28 @@
+import { rest } from 'msw';
+import { apiV1Url } from '../../../../src/configs/url.config';
+import { generateMockRelatedObjectV1 } from './data';
+
+const mockGetRelatedObjectActiveV1 = generateMockRelatedObjectV1();
+
+const getRelatedObjectV1 = (data = mockGetRelatedObjectActiveV1, status = 200) => {
+    return rest.get(`${apiV1Url}/relatedobject/:id`, (req, res, ctx) => {
+        return res(
+            ctx.status(status),
+            ctx.json({
+                data: [data],
+            })
+        );
+    });
+};
+
+const getRelatedObjectTypeV1 = (data = mockGetRelatedObjectActiveV1, status = 200) =>
+    rest.get(`${apiV1Url}/relatedobject/:type/:id`, (req, res, ctx) => {
+        return res(
+            ctx.status(status),
+            ctx.json({
+                data: [data],
+            })
+        );
+    });
+
+export { getRelatedObjectV1, getRelatedObjectTypeV1 };

--- a/test/handlers/relatedResources/v1/index.js
+++ b/test/handlers/relatedResources/v1/index.js
@@ -1,0 +1,2 @@
+export * from './data';
+export * from './handlers';

--- a/test/mocks/generateData.js
+++ b/test/mocks/generateData.js
@@ -1,0 +1,5 @@
+import { faker } from '@faker-js/faker';
+
+const generateMockUuid = () => faker.datatype.uuid();
+
+export { generateMockUuid };


### PR DESCRIPTION
 - Removed related resource logic from DataSetPage and put in its own module 
 - Introduced 'faker' to generate mock data for unit tests
 - Created handler functions to mock `relatedobject` api
 - Fixed count issue in GAT-1768
 - Fixed multiple api calls issue in GAT-1769