### PR TITLE
Feature/pop size labels

### DIFF
--- a/src/components/BarSlider/BarSlider.tsx
+++ b/src/components/BarSlider/BarSlider.tsx
@@ -150,22 +150,25 @@ const BarSliderContainer = ({
         }
     };
 
-    const humanReadableFormat = (value?: number) => {
-        const units = ['', 'k', 'mn', 'bn'];
+    const humanReadableFormat = (values?: (number | undefined)[]) => {
+        const readableValues = values?.map(value => {
+            const units = ["", "k", "mn", "bn"];
 
-        let unitIndex = 0;
-        let scaledValue = value || 1;
+            let unitIndex = 0;
+            let scaledValue = value || 1;
 
-        while (scaledValue >= 1000 && unitIndex < units.length - 1) {
-            unitIndex += 1;
-            scaledValue /= 1000;
-        }
+            while (scaledValue >= 1000 && unitIndex < units.length - 1) {
+                unitIndex += 1;
+                scaledValue /= 1000;
+            }
 
-        return `${scaledValue} ${units[unitIndex]}`;
-    }
+            return `${scaledValue} ${units[unitIndex]}`;
+        });
+        return readableValues;
+    };
 
     const valueLabelFormat = (value: number) => {
-        const [, high] = [humanReadableFormat(data[value - 1]?.xValue[0]), humanReadableFormat(data[value - 1]?.xValue[1])] || [1, 1];
+        const [, high] = humanReadableFormat(data[value - 1]?.xValue) || [1, 1];
         return high;
     };
 

--- a/src/components/BarSlider/BarSlider.tsx
+++ b/src/components/BarSlider/BarSlider.tsx
@@ -154,7 +154,7 @@ const BarSliderContainer = ({
         const units = ['', 'k', 'mn', 'bn'];
 
         let unitIndex = 0;
-        let scaledValue = value || 0;
+        let scaledValue = value || 1;
 
         while (scaledValue >= 1000 && unitIndex < units.length - 1) {
             unitIndex += 1;

--- a/src/components/BarSlider/BarSlider.tsx
+++ b/src/components/BarSlider/BarSlider.tsx
@@ -150,8 +150,22 @@ const BarSliderContainer = ({
         }
     };
 
+    const humanReadableFormat = (value?: number) => {
+        const units = ['', 'k', 'mn', 'bn'];
+
+        let unitIndex = 0;
+        let scaledValue = value || 0;
+
+        while (scaledValue >= 1000 && unitIndex < units.length - 1) {
+            unitIndex += 1;
+            scaledValue /= 1000;
+        }
+
+        return `${scaledValue} ${units[unitIndex]}`;
+    }
+
     const valueLabelFormat = (value: number) => {
-        const [, high] = data[value - 1]?.xValue || [1, 1];
+        const [, high] = [humanReadableFormat(data[value - 1]?.xValue[0]), humanReadableFormat(data[value - 1]?.xValue[1])] || [1, 1];
         return high;
     };
 

--- a/src/components/BarSlider/__snapshots__/BarSlider.test.tsx.snap
+++ b/src/components/BarSlider/__snapshots__/BarSlider.test.tsx.snap
@@ -54,7 +54,7 @@ exports[`BarSlider should render component 1`] = `
           <span
             class="MuiSlider-valueLabelLabel"
           >
-            1 
+            1
           </span>
         </span>
       </span>

--- a/src/components/BarSlider/__snapshots__/BarSlider.test.tsx.snap
+++ b/src/components/BarSlider/__snapshots__/BarSlider.test.tsx.snap
@@ -54,7 +54,7 @@ exports[`BarSlider should render component 1`] = `
           <span
             class="MuiSlider-valueLabelLabel"
           >
-            1
+            1 
           </span>
         </span>
       </span>
@@ -89,7 +89,7 @@ exports[`BarSlider should render component 1`] = `
           <span
             class="MuiSlider-valueLabelLabel"
           >
-            10000
+            10 k
           </span>
         </span>
       </span>


### PR DESCRIPTION
## Screenshots (if relevant)

https://github.com/user-attachments/assets/25487e34-4b33-4c97-ad42-9137f7110789

## Describe your changes
Shows human-readable abbreviations for population sizes ('k', 'mn', 'bn') in tooltip on population size slider.

## Issue ticket link

## Checklist before requesting a review

-   [x] I have performed a self-review of my code
-   [x] I have added appropriate unit tests
-   [ ] I have created mocks for unit tests (where appropriate)
-   [ ] The interface is responsive (where appropriate)
-   [ ] The interface is at least AA (where appropriate)
