### PR TITLE
Implement ordering of the filters panels

### DIFF
--- a/src/app/[locale]/(logged-out)/search/components/FilterPanel/FilterPanel.tsx
+++ b/src/app/[locale]/(logged-out)/search/components/FilterPanel/FilterPanel.tsx
@@ -290,7 +290,8 @@ const FilterPanel = ({
 
         if (item1 && item2) {
             return item1 - item2;
-        } else if (item1 && !item2) {
+        }
+        if (item1 && !item2) {
             return 1;
         }
 


### PR DESCRIPTION
## Screenshots (if relevant)
![image](https://github.com/HDRUK/gateway-web-2/assets/11610738/815a2ee8-2fca-4cd2-a297-7e6e349c4cc6)

## Describe your changes
Implements a reference ordering for filter panels per filter category, so we can order them as we please rather than relying on the BE order (which seems not to depend upon the seeder order).

## Issue ticket link
https://hdruk.atlassian.net/browse/GAT-4316

## Checklist before requesting a review

-   [x] I have performed a self-review of my code
-   [x] I have added appropriate unit tests
-   [ ] I have created mocks for unit tests (where appropriate)
-   [ ] The interface is responsive (where appropriate)
-   [ ] The interface is at least AA (where appropriate)
