### PR TITLE
Display existing dataset linkage titles correctly

### DIFF
--- a/src/app/[locale]/account/profile/publications/components/CreatePublication/CreatePublication.tsx
+++ b/src/app/[locale]/account/profile/publications/components/CreatePublication/CreatePublication.tsx
@@ -133,8 +133,18 @@ const CreatePublication = ({
             return;
         }
 
+        const formattedDatasets = existingPublicationData.datasets?.length
+            ? existingPublicationData.datasets.map(d => ({
+                  link_type: d.link_type,
+                  value: d.id,
+                  label: d.name,
+                  id: d.id,
+              }))
+            : defaultDatasetValue;
+
         const formData = {
             ...existingPublicationData,
+            datasets: formattedDatasets,
         };
 
         const propertiesToDelete = ["publication_type_mk1", "mongo_id"];

--- a/src/app/[locale]/account/profile/publications/components/DatasetRelationshipFields/DatasetRelationshipFields.tsx
+++ b/src/app/[locale]/account/profile/publications/components/DatasetRelationshipFields/DatasetRelationshipFields.tsx
@@ -64,9 +64,19 @@ const DatasetRelationshipFields = <TFieldValues extends FieldValues>({
     });
 
     const datasetOptions = useMemo(() => {
-        if (!datasetData) return [];
+        const fieldsToOptions = fields.reduce((acc, data) => {
+            if (data.link_type) {
+                acc.push({
+                    label: data.label,
+                    value: data.value,
+                });
+            }
+            return acc;
+        }, [] as OptionsType[]);
 
-        return datasetData.map(data => {
+        if (!datasetData) return fieldsToOptions;
+
+        const datasetToOptions = datasetData.map(data => {
             return {
                 label: get(
                     data,
@@ -75,7 +85,18 @@ const DatasetRelationshipFields = <TFieldValues extends FieldValues>({
                 value: data.id,
             };
         }) as OptionsType[];
-    }, [datasetData]);
+
+        // Concatenate and remove value duplicates
+        const combinedOptions = [
+            ...fieldsToOptions,
+            ...datasetToOptions,
+        ].filter(
+            (option, index, self) =>
+                index === self.findIndex(o => o.value === option.value)
+        );
+
+        return combinedOptions;
+    }, [datasetData, fields]);
 
     const [relationshipField, datasetTitleField] = publicationFormArrayFields;
 


### PR DESCRIPTION
## Screenshots (if relevant)
![image](https://github.com/user-attachments/assets/9d4df832-acae-4811-8468-983692a88b0a)

## Describe your changes
Adds existing dataset linakges to the options on load, so titles display correctly 

## Issue ticket link
https://hdruk.atlassian.net/browse/GAT-5491

## Checklist before requesting a review

-   [ ] I have performed a self-review of my code
-   [ ] I have added appropriate unit tests
-   [ ] I have created mocks for unit tests (where appropriate)
-   [ ] The interface is responsive (where appropriate)
-   [ ] The interface is at least AA (where appropriate)
