### PR TITLE
Fix/Pass view type mini for get collections endpoint on collection form

### DIFF
--- a/src/components/CollectionForm/CollectionForm.tsx
+++ b/src/components/CollectionForm/CollectionForm.tsx
@@ -102,10 +102,9 @@ const CollectionForm = ({
     );
 
     const { data: existingCollectionData } = useGet<Collection>(
-        `${apis.collectionsV1Url}/${collectionId}`,
+        `${apis.collectionsV1Url}/${collectionId}?view_type=mini`,
         { shouldFetch: !!collectionId }
     );
-
     const createCollection = usePost<CollectionSubmission>(
         apis.collectionsV1Url,
         { itemName: "Collection", successNotificationsOn: !file }


### PR DESCRIPTION
## Screenshots (if relevant)

Not all the data returned from the get currecnt collection endpoint is required, so instead we pass through the view_type=mini parameter to the backend

## Issue ticket link

## Checklist before requesting a review

-   [ ] I have performed a self-review of my code
-   [ ] I have added appropriate unit tests
-   [ ] I have created mocks for unit tests (where appropriate)
-   [ ] The interface is responsive (where appropriate)
-   [ ] The interface is at least AA (where appropriate)
