### PR TITLE
fix: (GAT-5879) Filters not appearing

### DIFF
--- a/src/app/[locale]/(logged-out)/search/page.tsx
+++ b/src/app/[locale]/(logged-out)/search/page.tsx
@@ -10,21 +10,11 @@ export const metadata = metaData(
         description: "",
     },
     noFollowRobots
-); // double check robots for search
-
-let filters: Filter[] | null = null;
-
-const fetchFilters = async () => {
-    const cookieStore = cookies();
-    const filters = await getFilters(cookieStore);
-    return filters;
-};
+);
 
 const SearchPage = async () => {
-    if (!filters) {
-        filters = await fetchFilters();
-    }
-
+    const cookieStore = cookies();
+    const filters: Filter[] = await getFilters(cookieStore);
     return <Search filters={filters} />;
 };
 

--- a/src/app/api/revalidate/route.ts
+++ b/src/app/api/revalidate/route.ts
@@ -1,0 +1,44 @@
+import { revalidateTag } from "next/cache";
+import { NextRequest, NextResponse } from "next/server";
+
+interface RevalidateRequestBody {
+    tags: string | string[];
+}
+
+export async function POST(request: NextRequest) {
+    try {
+        const { tags }: RevalidateRequestBody = await request.json();
+        if (!tags || (Array.isArray(tags) && tags.length === 0)) {
+            return NextResponse.json(
+                { message: "No tags provided" },
+                { status: 400 }
+            );
+        }
+
+        if (Array.isArray(tags)) {
+            for (const tag of tags) {
+                revalidateTag(tag);
+            }
+        } else {
+            revalidateTag(tags);
+        }
+        return NextResponse.json(
+            {
+                message: `Revalidated ${
+                    Array.isArray(tags) ? tags.length : 1
+                } tag(s) successfully`,
+                tags: Array.isArray(tags) ? tags : [tags],
+            },
+            { status: 200 }
+        );
+    } catch (error) {
+        console.error("Error revalidating:", error);
+        return NextResponse.json(
+            {
+                message: "Error revalidating",
+                error: (error as Error).message,
+            },
+            { status: 500 }
+        );
+    }
+}

--- a/src/app/api/revalidate/route.ts
+++ b/src/app/api/revalidate/route.ts
@@ -16,9 +16,9 @@ export async function POST(request: NextRequest) {
         }
 
         if (Array.isArray(tags)) {
-            for (const tag of tags) {
+            tags.forEach(tag => {
                 revalidateTag(tag);
-            }
+            });
         } else {
             revalidateTag(tags);
         }

--- a/src/utils/api.ts
+++ b/src/utils/api.ts
@@ -27,10 +27,10 @@ export interface Cache {
 async function get<T>(
     cookieStore: ReadonlyRequestCookies,
     url: string,
+    cache?: Cache,
     options: GetOptions = {
         suppressError: false,
-    },
-    cache?: Cache
+    }
 ): Promise<T> {
     const jwt = cookieStore.get(config.JWT_COOKIE);
 
@@ -66,7 +66,6 @@ async function getFilters(
     return get<Filter[]>(
         cookieStore,
         `${apis.filtersV1UrlIP}?perPage=${FILTERS_PER_PAGE}`,
-        undefined,
         cache
     );
 }


### PR DESCRIPTION
## Screenshots (if relevant)
Search page is first hit, so we call filters endpoint once:
![image](https://github.com/user-attachments/assets/6e80649e-5c95-48b5-b4cb-ab0faeaeb8e2)
If i refresh the page, filters should not be called again because we are cached for 2 hours.
![image](https://github.com/user-attachments/assets/7410703c-731a-43bb-9b4c-1dd5794176d3)
I call the revalidate endpoint and clear filters cache:
<img width="1322" alt="image" src="https://github.com/user-attachments/assets/8afe487f-b5b7-4b42-b926-393abe2003b7">
I refresh the page and filters should be called:
<img width="1107" alt="image" src="https://github.com/user-attachments/assets/6661bffe-1330-4eba-91cb-a8699980e094">

## Describe your changes
- The filters were leaked in serverside memory, they were only ever cleared when nodes garbage collector was ran.
- Introduced [NextJS data caching](https://nextjs.org/docs/app/building-your-application/data-fetching/fetching).
- Updated get call to make use of caching, by default disabled and when enabled the expire by default is 2 hours.
- Added in endpoint to clear tags as a post, accepts either a string or array
## Issue ticket link.

## Checklist before requesting a review

-   [x] I have performed a self-review of my code
-   [ ] I have added appropriate unit tests
-   [ ] I have created mocks for unit tests (where appropriate)
-   [ ] The interface is responsive (where appropriate)
-   [ ] The interface is at least AA (where appropriate)
