### PR TITLE
fix - sitemap generator

### DIFF
--- a/sitemap-seeder.ts
+++ b/sitemap-seeder.ts
@@ -16,7 +16,7 @@ if (NODE_ENV === 'development') {
 
 const { NEXT_PUBLIC_API_VERSION, NEXT_PUBLIC_API_V1_URL, NEXT_PUBLIC_GATEWAY_URL} = process.env
 const version = NEXT_PUBLIC_API_VERSION ?? 'v1'
-domain = domain ??`${NEXT_PUBLIC_GATEWAY_URL}/${locale}`
+domain = domain ?? `${NEXT_PUBLIC_GATEWAY_URL}/${locale}`
 
 const siteMapAPI = address ?? `${NEXT_PUBLIC_API_V1_URL}/${version}/${endpoint}`;
 

--- a/sitemap-seeder.ts
+++ b/sitemap-seeder.ts
@@ -5,18 +5,21 @@ const {NODE_ENV} = process.env
 const endpoint = 'sitemap'
 
 let address
+let domain
+const locale ='en'
 
 if (NODE_ENV === 'development') {
     // during the loading of docker in tilt, it can't seem to talk to gateway-api so for locally just call dev
     address = 'https://api.dev.hdruk.cloud/api/v1/' + endpoint
+    domain = `https://dev.hdruk.cloud/${locale}`
 }
 
 const { NEXT_PUBLIC_API_VERSION, NEXT_PUBLIC_API_V1_URL, NEXT_PUBLIC_GATEWAY_URL} = process.env
 const version = NEXT_PUBLIC_API_VERSION ?? 'v1'
+domain = domain ??`${NEXT_PUBLIC_GATEWAY_URL}/${locale}`
 
 const siteMapAPI = address ?? `${NEXT_PUBLIC_API_V1_URL}/${version}/${endpoint}`;
 
-const domain = `${NEXT_PUBLIC_GATEWAY_URL}/en`;
 const startingDir = "./src/app/[locale]/(logged-out)";
 const fileName = "page";
 const ext = ".tsx";

--- a/sitemap-seeder.ts
+++ b/sitemap-seeder.ts
@@ -1,5 +1,6 @@
 import fs from 'fs'
-
+import { MetadataRoute } from "next";
+import path from "path";
 const {NODE_ENV} = process.env
 const endpoint = 'sitemap'
 
@@ -7,14 +8,23 @@ let address
 
 if (NODE_ENV === 'development') {
     // during the loading of docker in tilt, it can't seem to talk to gateway-api so for locally just call dev
-    address = 'https://api.dev.hdruk.cloud/api/v1/'+endpoint
+    address = 'https://api.dev.hdruk.cloud/api/v1/' + endpoint
 }
 
-const { NEXT_PUBLIC_API_VERSION, NEXT_PUBLIC_API_V1_URL} = process.env
+const { NEXT_PUBLIC_API_VERSION, NEXT_PUBLIC_API_V1_URL, NEXT_PUBLIC_GATEWAY_URL} = process.env
 const version = NEXT_PUBLIC_API_VERSION ?? 'v1'
 
 const siteMapAPI = address ?? `${NEXT_PUBLIC_API_V1_URL}/${version}/${endpoint}`;
 
+const domain = `${NEXT_PUBLIC_GATEWAY_URL}/en`;
+const startingDir = "./src/app/[locale]/(logged-out)";
+const fileName = "page";
+const ext = ".tsx";
+const exclusions = ["search", "sign-in"];
+const staticRoutesConfig = {
+    changeFrequency: "monthly",
+    priority: 0.8,
+};
 
 const getSiteMapData:() => Promise<void> = async () => {
 
@@ -24,9 +34,21 @@ const getSiteMapData:() => Promise<void> = async () => {
                 throw new Error("Failed to fetch data for sitemap");
             }
             console.log('Data okay for sitemap')
+            const staticData = await findUrlInFiles()
+            const sitemapData = {
+            ...await res.json(),
+            static: [
+                {
+                    url: domain,
+                    changeFrequency: "Monthly",
+                    priority: 1,
+                },
+                ...staticData
+            ]
+            }
             fs.writeFile(
                 'src/seeded/sitemap.json',
-                JSON.stringify(await res.json()),
+                JSON.stringify(sitemapData),
                 (err) => {
                     if (err) {
                         console.log('Error writing file:', err)
@@ -41,6 +63,53 @@ const getSiteMapData:() => Promise<void> = async () => {
   catch(err) {
     console.log(`failed to call ${siteMapAPI}:`, err)
    };
+}
+
+
+const findUrlInFiles: () => Promise<MetadataRoute.Sitemap[]> = async(
+    dir: string = startingDir
+) => {
+    const items = await fs.promises.readdir(dir, { withFileTypes: true });
+
+    const promises = items.map(async item => {
+        const fullPath = path.join(dir, item.name);
+
+        if (item.isDirectory()) {
+            return findUrlInFiles(fullPath);
+        }
+        const fullFileName = fileName + ext;
+        if (item.name === fullFileName && path.extname(item.name) === ext) {
+            const url = fullPath
+                .replace("src/app/[locale]/(logged-out)", domain)
+                .replace("/page.tsx", "");
+
+            if (
+                url.includes("[") ||
+                url.includes("(") ||
+                exclusions.includes(
+                    fullPath
+                        .replace("src/app/[locale]/(logged-out)", "")
+                        .replace("/page.tsx", "")
+                        .replace("/", "")
+                )
+            ) {
+                console.log("dynamic route avoided for:", fullPath);
+                return [];
+            }
+            return [
+                {
+                    url,
+                    ...staticRoutesConfig,
+                },
+            ];
+        }
+
+        return [];
+    });
+
+    const resolvedResults = await Promise.all(promises);
+
+    return resolvedResults.flat() as MetadataRoute.Sitemap[];
 }
 
 getSiteMapData()

--- a/src/seeded/sitemap.json
+++ b/src/seeded/sitemap.json
@@ -1,20 +1,23 @@
 {
-    "collections": [
-     
-    ],
-    "dataCustodians": [
-     
-    ],
-    "dataCustodianNetworks": [
-      
-    ],
-    "dataSets": [
-     
-    ],
-    "durs": [
-    
-    ],
-    "tools": [
+  "collections": [
    
-    ]
-  }
+  ],
+  "dataCustodians": [
+   
+  ],
+  "dataCustodianNetworks": [
+    
+  ],
+  "dataSets": [
+   
+  ],
+  "durs": [
+  
+  ],
+  "tools": [
+ 
+  ],
+  "static": [
+ 
+  ]
+}


### PR DESCRIPTION
## Screenshots (if relevant)

## Describe your changes
Moved the generation of the static pages sitemap data to the seeder, there is no need for this to be ran everytime if it will only ever be changed once a build has happened, so run it in seeder.
## Issue ticket link

## Checklist before requesting a review

-   [ ] I have performed a self-review of my code
-   [ ] I have added appropriate unit tests
-   [ ] I have created mocks for unit tests (where appropriate)
-   [ ] The interface is responsive (where appropriate)
-   [ ] The interface is at least AA (where appropriate)
