### PR TITLE
Reinstate the withTrashed parameter until it is not needed.

### DIFF
--- a/src/app/[locale]/account/team/[teamId]/(withLeftNav)/datasets/components/TeamDatasets/TeamDatasets.tsx
+++ b/src/app/[locale]/account/team/[teamId]/(withLeftNav)/datasets/components/TeamDatasets/TeamDatasets.tsx
@@ -71,6 +71,7 @@ const TeamDatasets = ({ permissions, teamId }: TeamDatasetsProps) => {
     );
 
     const [queryParams, setQueryParams] = useState({
+        withTrashed: "true",
         status: "ACTIVE",
         page: "1",
         sort: `${datasetSearchDefaultValues.sortField}:${initialSort.initialDirection}`,


### PR DESCRIPTION
## Screenshots (if relevant)

## Describe your changes
Hotfix to https://github.com/HDRUK/gateway-web-2/pull/938

We still require the `withTrashed` parameter to be `true` until the underlying data has been migrated to un-delete archived datasets.

## Issue ticket link
https://hdruk.atlassian.net/browse/GAT-5785

## Checklist before requesting a review

-   [ ] I have performed a self-review of my code
-   [ ] I have added appropriate unit tests
-   [ ] I have created mocks for unit tests (where appropriate)
-   [ ] The interface is responsive (where appropriate)
-   [ ] The interface is at least AA (where appropriate)
