### PR TITLE
fix: add tags when creating or editting tools

### DIFF
--- a/src/components/Autocomplete/Autocomplete.tsx
+++ b/src/components/Autocomplete/Autocomplete.tsx
@@ -141,6 +141,7 @@ const Autocomplete = <T extends FieldValues>(props: AutocompleteProps<T>) => {
                             typeof getChipLabel === "function"
                                 ? getChipLabel(options, option)
                                 : option?.label || `${option}`;
+
                         return (
                             <Chip
                                 label={chipLabel || ""}

--- a/src/components/Autocomplete/utils.ts
+++ b/src/components/Autocomplete/utils.ts
@@ -1,0 +1,14 @@
+import { ValueType } from "./Autocomplete";
+
+const getChipLabel = (
+    options: { value: string | number; label: string }[],
+    value: ValueType
+) => {
+    if (typeof value === "string") {
+        return value;
+    }
+
+    return options.find(option => option.value === value)?.label;
+};
+
+export { getChipLabel };

--- a/src/config/forms/application.tsx
+++ b/src/config/forms/application.tsx
@@ -1,5 +1,6 @@
 import * as yup from "yup";
 import { ApplicationForm } from "@/interfaces/Application";
+import { getChipLabel } from "@/components/Autocomplete/utils";
 import { REGEX_ALPHA_NUMERIC_ONLY } from "@/consts/regex";
 import { inputComponents } from ".";
 
@@ -58,10 +59,7 @@ const formFields = [
             option: { value: string | number; label: string },
             value: string | number
         ) => option.value === value,
-        getChipLabel: (
-            options: { value: string | number; label: string }[],
-            value: unknown
-        ) => options.find(option => option.value === value)?.label,
+        getChipLabel,
         component: inputComponents.Autocomplete,
         info: "Identify which team members should receive notifications related to this Private App. Select from the drop-down list.",
     },

--- a/src/config/forms/integration.tsx
+++ b/src/config/forms/integration.tsx
@@ -1,5 +1,6 @@
 import * as yup from "yup";
 import { AuthType, IntegrationForm } from "@/interfaces/Integration";
+import { getChipLabel } from "@/components/Autocomplete/utils";
 import { authTypes, federationTypes } from "@/consts/integrations";
 import { requiresSecretKey } from "@/utils/integrations";
 import { inputComponents } from ".";
@@ -112,10 +113,7 @@ const formFields = [
             option: { value: string | number; label: string },
             value: string | number
         ) => option.value === value,
-        getChipLabel: (
-            options: { value: string | number; label: string }[],
-            value: unknown
-        ) => options.find(option => option.value === value)?.label,
+        getChipLabel,
         component: inputComponents.Autocomplete,
         info: "Email address for people who should receive notifications related to integration. Use ‘tab’ or ‘enter’ to add another email address if adding more than one",
     },

--- a/src/config/forms/team.tsx
+++ b/src/config/forms/team.tsx
@@ -1,5 +1,6 @@
 import * as yup from "yup";
 import { TeamForm } from "@/interfaces/Team";
+import { getChipLabel } from "@/components/Autocomplete/utils";
 import { memberOfOptions } from "@/consts/team";
 import { inputComponents } from ".";
 
@@ -69,10 +70,7 @@ const formFields = [
             option: { value: string | number; label: string },
             value: string | number
         ) => option.value === value,
-        getChipLabel: (
-            options: { value: string | number; label: string }[],
-            value: unknown
-        ) => options.find(option => option.value === value)?.label,
+        getChipLabel,
         component: inputComponents.Autocomplete,
         info: "Assign at least one team admin. A team admin will be able to manage members, add new team members and manage the team notification preferences.",
     },

--- a/src/config/forms/tool.tsx
+++ b/src/config/forms/tool.tsx
@@ -1,4 +1,5 @@
 import * as yup from "yup";
+import { getChipLabel } from "@/components/Autocomplete/utils";
 import { inputComponents } from ".";
 
 const defaultDatasetValue = [
@@ -133,16 +134,16 @@ const formFields = [
         info: "Technological paradigms or other keywords, eg. rule-based, clustering, supervised machine learning",
         name: "keywords",
         component: inputComponents.Autocomplete,
-        // canCreate: true,
+        canCreate: true,
         multiple: true,
+        selectOnFocus: true,
+        clearOnBlur: true,
+        handleHomeEndKeys: true,
         isOptionEqualToValue: (
             option: { value: string | number; label: string },
             value: string | number
         ) => option.value === value,
-        getChipLabel: (
-            options: { value: string | number; label: string }[],
-            value: unknown
-        ) => options.find(option => option.value === value)?.label,
+        getChipLabel,
     },
     {
         label: "DATASET_RELATIONSHIP_COMPONENT",


### PR DESCRIPTION
## Screenshots (if relevant)

## Describe your changes
Adds capability to create a tag when using autocomplete in create and update tools forms

## Issue ticket link
https://hdruk.atlassian.net/browse/GAT-5049

## Checklist before requesting a review

-   [x] I have performed a self-review of my code
-   [ ] I have added appropriate unit tests
-   [ ] I have created mocks for unit tests (where appropriate)
-   [ ] The interface is responsive (where appropriate)
-   [ ] The interface is at least AA (where appropriate)
