### PR TITLE
Bugfix: user publications regression

### DIFF
--- a/src/app/[locale]/account/profile/publications/components/UserPublications.tsx
+++ b/src/app/[locale]/account/profile/publications/components/UserPublications.tsx
@@ -66,7 +66,7 @@ const UserPublications = ({
         page: "1",
         sort: `${publicationSearchDefaultValues.sortField}:${initialSort.initialDirection}`,
         paper_title: "",
-        ...(teamId ? { team_id: teamId } : { owner_id: 1 }),
+        ...(teamId ? { team_id: teamId } : { owner_id: userId }),
     }));
 
     const { control, watch, setValue } = useForm({


### PR DESCRIPTION
Fix a regression - users were seeing _all_ publications in their profile view, rather than their owned publications.

## Screenshots (if relevant)

## Describe your changes

## Issue ticket link

## Checklist before requesting a review

-   [x] I have performed a self-review of my code
-   [ ] I have added appropriate unit tests
-   [ ] I have created mocks for unit tests (where appropriate)
-   [ ] The interface is responsive (where appropriate)
-   [ ] The interface is at least AA (where appropriate)
