### PR TITLE
fix: lock alpine version

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM node:alpine
+FROM node:22.10.0-alpine
 
 RUN mkdir -p /usr/src
 WORKDIR /usr/src


### PR DESCRIPTION
## Screenshots (if relevant)

## Describe your changes
Locks node / alpine version - fixes error with webpack pack in .next cache dir

## Issue ticket link

## Checklist before requesting a review

-   [x] I have performed a self-review of my code
-   [ ] I have added appropriate unit tests
-   [ ] I have created mocks for unit tests (where appropriate)
-   [ ] The interface is responsive (where appropriate)
-   [ ] The interface is at least AA (where appropriate)
