### PR TITLE
GAT-5785: Change DatasetCard to parse newly formatted inputs.

### DIFF
--- a/mocks/data/dataset/v1/dataset.data.ts
+++ b/mocks/data/dataset/v1/dataset.data.ts
@@ -350,10 +350,10 @@ const generateDatasetForTeamV1 = (version = "1.0", data = {}): Dataset => {
                 publisher:
                     version === "1.0"
                         ? {
-                              name: faker.datatype.string(),
+                              publisherName: faker.datatype.string(),
                           }
                         : {
-                              publisherName: faker.datatype.string(),
+                              name: faker.datatype.string(),
                           },
             },
             gwdmVersion: "1.1",

--- a/mocks/data/dataset/v1/dataset.data.ts
+++ b/mocks/data/dataset/v1/dataset.data.ts
@@ -356,7 +356,7 @@ const generateDatasetForTeamV1 = (version = "1.0", data = {}): Dataset => {
                               name: faker.datatype.string(),
                           },
             },
-            gwdmVersion: "1.1",
+            gwdmVersion: version,
         },
         updated: faker.date.past().toString(),
         ...data,

--- a/mocks/data/dataset/v1/dataset.data.ts
+++ b/mocks/data/dataset/v1/dataset.data.ts
@@ -334,6 +334,31 @@ const generateDatasetV1 = (version = "1.0", data = {}): Dataset => {
     };
 };
 
