### PR TITLE
GAT-5892: Reset page to 1 each time a filter is changed.

### DIFF
--- a/src/app/[locale]/(logged-out)/search/components/Search/Search.tsx
+++ b/src/app/[locale]/(logged-out)/search/components/Search/Search.tsx
@@ -800,10 +800,12 @@ const Search = ({ filters }: SearchProps) => {
                         ) => {
                             // url requires string format, ie "one, two, three"
                             updatePath(filterName, filterValues.join(","));
+                            updatePath(PAGE_FIELD, "1");
 
                             // api requires string[] format, ie ["one", "two", "three"]
                             setQueryParams({
                                 ...queryParams,
+                                page: "1",
                                 [filterName]: filterValues,
                             });
                         }}


### PR DESCRIPTION
## Screenshots (if relevant)

https://github.com/user-attachments/assets/a5e2f62b-dc62-4bbe-a645-a1931c860286



## Describe your changes
Each time a filter is changed, the page number is now reset to 1 - both in the query params and in the path. This avoids the previous behaviour where applying a restrictive filter while being on e.g. page 4 could result in looking like there were no results - but we were simply too far down the pagination to show anything.

## Issue ticket link
https://hdruk.atlassian.net/browse/GAT-5892

## Checklist before requesting a review

-   [ ] I have performed a self-review of my code
-   [ ] I have added appropriate unit tests
-   [ ] I have created mocks for unit tests (where appropriate)
-   [ ] The interface is responsive (where appropriate)
-   [ ] The interface is at least AA (where appropriate)
