### PR TITLE
Make use of the '-1' perPage option in a number of places when listing all options etc.

### DIFF
--- a/src/app/[locale]/(logged-out)/search/components/ResultsTable/ResultsTable.tsx
+++ b/src/app/[locale]/(logged-out)/search/components/ResultsTable/ResultsTable.tsx
@@ -253,7 +253,7 @@ const ResultTable = ({ results }: ResultTableProps) => {
     const { isLoggedIn } = useAuth();
 
     const { data: libraryData, mutate: mutateLibraries } = useGet<Library[]>(
-        `${apis.librariesV1Url}?perPage=all`,
+        `${apis.librariesV1Url}?perPage=-1`,
         { shouldFetch: isLoggedIn }
     );
 

--- a/src/app/[locale]/(logged-out)/search/components/Search/Search.tsx
+++ b/src/app/[locale]/(logged-out)/search/components/Search/Search.tsx
@@ -298,7 +298,7 @@ const Search = ({ filters }: SearchProps) => {
 
     // Update the list of libraries
     const { data: libraryData, mutate: mutateLibraries } = useGet<Library[]>(
-        `${apis.librariesV1Url}?perPage=all`,
+        `${apis.librariesV1Url}?perPage=-1`,
         { shouldFetch: isLoggedIn }
     );
 

--- a/src/app/[locale]/account/team/[teamId]/(withLeftNav)/data-uses/[dataUseId]/components/EditDataUse.tsx
+++ b/src/app/[locale]/account/team/[teamId]/(withLeftNav)/data-uses/[dataUseId]/components/EditDataUse.tsx
@@ -46,7 +46,7 @@ const EditDataUse = () => {
     const { push } = useRouter();
 
     const { data: keywords } = useGet<Keyword[]>(
-        `${apis.keywordsV1Url}?perPage=all`
+        `${apis.keywordsV1Url}?perPage=-1`
     );
 
     const { data } = useGet<DataUse[]>(

--- a/src/app/[locale]/account/team/[teamId]/(withLeftNav)/tools/create/components/CreateTool/CreateTool.tsx
+++ b/src/app/[locale]/account/team/[teamId]/(withLeftNav)/tools/create/components/CreateTool/CreateTool.tsx
@@ -75,14 +75,14 @@ const CreateTool = ({ teamId, userId, toolId }: ToolCreateProps) => {
         });
 
     const { data: toolCategoryData } = useGet<Category[]>(
-        `${apis.toolCategoriesV1Url}?perPage=all`
+        `${apis.toolCategoriesV1Url}?perPage=-1`
     );
 
     const { data: programmingLanguageData } = useGet<ProgrammingLanguage[]>(
-        `${apis.programmingLanguagesV1Url}?perPage=all`
+        `${apis.programmingLanguagesV1Url}?perPage=-1`
     );
 
-    const { data: tagData } = useGet<Tag[]>(`${apis.tagsV1Url}?per_page=all`);
+    const { data: tagData } = useGet<Tag[]>(`${apis.tagsV1Url}?per_page=-1`);
 
     const { data: existingToolData } = useGet<Tool>(
         `${apis.toolsV1Url}/${toolId}`,

--- a/src/modules/DatasetRelationshipDialog/DatasetRelationshipDialog.tsx
+++ b/src/modules/DatasetRelationshipDialog/DatasetRelationshipDialog.tsx
@@ -46,7 +46,7 @@ const DatasetRelationshipDialog = ({
 
     // Update the list of libraries
     const { data: libraryData, mutate: mutateLibraries } = useGet<Library[]>(
-        `${apis.librariesV1Url}?perPage=all`,
+        `${apis.librariesV1Url}?perPage=-1`,
         { shouldFetch: isLoggedIn }
     );
 


### PR DESCRIPTION

## Screenshots (if relevant)

## Describe your changes
Make use of the changes in https://github.com/HDRUK/gateway-api-2/pull/683 to allow the FE to list _all_ of some things (like library entries, tag options), skipping the pagination, to stop the FE having to guess arbitrarily large numbers per page.

## Issue ticket link

## Checklist before requesting a review

-   [x] I have performed a self-review of my code
-   [ ] I have added appropriate unit tests
-   [ ] I have created mocks for unit tests (where appropriate)
-   [ ] The interface is responsive (where appropriate)
-   [ ] The interface is at least AA (where appropriate)
