### PR TITLE
Remove Data Custodian Network filter from Tools, DURs, and Collections search tabs.

### DIFF
--- a/src/app/[locale]/(logged-out)/search/components/FilterPanel/FilterPanel.tsx
+++ b/src/app/[locale]/(logged-out)/search/components/FilterPanel/FilterPanel.tsx
@@ -50,6 +50,9 @@ import PopulationFilter from "../PopulationFilter";
 const TRANSLATION_PATH = "pages.search.components.FilterPanel.filters";
 const TOOLTIP_SUFFIX = "Tooltip";
 const FILTER_CATEGORY_PUBLICATIONS = "paper";
+const FILTER_CATEGORY_DURS = "dataUseRegister";
+const FILTER_CATEGORY_TOOLS = "tool";
+const FILTER_CATEGORY_COLLECTIONS = "collection";
 const STATIC_FILTER_SOURCE = "source";
 const STATIC_FILTER_SOURCE_OBJECT = {
     buckets: [
@@ -221,6 +224,13 @@ const FilterPanel = ({
         if (staticFilterValues.source.FED) {
             formattedFilters = formattedFilters.filter(
                 filterItem => filterItem.label !== FILTER_DATA_SET_TITLES
+            );
+        }
+
+        // If on the 'Data Uses', 'Tools' or 'Collections' tabs then remove the 'Data Custodian Network' filter
+        if ([FILTER_CATEGORY_DURS, FILTER_CATEGORY_TOOLS, FILTER_CATEGORY_COLLECTIONS].includes(filterCategory)) {
+            formattedFilters = formattedFilters.filter(
+                filterItem => filterItem.label !== FILTER_DATA_CUSTODIAN_NETWORK
             );
         }
 

--- a/src/app/[locale]/(logged-out)/search/components/FilterPanel/FilterPanel.tsx
+++ b/src/app/[locale]/(logged-out)/search/components/FilterPanel/FilterPanel.tsx
@@ -228,7 +228,13 @@ const FilterPanel = ({
         }
 
         // If on the 'Data Uses', 'Tools' or 'Collections' tabs then remove the 'Data Custodian Network' filter
-        if ([FILTER_CATEGORY_DURS, FILTER_CATEGORY_TOOLS, FILTER_CATEGORY_COLLECTIONS].includes(filterCategory)) {
+        if (
+            [
+                FILTER_CATEGORY_DURS,
+                FILTER_CATEGORY_TOOLS,
+                FILTER_CATEGORY_COLLECTIONS,
+            ].includes(filterCategory)
+        ) {
             formattedFilters = formattedFilters.filter(
                 filterItem => filterItem.label !== FILTER_DATA_CUSTODIAN_NETWORK
             );


### PR DESCRIPTION
## Screenshots (if relevant)

## Describe your changes
These were inadvertantly added by adding to the Datasets tab. Since elastic already indexes this keyword for the other entities, the FE tries to load them too, and then has no filter label text to show. This PR hides them until/if they are required in future.

## Issue ticket link

## Checklist before requesting a review

-   [ ] I have performed a self-review of my code
-   [ ] I have added appropriate unit tests
-   [ ] I have created mocks for unit tests (where appropriate)
-   [ ] The interface is responsive (where appropriate)
-   [ ] The interface is at least AA (where appropriate)
