### PR TITLE
fix:(GAT-5659) - dataset summary

### DIFF
--- a/src/app/[locale]/(logged-out)/dataset/[datasetId]/components/DatasetContent/DatasetContent.tsx
+++ b/src/app/[locale]/(logged-out)/dataset/[datasetId]/components/DatasetContent/DatasetContent.tsx
@@ -11,6 +11,7 @@ import BoxContainer from "@/components/BoxContainer";
 import Button from "@/components/Button";
 import DemographicsAccordion from "@/components/DemographicsAccordion";
 import Link from "@/components/Link";
+import { MarkDownSanitizedWithHtml } from "@/components/MarkDownSanitizedWithHTML";
 import Paper from "@/components/Paper";
 import StructuralMetadataAccordion from "@/components/StructuralMetadataAccordion";
 import Table from "@/components/Table";
@@ -18,10 +19,7 @@ import TooltipIcon from "@/components/TooltipIcon";
 import Typography from "@/components/Typography";
 import useModal from "@/hooks/useModal";
 import { RouteName } from "@/consts/routeName";
-import {
-    formatTextWithLinks,
-    splitStringList,
-} from "@/utils/dataset";
+import { formatTextWithLinks, splitStringList } from "@/utils/dataset";
 import { formatDate } from "@/utils/date";
 import {
     DatasetSection,
@@ -35,7 +33,6 @@ import {
     ListContainer,
     ObservationTableWrapper,
 } from "./DatasetContent.styles";
-import { MarkDownSanitizedWithHtml } from "@/components/MarkDownSanitizedWithHTML";
 
 const DATE_FORMAT = "DD/MM/YYYY";
 const OBSERVATION_DATE = "observationDate";
@@ -149,10 +146,9 @@ const DatasetContent = ({
             }
 
             default: {
-                return (<MarkDownSanitizedWithHtml
-                    content={value}
-                    wrapper="span"
-                />)
+                return (
+                    <MarkDownSanitizedWithHtml content={value} wrapper="span" />
+                );
             }
         }
     };

--- a/src/app/[locale]/(logged-out)/dataset/[datasetId]/components/DatasetContent/DatasetContent.tsx
+++ b/src/app/[locale]/(logged-out)/dataset/[datasetId]/components/DatasetContent/DatasetContent.tsx
@@ -159,7 +159,6 @@ const DatasetContent = ({
 
     return (
         <Paper sx={{ borderRadius: 2, p: 2 }}>
-            teser
             {populatedSections.map((section, index) => {
                 const id = `anchor-${section.sectionName.replaceAll(
                     /\s/g,
@@ -270,7 +269,6 @@ const DatasetContent = ({
                                                     pb: 2,
                                                 }}
                                                 key={value}>
-                                                    test
                                                 {renderDatasetField(
                                                     field.type,
                                                     value

--- a/src/app/[locale]/(logged-out)/dataset/[datasetId]/components/DatasetContent/DatasetContent.tsx
+++ b/src/app/[locale]/(logged-out)/dataset/[datasetId]/components/DatasetContent/DatasetContent.tsx
@@ -19,7 +19,6 @@ import Typography from "@/components/Typography";
 import useModal from "@/hooks/useModal";
 import { RouteName } from "@/consts/routeName";
 import {
-    formatTextDelimiter,
     formatTextWithLinks,
     splitStringList,
 } from "@/utils/dataset";
@@ -36,6 +35,7 @@ import {
     ListContainer,
     ObservationTableWrapper,
 } from "./DatasetContent.styles";
+import { MarkDownSanitizedWithHtml } from "@/components/MarkDownSanitizedWithHTML";
 
 const DATE_FORMAT = "DD/MM/YYYY";
 const OBSERVATION_DATE = "observationDate";
@@ -149,13 +149,17 @@ const DatasetContent = ({
             }
 
             default: {
-                return formatTextWithLinks(formatTextDelimiter(value));
+                return (<MarkDownSanitizedWithHtml
+                    content={value}
+                    wrapper="span"
+                />)
             }
         }
     };
 
     return (
         <Paper sx={{ borderRadius: 2, p: 2 }}>
+            teser
             {populatedSections.map((section, index) => {
                 const id = `anchor-${section.sectionName.replaceAll(
                     /\s/g,
@@ -266,6 +270,7 @@ const DatasetContent = ({
                                                     pb: 2,
                                                 }}
                                                 key={value}>
+                                                    test
                                                 {renderDatasetField(
                                                     field.type,
                                                     value


### PR DESCRIPTION
## Screenshots (if relevant)

## Describe your changes
Text is coming through like:![image](https://github.com/user-attachments/assets/a5a3f9b8-3578-4f70-a244-e3d1354712c8), which passes the regex to check if its a url, but then it blows up on prefetch as its not a valid url because it contains the braces. we can just use the markdown component which handles it all 
![image](https://github.com/user-attachments/assets/2e053822-cf7e-45b7-af1d-173f4807ab1f)

## Issue ticket link

## Checklist before requesting a review

-   [ ] I have performed a self-review of my code
-   [ ] I have added appropriate unit tests
-   [ ] I have created mocks for unit tests (where appropriate)
-   [ ] The interface is responsive (where appropriate)
-   [ ] The interface is at least AA (where appropriate)