+const generateDatasetForTeamV1 = (data = {}): Dataset => {
+    return {
+        id: faker.datatype.number(),
+        team_id: faker.datatype.number(),
+        user_id: faker.datatype.number(),
+        status: faker.helpers.arrayElement(["ARCHIVED", "ACTIVE", "DRAFT"]),
+        create_origin: faker.helpers.arrayElement(["GMI", "API", "MANUAL"]),
+        pid: faker.datatype.uuid(),
+        latest_metadata: {
+            required: {
+                version: faker.datatype.number(),
+            },
+            summary: {
+                title: faker.datatype.string(5),
+                publisher: {
+                    name: faker.datatype.string(),
+                },
+            },
+            gwdmVersion: "1.1",
+        },
+        updated: faker.date.past().toString(),
+        ...data,
+    };
+};
+
 const generateDatasetHighlightsV1 = (): Highlight => {
     return {
         abstract: [faker.datatype.string(), faker.datatype.string()],
@@ -370,6 +395,7 @@ const datasetsV1p1 = Array.from({ length: 3 }).map(() =>
 
 export {
     generateDatasetV1,
+    generateDatasetForTeamV1,
     generateDatasetHighlightsV1,
     generateDatasetMetadataV1,
     generateDatasetMetadataMiniV1,

--- a/mocks/data/dataset/v1/dataset.data.ts
+++ b/mocks/data/dataset/v1/dataset.data.ts
@@ -8,7 +8,6 @@ import {
 import { Highlight } from "@/interfaces/HighlightDataset";
 import { SearchResultDataset } from "@/interfaces/Search";
 
-
 const generatePageDataSetV1 = (): Dataset => {
     return {
         id: faker.datatype.number(),
@@ -334,7 +333,7 @@ const generateDatasetV1 = (version = "1.0", data = {}): Dataset => {
     };
 };
 
-const generateDatasetForTeamV1 = (data = {}): Dataset => {
+const generateDatasetForTeamV1 = (version = "1.0", data = {}): Dataset => {
     return {
         id: faker.datatype.number(),
         team_id: faker.datatype.number(),
@@ -348,9 +347,14 @@ const generateDatasetForTeamV1 = (data = {}): Dataset => {
             },
             summary: {
                 title: faker.datatype.string(5),
-                publisher: {
-                    name: faker.datatype.string(),
-                },
+                publisher:
+                    version === "1.0"
+                        ? {
+                              name: faker.datatype.string(),
+                          }
+                        : {
+                              publisherName: faker.datatype.string(),
+                          },
             },
             gwdmVersion: "1.1",
         },

--- a/src/app/[locale]/account/team/[teamId]/(withLeftNav)/datasets/components/TeamDatasets/TeamDatasets.test.tsx
+++ b/src/app/[locale]/account/team/[teamId]/(withLeftNav)/datasets/components/TeamDatasets/TeamDatasets.test.tsx
@@ -14,15 +14,18 @@ const renderTeamDatasets = () =>
 describe("TeamDatasets", () => {
     it("should render all datasets (filtered on BE)", async () => {
         const mockDatasets = [
-            generateDatasetForTeamV1({
+            generateDatasetForTeamV1("1.0", {
                 create_origin: "MANUAL",
                 status: "ARCHIVED",
             }),
-            generateDatasetForTeamV1({
+            generateDatasetForTeamV1("1.1", {
                 create_origin: "API",
                 status: "ACTIVE",
             }),
-            generateDatasetForTeamV1({ create_origin: "GMI", status: "DRAFT" }),
+            generateDatasetForTeamV1("1.0", {
+                create_origin: "GMI",
+                status: "DRAFT",
+            }),
         ];
         server.use(getTeamDatasetsV1(mockDatasets));
         renderTeamDatasets();
@@ -73,15 +76,15 @@ describe("TeamDatasets", () => {
 
     it("should render all datasets (with different GWDM versions)", async () => {
         const mockDatasets = [
-            generateDatasetForTeamV1({
+            generateDatasetForTeamV1("1.0", {
                 create_origin: "API",
                 status: "ACTIVE",
             }),
-            generateDatasetForTeamV1({
+            generateDatasetForTeamV1("1.0", {
                 create_origin: "API",
                 status: "ACTIVE",
             }),
-            generateDatasetForTeamV1({
+            generateDatasetForTeamV1("1.1", {
                 create_origin: "API",
                 status: "ACTIVE",
             }),

--- a/src/app/[locale]/account/team/[teamId]/(withLeftNav)/datasets/components/TeamDatasets/TeamDatasets.test.tsx
+++ b/src/app/[locale]/account/team/[teamId]/(withLeftNav)/datasets/components/TeamDatasets/TeamDatasets.test.tsx
@@ -1,6 +1,6 @@
 import mockRouter from "next-router-mock";
 import { render, screen, waitFor, within } from "@/utils/testUtils";
-import { generateDatasetV1 } from "@/mocks/data/dataset";
+import { generateDatasetForTeamV1 } from "@/mocks/data/dataset";
 import { getTeamDatasetsV1 } from "@/mocks/handlers/teams";
 import { server } from "@/mocks/server";
 import TeamDatasets from "./TeamDatasets";
@@ -14,15 +14,15 @@ const renderTeamDatasets = () =>
 describe("TeamDatasets", () => {
     it("should render all datasets (filtered on BE)", async () => {
         const mockDatasets = [
-            generateDatasetV1("1.0", {
+            generateDatasetForTeamV1({
                 create_origin: "MANUAL",
                 status: "ARCHIVED",
             }),
-            generateDatasetV1("1.0", {
+            generateDatasetForTeamV1({
                 create_origin: "API",
                 status: "ACTIVE",
             }),
-            generateDatasetV1("1.0", { create_origin: "GMI", status: "DRAFT" }),
+            generateDatasetForTeamV1({ create_origin: "GMI", status: "DRAFT" }),
         ];
         server.use(getTeamDatasetsV1(mockDatasets));
         renderTeamDatasets();
@@ -33,17 +33,17 @@ describe("TeamDatasets", () => {
 
             expect(
                 within(datasetCards[0]).getByText(
-                    `${mockDatasets[0].versions[0].metadata.metadata.summary.title}`
+                    `${mockDatasets[0].latest_metadata.summary.title}`
                 )
             ).toBeInTheDocument();
             expect(
                 within(datasetCards[0]).getByText(
-                    `${mockDatasets[0].versions[0].metadata.metadata.summary.publisher.publisherName}`
+                    `${mockDatasets[0].latest_metadata.summary.publisher.publisherName}`
                 )
             ).toBeInTheDocument();
             expect(
                 within(datasetCards[0]).getByText(
-                    `${mockDatasets[0].versions[0].metadata.metadata.required.version}`
+                    `${mockDatasets[0].latest_metadata.required.version}`
                 )
             ).toBeInTheDocument();
 
@@ -73,15 +73,15 @@ describe("TeamDatasets", () => {
 
     it("should render all datasets (with different GWDM versions)", async () => {
         const mockDatasets = [
-            generateDatasetV1("1.0", {
+            generateDatasetForTeamV1({
                 create_origin: "API",
                 status: "ACTIVE",
             }),
-            generateDatasetV1("1.0", {
+            generateDatasetForTeamV1({
                 create_origin: "API",
                 status: "ACTIVE",
             }),
-            generateDatasetV1("1.1", {
+            generateDatasetForTeamV1({
                 create_origin: "API",
                 status: "ACTIVE",
             }),
@@ -95,19 +95,19 @@ describe("TeamDatasets", () => {
 
             expect(
                 within(datasetCards[0]).getByText(
-                    `${mockDatasets[0].versions[0].metadata.metadata.summary.publisher.publisherName}`
+                    `${mockDatasets[0].latest_metadata.summary.publisher.publisherName}`
                 )
             ).toBeInTheDocument();
 
             expect(
                 within(datasetCards[1]).getByText(
-                    `${mockDatasets[1].versions[0].metadata.metadata.summary.publisher.publisherName}`
+                    `${mockDatasets[1].latest_metadata.summary.publisher.publisherName}`
                 )
             ).toBeInTheDocument();
 
             expect(
                 within(datasetCards[2]).getByText(
-                    `${mockDatasets[2].versions[0].metadata.metadata.summary.publisher.name}`
+                    `${mockDatasets[2].latest_metadata.summary.publisher.name}`
                 )
             ).toBeInTheDocument();
         });

--- a/src/app/[locale]/account/team/[teamId]/(withLeftNav)/datasets/components/TeamDatasets/TeamDatasets.tsx
+++ b/src/app/[locale]/account/team/[teamId]/(withLeftNav)/datasets/components/TeamDatasets/TeamDatasets.tsx
@@ -71,8 +71,6 @@ const TeamDatasets = ({ permissions, teamId }: TeamDatasetsProps) => {
     );
 
     const [queryParams, setQueryParams] = useState({
-        team_id: `${params?.teamId}`,
-        withTrashed: "true",
         status: "ACTIVE",
         page: "1",
         sort: `${datasetSearchDefaultValues.sortField}:${initialSort.initialDirection}`,

--- a/src/components/DatasetCard/DatasetCard.tsx
+++ b/src/components/DatasetCard/DatasetCard.tsx
@@ -28,18 +28,18 @@ const DatasetCard = ({ dataset, actions }: DatasetCardProps) => {
 
     const {
         updated_at,
-        metadata: { metadata, gwdmVersion },
+        gwdmVersion,
     } = latestMetadata;
 
-    const title = get(metadata, "summary.title") as unknown as string;
+    const title = get(latestMetadata, "summary.title") as unknown as string;
     const publisherName = get(
-        metadata,
+        latestMetadata,
         gwdmVersion === undefined || gwdmVersion === "1.0"
             ? "summary.publisher.publisherName"
             : "summary.publisher.name"
     ) as unknown as string;
 
-    const version = get(metadata, "required.version");
+    const version = get(latestMetadata, "required.version");
 
     const originMapping = {
         MANUAL: "Manually",

--- a/src/components/DatasetCard/DatasetCard.tsx
+++ b/src/components/DatasetCard/DatasetCard.tsx
@@ -26,10 +26,7 @@ const DatasetCard = ({ dataset, actions }: DatasetCardProps) => {
 
     if (!latestMetadata) return null;
 
-    const {
-        updated_at,
-        gwdmVersion,
-    } = latestMetadata;
+    const { updated_at, gwdmVersion } = latestMetadata;
 
     const title = get(latestMetadata, "summary.title") as unknown as string;
     const publisherName = get(


### PR DESCRIPTION
## Screenshots (if relevant)

## Describe your changes
Teams Dataset page now correctly renders cards for Datasets, where previously they rendered none.

This is reliant on the changes from https://github.com/HDRUK/gateway-api-2/pull/996 being merged first.

Builds on #936 

## Issue ticket link
https://hdruk.atlassian.net/browse/GAT-5785

## Checklist before requesting a review

-   [x] I have performed a self-review of my code
-   [ ] I have added appropriate unit tests
-   [ ] I have created mocks for unit tests (where appropriate)
-   [ ] The interface is responsive (where appropriate)
-   [ ] The interface is at least AA (where appropriate)
