### PR TITLE
Remove un-required polling

### DIFF
--- a/Dockerfile.dev
+++ b/Dockerfile.dev
@@ -5,9 +5,6 @@ WORKDIR /usr/src
 
 COPY . /usr/src
 
-ENV WATCHPACK_POLLING true
-ENV NEXT_WEBPACK_USEPOLLING true
-
 RUN npm install
 
 EXPOSE 3000

--- a/next.config.js
+++ b/next.config.js
@@ -19,15 +19,6 @@ const nextConfig = withNextIntl({
             },
         ],
     },
-    webpack: config => {
-        if (process.env.NEXT_WEBPACK_USEPOLLING) {
-            config.watchOptions = {
-                poll: 500,
-                aggregateTimeout: 300,
-            };
-        }
-        return config;
-    },
     async redirects() {
         return [
             {


### PR DESCRIPTION
Removes the Docker configuration for webpack polling

I found locally this was not required and removing this sped up my local environment dramatically