### PR TITLE
fix - GAT-5679 - Disable/Racecondition

### DIFF
--- a/src/app/[locale]/(logged-out)/about/cohort-discovery/components/CtaOverride/CtaOverride.tsx
+++ b/src/app/[locale]/(logged-out)/about/cohort-discovery/components/CtaOverride/CtaOverride.tsx
@@ -55,12 +55,10 @@ const CtaOverride = ({ ctaLink }: { ctaLink: CtaLink }) => {
         }
     }, [accessData, isClicked, isLoggedIn]);
 
-    const isDisabled = !(
+    const isDisabled =
         !isLoggedIn ||
-        (isLoggedIn && userData === null) ||
-        (isLoggedIn && userData?.request_status === "APPROVED")
-    );
-
+        (isLoggedIn && (userData === undefined || userData === null)) ||
+        (isLoggedIn && userData?.request_status !== "APPROVED");
     return (
         <Box sx={{ display: "flex" }}>
             <Tooltip title={isDisabled ? t(`notApproved`) : ""}>


### PR DESCRIPTION
## Screenshots (if relevant)

## Describe your changes
Amended the logic, been over it with Charlotte 
the button should be disabled if:

1. a user is not logged in.
2. user is logged in, but we have no userData back
3. if the user is logged in, we have userData but there request_status is not equal to “APPROVED”

## Issue ticket link

## Checklist before requesting a review

-   [ ] I have performed a self-review of my code
-   [ ] I have added appropriate unit tests
-   [ ] I have created mocks for unit tests (where appropriate)
-   [ ] The interface is responsive (where appropriate)
-   [ ] The interface is at least AA (where appropriate)
