### PR TITLE
Fix: collaborator box hydration

### DIFF
--- a/src/components/CollectionForm/CollectionForm.tsx
+++ b/src/components/CollectionForm/CollectionForm.tsx
@@ -180,7 +180,11 @@ const CollectionForm = ({
         };
 
         const collaborators =
-            existingCollectionData?.users?.slice(1).map(item => item.id) || [];
+            existingCollectionData?.users
+                ?.filter(item => item.pivot.role !== "CREATOR")
+                .map(item => {
+                    return item.id;
+                }) || [];
 
         const formData = {
             ...existingCollectionData,
@@ -196,12 +200,14 @@ const CollectionForm = ({
         };
 
         if (collaborators) {
-            const labels = existingCollectionData?.users?.slice(1).map(item => {
-                return {
-                    label: `${item.name} (${item.email})`,
-                    value: item.id,
-                };
-            });
+            const labels = existingCollectionData?.users
+                ?.filter(item => item.pivot.role !== "CREATOR")
+                .map(item => {
+                    return {
+                        label: `${item.name} (${item.email})`,
+                        value: item.id,
+                    };
+                });
             setUserOptions(labels);
         }
 


### PR DESCRIPTION
## Screenshots (if relevant)

## Describe your changes
Correct the code that excludes the CREATOR from list of collaborators - we can't rely on the ordering that the old code did.

Bug only shows up if a user adds as collaborator a user with a lower `user_id` than themselves!

## Issue ticket link

## Checklist before requesting a review

-   [x] I have performed a self-review of my code
-   [ ] I have added appropriate unit tests
-   [ ] I have created mocks for unit tests (where appropriate)
-   [ ] The interface is responsive (where appropriate)
-   [ ] The interface is at least AA (where appropriate)
