### PR TITLE
Fix: Remove call to toTitleCase and just capitalize

### DIFF
--- a/src/app/[locale]/(logged-out)/collection/[collectionId]/components/DatasetsContent/DatasetsContent.tsx
+++ b/src/app/[locale]/(logged-out)/collection/[collectionId]/components/DatasetsContent/DatasetsContent.tsx
@@ -8,7 +8,7 @@ import { usePathname, useRouter } from "next/navigation";
 import { Dataset } from "@/interfaces/Dataset";
 import { RouteName } from "@/consts/routeName";
 import { getLatestVersion } from "@/utils/dataset";
-import { capitalize } from "@/utils/string";
+import { capitalise } from "@/utils/general";
 import AccordionSection from "../AccordionSection";
 
 const TRANSLATION_PATH = "pages.collection.components.DatasetsContent";
@@ -76,7 +76,7 @@ export default function DatasetContent({
                                     })}
                                 </div>
                             )}
-                            <div>{capitalize(datasetType)}</div>
+                            <div>{capitalise(datasetType)}</div>
                         </Fragment>
                     )
                 )}

--- a/src/utils/string.ts
+++ b/src/utils/string.ts
@@ -4,13 +4,9 @@ const toTitleCase = (value: string) => {
     });
 };
 
-const capitalize = (value: string) => {
-    return value.charAt(0).toUpperCase() + value.slice(1);
-};
-
 const getLastSplitPart = (input: string, delimiter: string): string => {
     const parts = input.split(delimiter);
     return parts[parts.length - 1];
 };
 
-export { toTitleCase, getLastSplitPart, capitalize };
+export { toTitleCase, getLastSplitPart };


### PR DESCRIPTION
<img width="778" alt="Screenshot 2024-09-26 at 23 14 33" src="https://github.com/user-attachments/assets/a4a1a957-93d3-4fcd-9a71-c9c347109084">

Fixes a bug where the datasetType for datasets on the collection page was outputting in the wrong format due to toTitleCase method. This removes that call and instead just capitalises the string.

[## Issue ticket link](https://hdruk.atlassian.net/jira/software/c/projects/GAT/boards/51?assignee=712020%3A080e718f-ac9b-41ff-a347-37acb4b1b922&selectedIssue=GAT-5147)

## Checklist before requesting a review

-   [ ] I have performed a self-review of my code
-   [ ] I have added appropriate unit tests
-   [ ] I have created mocks for unit tests (where appropriate)
-   [ ] The interface is responsive (where appropriate)
-   [ ] The interface is at least AA (where appropriate)
