### PR TITLE
fix: GAT-5801 - Description validation when blank

### DIFF
--- a/src/config/forms/collection.tsx
+++ b/src/config/forms/collection.tsx
@@ -4,7 +4,7 @@ import { inputComponents } from ".";
 
 const defaultValues = {
     name: "",
-    description: "",
+    description: '{"type":"doc","content":[{"type":"paragraph"}]}',
     id: "",
     image_link: "",
     keywords: [],

--- a/src/config/forms/collection.tsx
+++ b/src/config/forms/collection.tsx
@@ -4,7 +4,7 @@ import { inputComponents } from ".";
 
 const defaultValues = {
     name: "",
-    description: "",
+    description: '{"type":"doc","content":[{"type":"paragraph"}]}',
     id: "",
     image_link: "",
     keywords: [],
@@ -18,7 +18,7 @@ const defaultValues = {
 const validationSchema = yup.object().shape({
     name: yup.string().required().min(2).label("Collection name"),
     keywords: yup.array().of(yup.string()).label("Keywords (optional)"),
-    description: yup.string().optional(),
+    description: yup.string().min(2).max(5000).required().label("Description"),
     collaborators: yup
         .array()
         .of(yup.string())

--- a/src/config/forms/collection.tsx
+++ b/src/config/forms/collection.tsx
@@ -4,7 +4,7 @@ import { inputComponents } from ".";
 
 const defaultValues = {
     name: "",
-    description: '{"type":"doc","content":[{"type":"paragraph"}]}',
+    description: "",
     id: "",
     image_link: "",
     keywords: [],
@@ -18,7 +18,7 @@ const defaultValues = {
 const validationSchema = yup.object().shape({
     name: yup.string().required().min(2).label("Collection name"),
     keywords: yup.array().of(yup.string()).label("Keywords (optional)"),
-    description: yup.string().min(2).max(5000).required().label("Description"),
+    description: yup.string().optional(),
     collaborators: yup
         .array()
         .of(yup.string())


### PR DESCRIPTION
## Screenshots (if relevant)

## Describe your changes
Error message never actually appears because wysiwyg is not an input field so yup has no idea where to show the error.

2 ways to fix, it either becomes optional, or we default the value with an empty paragraph (this is actually what happens to it when you click into it, see line 46 of wysiwyg.tsx, seems too specific to be a "bug") defaulting the value seems the safer option as imagine if we allow empty values in, it may blow up elsewhere.

## Issue ticket link
https://hdruk.atlassian.net/browse/GAT-5801
## Checklist before requesting a review

-   [x] I have performed a self-review of my code
-   [ ] I have added appropriate unit tests
-   [ ] I have created mocks for unit tests (where appropriate)
-   [ ] The interface is responsive (where appropriate)
-   [ ] The interface is at least AA (where appropriate)
