### PR TITLE
GAT-4362: disable facets on EuropePMC search

### DIFF
--- a/src/app/[locale]/(logged-out)/search/components/FilterPanel/FilterPanel.tsx
+++ b/src/app/[locale]/(logged-out)/search/components/FilterPanel/FilterPanel.tsx
@@ -377,6 +377,10 @@ const FilterPanel = ({
                         counts={formatBucketCounts(
                             get(aggregations, label)?.buckets
                         )}
+                        countsDisabled={
+                            filterCategory === FILTER_CATEGORY_PUBLICATIONS &&
+                            (staticFilterValues.source?.FED || false)
+                        }
                     />
                 );
         }

--- a/src/components/FilterSection/FilterSection.tsx
+++ b/src/components/FilterSection/FilterSection.tsx
@@ -27,6 +27,7 @@ interface FilterSectionProps<TFieldValues extends FieldValues, TName> {
     placeholder?: string;
     checkboxValues: { [key: string]: boolean };
     counts?: CountType;
+    countsDisabled: boolean;
     handleCheckboxChange: (updates: { [key: string]: boolean }) => void;
     setValue: (
         name: keyof TFieldValues,
@@ -45,6 +46,7 @@ const FilterSection = <
     noFilterLabel,
     placeholder,
     counts = {},
+    countsDisabled,
     handleCheckboxChange,
     setValue,
     resetFilterSection,
@@ -76,7 +78,9 @@ const FilterSection = <
         style: CSSProperties;
     }) => {
         const formattedRow = cloneDeep(checkboxes[index]);
-        formattedRow.count = !isEmpty(counts)
+        formattedRow.count = countsDisabled
+            ? undefined
+            : !isEmpty(counts)
             ? counts[checkboxes[index].label] || 0
             : checkboxes[index].count;
 


### PR DESCRIPTION
## Screenshots (if relevant)
<img src="https://github.com/HDRUK/gateway-web-2/assets/11610738/e23c98d3-77a0-44e8-b812-75359180d5e6" width="45%">
<img src="https://github.com/HDRUK/gateway-web-2/assets/11610738/0a116699-d69f-496f-a44f-4d80621bddba" width="45%">

## Describe your changes
Add `countsDisabled` parameter, triggered when in federated publication search.

## Issue ticket link
https://hdruk.atlassian.net/browse/GAT-4362

## Checklist before requesting a review

-   [x] I have performed a self-review of my code
-   [x] I have added appropriate unit tests
-   [ ] I have created mocks for unit tests (where appropriate)
-   [ ] The interface is responsive (where appropriate)
-   [ ] The interface is at least AA (where appropriate)
