### PR TITLE
feat: (GAT-5697) - Added in link to data-custodian

### DIFF
--- a/src/app/[locale]/(logged-out)/search/components/ResultCard/ResultCard.tsx
+++ b/src/app/[locale]/(logged-out)/search/components/ResultCard/ResultCard.tsx
@@ -10,6 +10,7 @@ import { Library, NewLibrary } from "@/interfaces/Library";
 import { SearchResultDataset } from "@/interfaces/Search";
 import Box from "@/components/Box";
 import Button from "@/components/Button";
+import Link from "@/components/Link";
 import MenuDropdown from "@/components/MenuDropdown";
 import Typography from "@/components/Typography";
 import DarEnquiryDialog from "@/modules/DarEnquiryDialog";
@@ -199,6 +200,10 @@ const ResultCard = ({
         highlight?.abstract?.[0] ??
         highlight?.description?.[0] ??
         metadata.summary.abstract;
+    const dataCustodianId = metadata.summary.publisher.gatewayId;
+    // if the below is false, its because the api has failed to find the team id based off the original uid for gatewayId
+    const isNumber = !(typeof dataCustodianId === "string");
+    const linkHref = `/${RouteName.DATA_PROVIDERS_ITEM}/${dataCustodianId}`;
 
     return (
         <>
@@ -284,22 +289,47 @@ const ResultCard = ({
                             disableTypography
                             secondary={
                                 <section aria-describedby={resultId}>
-                                    <Typography
-                                        // eslint-disable-next-line
+                                    {isNumber && (
+                                        <Link href={linkHref}>
+                                            <Typography
+                                                // eslint-disable-next-line
                                         aria-description="Data Custodian"
-                                        sx={{
-                                            textDecoration: "uppercase",
-                                            fontWeight: 400,
-                                            fontSize: 16,
-                                            color: "black",
-                                            mb: 1.5,
-                                        }}>
-                                        {metadata.summary.publisher.name !==
-                                        undefined
-                                            ? metadata.summary.publisher.name
-                                            : metadata.summary.publisher
-                                                  .publisherName}
-                                    </Typography>
+                                                sx={{
+                                                    textDecoration: "uppercase",
+                                                    fontWeight: 400,
+                                                    fontSize: 16,
+                                                    color: "black",
+                                                    mb: 1.5,
+                                                }}>
+                                                {metadata.summary.publisher
+                                                    .name !== undefined
+                                                    ? metadata.summary.publisher
+                                                          .name
+                                                    : metadata.summary.publisher
+                                                          .publisherName}
+                                            </Typography>
+                                        </Link>
+                                    )}
+
+                                    {!isNumber && (
+                                        <Typography
+                                            // eslint-disable-next-line
+                                        aria-description="Data Custodian"
+                                            sx={{
+                                                textDecoration: "uppercase",
+                                                fontWeight: 400,
+                                                fontSize: 16,
+                                                color: "black",
+                                                mb: 1.5,
+                                            }}>
+                                            {metadata.summary.publisher.name !==
+                                            undefined
+                                                ? metadata.summary.publisher
+                                                      .name
+                                                : metadata.summary.publisher
+                                                      .publisherName}
+                                        </Typography>
+                                    )}
                                     <Highlight
                                         sx={{ mb: 1.5 }}
                                         component="div"

--- a/src/app/[locale]/(logged-out)/search/components/ResultsTable/ResultsTable.tsx
+++ b/src/app/[locale]/(logged-out)/search/components/ResultsTable/ResultsTable.tsx
@@ -24,6 +24,7 @@ interface ResultTableProps {
 
 const CONFORMS_TO_PATH = "metadata.accessibility.formatAndStandards.conformsTo";
 const PUBLISHER_NAME_PATH = "metadata.summary.publisher.name";
+const PUBLISHERS_ID = "metadata.summary.publisher.gatewayId";
 const COHORT_DISCOVERY_PATH = "isCohortDiscovery";
 const ACCESS_SERVICE_PATH =
     "metadata.accessibility.access.accessServiceCategory";
@@ -84,14 +85,31 @@ const getColumns = ({
 
     columnHelper.display({
         id: "dataProvider",
-        cell: ({ row: { original } }) => (
-            <div style={{ textAlign: "center" }}>
-                <EllipsisLineLimit
-                    showToolTip
-                    text={get(original, PUBLISHER_NAME_PATH)}
-                />
-            </div>
-        ),
+        cell: ({ row: { original } }) => {
+            const dataCustodianId = get(original, PUBLISHERS_ID);
+            // if the below is false, its because the api has failed to find the team id based off the original uid for gatewayId
+            const isNumber = !(typeof dataCustodianId === "string");
+            const linkHref = `/${RouteName.DATA_PROVIDERS_ITEM}/${dataCustodianId}`;
+
+            return (
+                <div style={{ textAlign: "center" }}>
+                    {isNumber && (
+                        <Link href={linkHref}>
+                            <EllipsisLineLimit
+                                showToolTip
+                                text={get(original, PUBLISHER_NAME_PATH)}
+                            />
+                        </Link>
+                    )}
+                    {!isNumber && (
+                        <EllipsisLineLimit
+                            showToolTip
+                            text={get(original, PUBLISHER_NAME_PATH)}
+                        />
+                    )}
+                </div>
+            );
+        },
         header: () => (
             <TooltipIcon
                 buttonSx={{ p: 0 }}

--- a/src/interfaces/Dataset.ts
+++ b/src/interfaces/Dataset.ts
@@ -63,6 +63,7 @@ interface Metadata {
         title: string;
         populationSize: number | null;
         publisher: {
+            gatewayId: string | number;
             publisherName: string;
             name?: string;
         };


### PR DESCRIPTION
## Screenshots (if relevant)
![image](https://github.com/user-attachments/assets/5626e7e1-f5be-471b-8982-0070908d1db6)
![image](https://github.com/user-attachments/assets/53fb8e87-07cf-408a-bb39-72b4a37b0715)

## Describe your changes
Added in links on the dataset search results for table and list, to link off to the data custodian page of the publisher, there is a safety net around the link, if the id is a string then the API has failed to find the publishers ID so we dont want to show a link in this scenario as it would be wrong.
## Issue ticket link
https://hdruk.atlassian.net/jira/software/c/projects/GAT/boards/51?assignee=712020%3A05fbbf0f-9386-469a-a212-84cfbf9cc587&selectedIssue=GAT-5697
## Checklist before requesting a review

-   [x] I have performed a self-review of my code
-   [ ] I have added appropriate unit tests
-   [ ] I have created mocks for unit tests (where appropriate)
-   [ ] The interface is responsive (where appropriate)
-   [ ] The interface is at least AA (where appropriate)
