### PR TITLE
adds in missing web and service url fields

### DIFF
--- a/src/config/forms/team.tsx
+++ b/src/config/forms/team.tsx
@@ -81,6 +81,18 @@ const formFields = [
         info: "Please provide a valid email address that can be used as a default.",
         component: inputComponents.TextField,
     },
+    {
+        label: "Website URL",
+        name: "url",
+        info: "Provide a valid URL to your own website.",
+        component: inputComponents.TextField,
+    },
+    {
+        label: "Service URL",
+        name: "service",
+        info: "Provide a valid URL to services offered.",
+        component: inputComponents.TextField,
+    },
 ];
 
 export {


### PR DESCRIPTION
## Screenshots (if relevant)
<img width="1134" alt="image" src="https://github.com/user-attachments/assets/1aaa0742-6d2f-4324-b249-cc98637e5de6">

## Describe your changes
Web and service URL fields were missing from the team administration form

## Issue ticket link
N/A

## Checklist before requesting a review

-   [x] I have performed a self-review of my code
-   [ ] I have added appropriate unit tests
-   [ ] I have created mocks for unit tests (where appropriate)
-   [ ] The interface is responsive (where appropriate)
-   [ ] The interface is at least AA (where appropriate)
