### PR TITLE
GAT-5145: Change functionality of bookmark radio buttons

### DIFF
--- a/src/components/ActiveList/ActiveList.tsx
+++ b/src/components/ActiveList/ActiveList.tsx
@@ -51,6 +51,7 @@ const ActiveList = ({
                                     sx={{
                                         opacity:
                                             activeItem === index + 1 ? 1 : 0.3,
+                                        transition: "opacity 0.2s, lineBreak",
                                     }}
                                 />
                             }>

--- a/src/modules/ActiveListSidebar/ActiveListSidebar.tsx
+++ b/src/modules/ActiveListSidebar/ActiveListSidebar.tsx
@@ -1,9 +1,7 @@
 "use client";
 
-import { useCallback, useEffect, useState } from "react";
-import { toNumber } from "lodash";
+import { useCallback, useState } from "react";
 import { useTranslations } from "next-intl";
-import { useSearchParams } from "next/navigation";
 import ActiveList from "@/components/ActiveList";
 import {
     ActiveLinkWrapper,
@@ -21,26 +19,17 @@ const ActiveListSidebar = ({
     }[];
 }) => {
     const t = useTranslations(TRANSLATION_PATH);
-    const searchParams = useSearchParams();
 
-    const [activeItem, setActiveItem] = useState(1);
-
-    useEffect(() => {
-        if (!searchParams) {
-            return;
-        }
-
-        const sectionInView = searchParams.get("section");
-        if (sectionInView) {
-            setActiveItem(toNumber(sectionInView));
-        }
-    }, [searchParams]);
+    const [activeItem, setActiveItem] = useState(0);
 
     const handleScroll = useCallback((id: number) => {
         const section = document.querySelector(`#anchor${id}`);
         if (section) {
             section.scrollIntoView({ behavior: "smooth", block: "start" });
             setActiveItem(id);
+            setTimeout(() => {
+                setActiveItem(0);
+            }, 200);
         }
     }, []);
 


### PR DESCRIPTION
https://github.com/user-attachments/assets/b59a40ac-67b3-427e-80b3-19badd1c1385

The current functionality of the the radio buttons in the bookmark section is that the currently active item is dependent on which section is in view on the page. The problem with this is that If any page have any empty entities, there is always a possibility of one of the below sections being immediately in view. Therefore, the radio buttons are going to initially jump to the wrong section.

This PR changes the implementation of how they work and they become more of a selector to navigate to the right section, as opposed to reacting to whatever bottom most section is in view.

[## Issue ticket link](https://hdruk.atlassian.net/jira/software/c/projects/GAT/boards/51?assignee=712020%3A080e718f-ac9b-41ff-a347-37acb4b1b922&selectedIssue=GAT-5145)

## Checklist before requesting a review

-   [ ] I have performed a self-review of my code
-   [ ] I have added appropriate unit tests
-   [ ] I have created mocks for unit tests (where appropriate)
-   [ ] The interface is responsive (where appropriate)
-   [ ] The interface is at least AA (where appropriate)
