### PR TITLE
Add datasets with tissues filter

### DIFF
--- a/src/app/[locale]/(logged-out)/search/components/FilterPanel/FilterPanel.tsx
+++ b/src/app/[locale]/(logged-out)/search/components/FilterPanel/FilterPanel.tsx
@@ -25,6 +25,7 @@ import {
     FILTER_TYPE_CATEGORY,
     filtersList,
     FILTER_POPULATION_SIZE,
+    FILTER_CONTAINS_TISSUE,
 } from "@/config/forms/filters";
 import { SOURCE_GAT } from "@/config/forms/search";
 import { INCLUDE_UNREPORTED } from "@/consts/filters";
@@ -34,6 +35,7 @@ import {
     transformQueryFiltersToForm,
 } from "@/utils/filters";
 import DateRangeFilter from "../DateRangeFilter";
+import FilterSectionInlineSwitch from "../FilterSectionInlineSwitch";
 import PopulationFilter from "../PopulationFilter";
 
 const TRANSLATION_PATH = "pages.search.components.FilterPanel.filters";
@@ -319,38 +321,69 @@ const FilterPanel = ({
 
     return (
         <>
-            {filterItems.map(filterItem => {
-                const { label } = filterItem;
+            {filterItems
+                .sort((item1, item2) =>
+                    item1.label === FILTER_CONTAINS_TISSUE
+                        ? -1
+                        : item2.label === FILTER_CONTAINS_TISSUE
+                        ? 1
+                        : 0
+                )
+                .map(filterItem => {
+                    const { label } = filterItem;
 
-                return (
-                    <Accordion
-                        key={label}
-                        sx={{
-                            background: "transparent",
-                            boxShadow: "none",
-                        }}
-                        expanded={maximised.includes(label)}
-                        heading={
-                            <Tooltip
-                                key={label}
-                                placement="right"
-                                title={t(`${label}${TOOLTIP_SUFFIX}`)}>
-                                <Typography fontWeight="400" fontSize="20px">
-                                    {t(label)}
-                                </Typography>
-                            </Tooltip>
-                        }
-                        onChange={() =>
-                            setMaximised(
-                                maximised.includes(label)
-                                    ? maximised.filter(e => e !== label)
-                                    : [...maximised, label]
-                            )
-                        }
-                        contents={renderFilterContent(filterItem)}
-                    />
-                );
-            })}
+                    if (filterItem.label === FILTER_CONTAINS_TISSUE) {
+                        return (
+                            <FilterSectionInlineSwitch
+                                filterCategory={filterCategory}
+                                filterItem={filterItem}
+                                selectedFilters={selectedFilters}
+                                handleRadioChange={(
+                                    event: React.ChangeEvent<HTMLInputElement>
+                                ) =>
+                                    updateCheckboxes(
+                                        {
+                                            [filterItem.label]:
+                                                event.target.checked,
+                                        },
+                                        label
+                                    )
+                                }
+                            />
+                        );
+                    }
+
+                    return (
+                        <Accordion
+                            key={label}
+                            sx={{
+                                background: "transparent",
+                                boxShadow: "none",
+                            }}
+                            expanded={maximised.includes(label)}
+                            heading={
+                                <Tooltip
+                                    key={label}
+                                    placement="right"
+                                    title={t(`${label}${TOOLTIP_SUFFIX}`)}>
+                                    <Typography
+                                        fontWeight="400"
+                                        fontSize="20px">
+                                        {t(label)}
+                                    </Typography>
+                                </Tooltip>
+                            }
+                            onChange={() =>
+                                setMaximised(
+                                    maximised.includes(label)
+                                        ? maximised.filter(e => e !== label)
+                                        : [...maximised, label]
+                                )
+                            }
+                            contents={renderFilterContent(filterItem)}
+                        />
+                    );
+                })}
         </>
     );
 };

--- a/src/app/[locale]/(logged-out)/search/components/FilterSectionInlineSwitch/FilterSectionInlineSwitch.tsx
+++ b/src/app/[locale]/(logged-out)/search/components/FilterSectionInlineSwitch/FilterSectionInlineSwitch.tsx
@@ -1,0 +1,61 @@
+"use client";
+
+import MuiSwitch from "@mui/material/Switch";
+import { useTranslations } from "next-intl";
+import { BucketCheckbox } from "@/interfaces/Filter";
+import Box from "@/components/Box";
+import TooltipIcon from "@/components/TooltipIcon";
+import Typography from "@/components/Typography";
+
+const TRANSLATION_PATH = "pages.search.components.FilterPanel.filters";
+const TOOLTIP_SUFFIX = "Tooltip";
+
+interface FilterSectionInlineSwitchProps {
+    filterCategory: string;
+    filterItem: { label: string; value: string; buckets: BucketCheckbox[] };
+    selectedFilters: { [filter: string]: string[] | undefined };
+    handleRadioChange: (event: React.ChangeEvent<HTMLInputElement>) => void;
+}
+const FilterSectionInlineSwitch = ({
+    filterCategory,
+    filterItem,
+    selectedFilters,
+    handleRadioChange,
+}: FilterSectionInlineSwitchProps) => {
+    const t = useTranslations(`${TRANSLATION_PATH}.${filterCategory}`);
+
+    const { label } = filterItem;
+
+    return (
+        <Box
+            sx={{
+                display: "flex",
+                justifyContent: "space-between",
+                alignItems: "center",
+            }}>
+            <Typography fontWeight="400" fontSize="20px">
+                {t(label)}
+            </Typography>
+            <Box
+                sx={{
+                    display: "flex",
+                    gap: 1,
+                    p: 0,
+                }}>
+                <TooltipIcon
+                    buttonSx={{ p: 0 }}
+                    size="small"
+                    label=""
+                    content={t(`${label}${TOOLTIP_SUFFIX}`)}
+                />
+                <MuiSwitch
+                    disableRipple
+                    onChange={handleRadioChange}
+                    checked={!!selectedFilters[filterItem.label]?.length}
+                />
+            </Box>
+        </Box>
+    );
+};
+
+export default FilterSectionInlineSwitch;

--- a/src/app/[locale]/(logged-out)/search/components/FilterSectionInlineSwitch/index.ts
+++ b/src/app/[locale]/(logged-out)/search/components/FilterSectionInlineSwitch/index.ts
@@ -1,0 +1,3 @@
+import FilterSectionInlineSwitch from "./FilterSectionInlineSwitch";
+
+export default FilterSectionInlineSwitch;

--- a/src/app/[locale]/(logged-out)/search/components/Search/Search.tsx
+++ b/src/app/[locale]/(logged-out)/search/components/Search/Search.tsx
@@ -46,6 +46,7 @@ import {
     FILTER_POPULATION_SIZE,
     FILTER_TYPE_CATEGORY,
     FILTER_PROGRAMMING_LANGUAGE,
+    FILTER_CONTAINS_TISSUE,
 } from "@/config/forms/filters";
 import searchFormConfig, {
     QUERY_FIELD,
@@ -140,6 +141,7 @@ const Search = ({ filters }: { filters: Filter[] }) => {
             FILTER_PROGRAMMING_LANGUAGE
         ),
         [FILTER_TYPE_CATEGORY]: getParamArray(FILTER_TYPE_CATEGORY),
+        [FILTER_CONTAINS_TISSUE]: getParamArray(FILTER_CONTAINS_TISSUE),
     });
 
     const { handleDownload } = useSearch(
@@ -242,6 +244,7 @@ const Search = ({ filters }: { filters: Filter[] }) => {
             [FILTER_POPULATION_SIZE]: undefined,
             [FILTER_PROGRAMMING_LANGUAGE]: undefined,
             [FILTER_TYPE_CATEGORY]: undefined,
+            [FILTER_CONTAINS_TISSUE]: undefined,
         });
     };
 

