### PR TITLE
Fix: Teams logo image upload

### DIFF
--- a/src/app/[locale]/account/profile/teams/components/CreateTeamForm/CreateTeamForm.tsx
+++ b/src/app/[locale]/account/profile/teams/components/CreateTeamForm/CreateTeamForm.tsx
@@ -39,7 +39,7 @@ const CreateIntegrationForm = () => {
         teamId: string;
     }>();
     const t = useTranslations();
-    const [fileNotUploaded, setFileNotUploaded] = useState(false);
+    const [fileWarning, setFileWarning] = useState(false);
     const [imageUploaded, setImageUploaded] = useState(false);
     const [file, setFile] = useState<File>();
     const [createdTeamId, setCreatedTeamId] = useState<string | undefined>(
@@ -247,7 +247,7 @@ const CreateIntegrationForm = () => {
                                           )
                                 }
                                 error={
-                                    fileNotUploaded
+                                    fileWarning
                                         ? {
                                               type: "",
                                               message: t(
@@ -274,15 +274,14 @@ const CreateIntegrationForm = () => {
                                         );
                                     }}
                                     onFileChange={(file: File) => {
-                                        setFileNotUploaded(false);
                                         setFile(file);
+                                        setFileWarning(false);
                                     }}
                                     onFileCheckSucceeded={() => {
                                         setImageUploaded(true);
-                                        setFileNotUploaded(false);
                                     }}
                                     onFileCheckFailed={() => {
-                                        setFileNotUploaded(true);
+                                        setFileWarning(true);
                                     }}
                                     sx={{ py: 2 }}
                                     showUploadButton={false}

--- a/src/components/UploadFile/UploadFile.tsx
+++ b/src/components/UploadFile/UploadFile.tsx
@@ -193,10 +193,9 @@ const UploadFile = ({
                             onFileChange={(file: File) => {
                                 if (file.type.startsWith("image/")) {
                                     imageValidation(file).then(result => {
-                                        if (result) {
-                                            setFile(file);
-                                            onFileChange?.(file);
-                                        } else {
+                                        setFile(file);
+                                        onFileChange?.(file);
+                                        if (!result) {
                                             onFileCheckFailed?.();
                                         }
                                     });

--- a/src/config/messages/en.json
+++ b/src/config/messages/en.json
@@ -265,8 +265,8 @@
                         "backButton": "Back to Teams list",
                         "title": "Add Team’s details",
                         "text": "Add details of the data publisher team you want to create on the Gateway",
-                        "aspectRatioInfo": "Please note the aspect ratio of the image must be approximately 2:1 (width:height)",
-                        "aspectRatioError": "File needs to be of approximately of aspect ratio 2:1 (width:height)",
+                        "aspectRatioInfo": "Please note the aspect ratio of the image should be approximately 2:1 (width:height)",
+                        "aspectRatioError": "Warning: File should approximately have an aspect ratio of 2:1 (width:height)",
                         "addImageSuccess": "Image Uploaded",
                         "fileSelectButtonText": "Choose logo"
                     },


### PR DESCRIPTION
## Screenshots (if relevant)

A couple tweaks to the upload image functionality for creating a team. Including making the ratio checks a tiny bit more forgiving and changing the entity flag so the file is correctly scanned and uploaded

## Issue ticket link

## Checklist before requesting a review

-   [ ] I have performed a self-review of my code
-   [ ] I have added appropriate unit tests
-   [ ] I have created mocks for unit tests (where appropriate)
-   [ ] The interface is responsive (where appropriate)
-   [ ] The interface is at least AA (where appropriate)
