### PR TITLE
fixes the nextjs fast reload under docker in k8s env

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -5,6 +5,9 @@ WORKDIR /usr/src
 
 COPY . /usr/src
 
+ENV WATCHPACK_POLLING true
+ENV NEXT_WEBPACK_USEPOLLING true
+
 RUN npm install
 
 EXPOSE 3000

--- a/Tiltfile
+++ b/Tiltfile
@@ -9,8 +9,8 @@ docker_build(
     ref='hdruk/' + cfg.get('name'),
     context='.',
     live_update=[
-        sync('./src', '/usr/src'),
-        run('npm install', trigger='./package-lock.json')
+        sync('.', '/usr/src'),
+        run('npm install', trigger='./package-lock.json'),
     ]
 )
 

--- a/next.config.js
+++ b/next.config.js
@@ -1,6 +1,16 @@
 /** @type {import('next').NextConfig} */
 const nextConfig = {
   reactStrictMode: true,
+  swcMinify: true,
+  webpack: (config, context) => {
+    if (process.env.NEXT_WEBPACK_USEPOLLING) {
+      config.watchOptions = {
+        poll: 500,
+        aggregateTimeout: 300
+      }
+    }
+    return config
+  }
 }
 
 module.exports = nextConfig


### PR DESCRIPTION
Quickly fixes the fast refresh provided by nextjs - that wasn't working due to inotify not triggering under k8s deployment. This process forces webpack watch to poll and within a second or two the changes are reflected in the front end once sync has been completed.