--- a/src/config/forms/filters.ts
+++ b/src/config/forms/filters.ts
@@ -13,6 +13,7 @@ export const FILTER_LICENSE = "license";
 export const FILTER_ACCESS_SERVICE = "accessService";
 export const FILTER_POPULATION_SIZE = "populationSize";
 export const FILTER_TYPE_CATEGORY = "typeCategory";
+export const FILTER_CONTAINS_TISSUE = "containsTissue";
 
 export const filtersList = [
     FILTER_PUBLISHER_NAME,
@@ -30,4 +31,5 @@ export const filtersList = [
     FILTER_ACCESS_SERVICE,
     FILTER_POPULATION_SIZE,
     FILTER_TYPE_CATEGORY,
+    FILTER_CONTAINS_TISSUE,
 ];

--- a/src/config/messages/en.json
+++ b/src/config/messages/en.json
@@ -406,7 +406,9 @@
                             "dataProvider": "Data Provider",
                             "dataProviderTooltip": "The name of the Data Provider (i.e. the organisation who facilitates access to the dataset)",
                             "accessService": "Access service",
-                            "accessServiceTooltip": "The method through which a researcher accesses the dataset"
+                            "accessServiceTooltip": "The method through which a researcher accesses the dataset",
+                            "containsTissue": "Datasets with tissues",
+                            "containsTissueTooltip": "Restrict your search result to datasets with tissue sample"
                         },
                         "dataUseRegister": {
                             "publisherName": "Data custodian",

--- a/src/interfaces/Search.ts
+++ b/src/interfaces/Search.ts
@@ -12,6 +12,7 @@ import {
     FILTER_POPULATION_SIZE,
     FILTER_PROGRAMMING_LANGUAGE,
     FILTER_TYPE_CATEGORY,
+    FILTER_CONTAINS_TISSUE,
 } from "@/config/forms/filters";
 import { Metadata } from "./Dataset";
 import { Bucket } from "./Filter";
@@ -157,6 +158,7 @@ export interface SearchQueryParams {
     [FILTER_POPULATION_SIZE]: string[] | undefined;
     [FILTER_PROGRAMMING_LANGUAGE]: string[] | undefined;
     [FILTER_TYPE_CATEGORY]: string[] | undefined;
+    [FILTER_CONTAINS_TISSUE]: string[] | undefined;
 }
 
 export type CountType = { [key: string]: number };

--- a/src/utils/filters.ts
+++ b/src/utils/filters.ts
@@ -1,7 +1,7 @@
 import { pick } from "lodash";
 import { Bucket, BucketCheckbox, Filter } from "@/interfaces/Filter";
 import { SearchQueryParams } from "@/interfaces/Search";
-import { filtersList } from "@/config/forms/filters";
+import { FILTER_CONTAINS_TISSUE, filtersList } from "@/config/forms/filters";
 import { INCLUDE_UNREPORTED } from "@/consts/filters";
 
 const groupByType = (
@@ -78,6 +78,11 @@ const pickOnlyFilters = (type: string, allSearchQueries: SearchQueryParams) => {
                               INCLUDE_UNREPORTED
                           ),
                   },
+                  [FILTER_CONTAINS_TISSUE]: [
+                      !!filterQueries?.[FILTER_CONTAINS_TISSUE]?.includes(
+                          FILTER_CONTAINS_TISSUE
+                      ),
+                  ],
               }
             : filterQueries;
 


### PR DESCRIPTION
## Screenshots (if relevant)
![image](https://github.com/HDRUK/gateway-web-2/assets/153518986/cf47ea59-9b6b-4d30-a0fe-80a7afb2fe77)

## Describe your changes
Adds dataset with tissue filter. Had to modify the sent parameters of the request as filter format doesn't match previous one
(normally in an array of strings)

## Issue ticket link
https://hdruk.atlassian.net/browse/GAT-4288

## Checklist before requesting a review

-   [x] I have performed a self-review of my code
-   [ ] I have added appropriate unit tests
-   [ ] I have created mocks for unit tests (where appropriate)
-   [x] The interface is responsive (where appropriate)
-   [ ] The interface is at least AA (where appropriate)
