### PR TITLE
fix/GAT-5101 Fix for publication display when no url

### DIFF
--- a/src/config/tables/addResources.tsx
+++ b/src/config/tables/addResources.tsx
@@ -32,15 +32,24 @@ const isResourceSelected = (
 };
 
 const getTitle = (data: ResourceDataType, resourceType: ResourceType) => {
-    const getLink = (url: string, text?: string) => (
-        <Link href={url} target="_blank">
-            <EllipsisLineLimit
-                maxLine={2}
-                text={text || EMPTY_VALUE}
-                showToolTip
-            />
-        </Link>
-    );
+    const getLink = (url?: string, text?: string) =>
+        url ? (
+            <Link href={url} target="_blank">
+                <EllipsisLineLimit
+                    maxLine={2}
+                    text={text || EMPTY_VALUE}
+                    showToolTip
+                />
+            </Link>
+        ) : (
+            <Typography>
+                <EllipsisLineLimit
+                    maxLine={2}
+                    text={text || EMPTY_VALUE}
+                    showToolTip
+                />
+            </Typography>
+        );
 
     const titleMap = {
         [ResourceType.DATASET]: () =>


### PR DESCRIPTION
## Screenshots (if relevant)
![image](https://github.com/user-attachments/assets/54fd766e-3770-4ecb-b3db-c44db39413f5)

## Describe your changes
Was blowing up on resource select modal when publication had no url 

## Issue ticket link
https://hdruk.atlassian.net/browse/GAT-5101

## Checklist before requesting a review

-   [ ] I have performed a self-review of my code
-   [ ] I have added appropriate unit tests
-   [ ] I have created mocks for unit tests (where appropriate)
-   [ ] The interface is responsive (where appropriate)
-   [ ] The interface is at least AA (where appropriate)
