### PR TITLE
fixes an errant call to traser which doesnt work and throws 500s in logs

### DIFF
--- a/src/utils/api.ts
+++ b/src/utils/api.ts
@@ -109,7 +109,7 @@ async function getDataset(
 
     if (schemaModel && schemaVersion) {
         params.append("schema_model", schemaModel);
-        params.append("schemaVersion", schemaVersion);
+        params.append("schema_version", schemaVersion);
     }
     const queryString = params.toString();
 


### PR DESCRIPTION
## Screenshots (if relevant)
![image](https://github.com/user-attachments/assets/d01d0a92-f5a4-47a3-82ff-c8af262fd73a)

## Describe your changes
Invalid named query parameter is causing 500 errors in the gcp logs. This names the parameter correctly, specifically `schema_version` rather than `schemaVersion`

## Issue ticket link
N/A

## Checklist before requesting a review

-   [x] I have performed a self-review of my code
-   [ ] I have added appropriate unit tests
-   [ ] I have created mocks for unit tests (where appropriate)
-   [ ] The interface is responsive (where appropriate)
-   [ ] The interface is at least AA (where appropriate)
