### PR TITLE
Feature/gat 3967 Add publication search explanation text

### DIFF
--- a/src/app/[locale]/(logged-out)/search/components/Search/Search.tsx
+++ b/src/app/[locale]/(logged-out)/search/components/Search/Search.tsx
@@ -381,6 +381,11 @@ const Search = ({ filters }: { filters: Filter[] }) => {
                 return t("searchExplainerDatasets");
         }
     };
+    const showPublicationWelcomeMessage =
+        !isSearching &&
+        !queryParams.query &&
+        queryParams.type === SearchCategory.PUBLICATIONS &&
+        (!data?.list.length || !data?.path?.includes(queryParams.type));
 
     return (
         <Box
@@ -554,44 +559,29 @@ const Search = ({ filters }: { filters: Filter[] }) => {
                             </Box>
                         )}
 
-                        {!isSearching &&
-                            !queryParams.query &&
-                            queryParams.type === SearchCategory.PUBLICATIONS &&
-                            (!data?.list.length ||
-                                !data?.path?.includes(queryParams.type)) && (
-                                <Paper sx={{ textAlign: "left", p: 3 }}>
-                                    <Typography
-                                        variant="h2"
-                                        style={{ fontWeight: "bolder" }}
-                                        sx={{
-                                            pb: 4,
-                                            borderBottom: 1,
-                                            borderColor: "greyCustom.light",
-                                        }}>
-                                        {t("publicationWelcomeHeader")}
-                                    </Typography>
-                                    <Typography variant="h3">
-                                        <p>
-                                            To start your search, enter a
-                                            keyword at the top and select the
-                                            search source on the left then hit
-                                            enter or return.
-                                        </p>
-                                        <p>
-                                            Gateway assets are linked to make it
-                                            easier to find relevant resources
-                                            for your work.
-                                        </p>
-                                        <p>
-                                            Search Gateway for publications with
-                                            curated linkages to explore related
-                                            resources, like publications about a
-                                            dataset or publications that have
-                                            used a dataset.
-                                        </p>
-                                    </Typography>
-                                </Paper>
-                            )}
+                        {showPublicationWelcomeMessage && (
+                            <Paper sx={{ textAlign: "left", p: 3 }}>
+                                <Typography
+                                    variant="h2"
+                                    style={{ fontWeight: "bolder" }}
+                                    sx={{
+                                        pb: 4,
+                                        borderBottom: 1,
+                                        borderColor: "greyCustom.light",
+                                    }}>
+                                    {t("publicationWelcomeHeader")}
+                                </Typography>
+                                <Typography variant="h3">
+                                    {t("publicationWelcomeText1")}
+                                </Typography>
+                                <Typography variant="h3">
+                                    {t("publicationWelcomeText2")}
+                                </Typography>
+                                <Typography variant="h3">
+                                    {t("publicationWelcomeText3")}
+                                </Typography>
+                            </Paper>
+                        )}
                         {isSearching && <Loading />}
 
                         {!isSearching &&

--- a/src/config/messages/en.json
+++ b/src/config/messages/en.json
@@ -322,6 +322,9 @@
             "downloadStarted": "Your download has started",
             "filtersApplied": "Filter(s) applied",
             "publicationWelcomeHeader": "Welcome to publications search on the Gateway.",
+            "publicationWelcomeText1": "To start your search, enter a keyword at the top and select the search source on the left then hit enter or return.",
+            "publicationWelcomeText2": "Gateway assets are linked to make it easier to find relevant resources for your work.",
+            "publicationWelcomeText3": "Search Gateway for publications with curated linkages to explore related resources, like publications about a dataset or publications that have used a dataset.",
             "components": {
                 "Search": {
                     "toggleLabelTable": "Table",


### PR DESCRIPTION
## Screenshots (if relevant)
Displays when first loading the publication tab:
![image](https://github.com/HDRUK/gateway-web-2/assets/11610738/9a782a51-2361-4872-97da-e9ae6410972d)

But not when there is a successful query being used:
![image](https://github.com/HDRUK/gateway-web-2/assets/11610738/8e497974-62f2-4f8d-9726-fbc18773ff35)

And the "No results" text still shows when a query has given no results:
![image](https://github.com/HDRUK/gateway-web-2/assets/11610738/1e391c6a-9d44-4a99-852e-48390e13dfd2)

## Describe your changes
Add publication search explanation text.

## Issue ticket link
https://hdruk.atlassian.net/browse/GAT-3967

## Checklist before requesting a review

-   [ ] I have performed a self-review of my code
-   [ ] I have added appropriate unit tests
-   [ ] I have created mocks for unit tests (where appropriate)
-   [ ] The interface is responsive (where appropriate)
-   [ ] The interface is at least AA (where appropriate)
