### PR TITLE
bugfix:gat-5292 Apply team permissions to Publications page.

### DIFF
--- a/src/app/[locale]/account/team/[teamId]/(withLeftNav)/publications/page.tsx
+++ b/src/app/[locale]/account/team/[teamId]/(withLeftNav)/publications/page.tsx
@@ -1,7 +1,8 @@
 import { cookies } from "next/headers";
 import ProtectedAccountRoute from "@/components/ProtectedAccountRoute";
-import { getUser } from "@/utils/api";
+import { getTeam, getUser } from "@/utils/api";
 import { getPermissions } from "@/utils/permissions";
+import { getTeamUser } from "@/utils/user";
 import UserPublications from "@/app/[locale]/account/profile/publications/components/UserPublications";
 
 export const metadata = {
@@ -17,7 +18,9 @@ export default async function UserPublicationsPage({
     const { teamId } = params;
     const cookieStore = cookies();
     const user = await getUser(cookieStore);
-    const permissions = getPermissions(user.roles);
+    const team = await getTeam(cookieStore, teamId);
+    const teamUser = getTeamUser(team?.users, user?.id);
+    const permissions = getPermissions(user.roles, teamUser?.roles);
     const userId = user?.id?.toString();
 
     return (


### PR DESCRIPTION
## Screenshots (if relevant)

## Describe your changes
Applies team permissions checks to Publications page when navigating from team profile, so that user doesn't get a 403 when navigating to it. This fix is consistent with other pages e.g. Data Uses and Tools.

## Issue ticket link
https://hdruk.atlassian.net/browse/GAT-5292

## Checklist before requesting a review

-   [ ] I have performed a self-review of my code
-   [ ] I have added appropriate unit tests
-   [ ] I have created mocks for unit tests (where appropriate)
-   [ ] The interface is responsive (where appropriate)
-   [ ] The interface is at least AA (where appropriate)
