### PR TITLE
Remove links from two dataset metadata fields

### DIFF
--- a/src/app/[locale]/(logged-out)/dataset/[datasetId]/config.tsx
+++ b/src/app/[locale]/(logged-out)/dataset/[datasetId]/config.tsx
@@ -120,7 +120,7 @@ const datasetFields: DatasetSection[] = [
         fields: [
             {
                 path: "metadata.metadata.accessibility.access.accessRights",
-                type: FieldType.LINK_LIST,
+                type: FieldType.LIST,
                 label: "Access Rights",
             },
             {
@@ -130,7 +130,7 @@ const datasetFields: DatasetSection[] = [
             },
             {
                 path: "metadata.metadata.accessibility.access.accessRequestCost",
-                type: FieldType.LINK_LIST,
+                type: FieldType.LIST,
                 label: "Organisation Access Request Cost",
             },
             {


### PR DESCRIPTION
## Screenshots (if relevant)

## Describe your changes
Remove links from two dataset metadata fields - `access rights` and `Organisation Access Request Cost`

## Issue ticket link
https://hdruk.atlassian.net/browse/GAT-4597

## Checklist before requesting a review

-   [x] I have performed a self-review of my code
-   [ ] I have added appropriate unit tests
-   [ ] I have created mocks for unit tests (where appropriate)
-   [ ] The interface is responsive (where appropriate)
-   [ ] The interface is at least AA (where appropriate)
