### PR TITLE
fix - visit cohort discovery

### DIFF
--- a/src/app/[locale]/(logged-out)/about/cohort-discovery/components/CtaOverride/CtaOverride.tsx
+++ b/src/app/[locale]/(logged-out)/about/cohort-discovery/components/CtaOverride/CtaOverride.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import { useEffect, useState } from "react";
+import { useState } from "react";
 import { Box } from "@mui/material";
 import { useRouter } from "next/navigation";
 import { CtaLink } from "@/interfaces/Cms";


### PR DESCRIPTION
## Screenshots (if relevant)

## Describe your changes
As the API is of a different sub domain, its classed as a different origin, the call to the api is a client side call, so the client side must handle the redirect, if this needs to be a serverside redirect, then this needs to be made not a client side call but a nextjs serverside call to the gatewayAPI.


## Issue ticket link

## Checklist before requesting a review

-   [ ] I have performed a self-review of my code
-   [ ] I have added appropriate unit tests
-   [ ] I have created mocks for unit tests (where appropriate)
-   [ ] The interface is responsive (where appropriate)
-   [ ] The interface is at least AA (where appropriate)
