### PR TITLE
Hotfix: Use ternary op in template literal.

### DIFF
--- a/src/app/[locale]/(logged-out)/search/components/Search/Search.tsx
+++ b/src/app/[locale]/(logged-out)/search/components/Search/Search.tsx
@@ -188,8 +188,9 @@ const Search = ({ filters }: { filters: Filter[] }) => {
         `${apis.searchV1Url}/${queryParams.type}?view_type=mini&perPage=${
             queryParams.per_page
         }&page=${queryParams.page}&sort=${queryParams.sort}${
-            queryParams.type === SearchCategory.PUBLICATIONS ?
-            `&${STATIC_FILTER_SOURCE}=${queryParams.source}` : ``
+            queryParams.type === SearchCategory.PUBLICATIONS
+                ? `&${STATIC_FILTER_SOURCE}=${queryParams.source}`
+                : ``
         }`,
         {
             query: queryParams.query,


### PR DESCRIPTION
## Screenshots (if relevant)

## Describe your changes
Corrects logic in URL generated. Previously, when not on the publication tab, the search url generated would end with `sort:descfalse` due to the conditional being evaluated to a string. Use of ternary operator removes that, while still returning e.g. `sort:desc&source=GAT` when on publication tab.

## Issue ticket link

## Checklist before requesting a review

-   [x] I have performed a self-review of my code
-   [ ] I have added appropriate unit tests
-   [ ] I have created mocks for unit tests (where appropriate)
-   [ ] The interface is responsive (where appropriate)
-   [ ] The interface is at least AA (where appropriate)
