### PR TITLE
fix: - (GAT-5688) Cropping off data custodian

### DIFF
--- a/src/components/CheckboxControlled/CheckboxControlled.tsx
+++ b/src/components/CheckboxControlled/CheckboxControlled.tsx
@@ -45,7 +45,7 @@ const CheckboxControlled = (props: CheckboxProps) => {
                                 flexDirection: "row",
                                 justifyContent: "space-between",
                             }}>
-                            <EllipsisLineLimit text={label} showToolTip/>
+                            <EllipsisLineLimit text={label} showToolTip />
                             <Typography sx={{ ml: 1 }} fontWeight={400}>
                                 {count}
                             </Typography>

--- a/src/components/CheckboxControlled/CheckboxControlled.tsx
+++ b/src/components/CheckboxControlled/CheckboxControlled.tsx
@@ -45,7 +45,7 @@ const CheckboxControlled = (props: CheckboxProps) => {
                                 flexDirection: "row",
                                 justifyContent: "space-between",
                             }}>
-                            <EllipsisLineLimit text={label} />
+                            <EllipsisLineLimit text={label} showToolTip/>
                             <Typography sx={{ ml: 1 }} fontWeight={400}>
                                 {count}
                             </Typography>


### PR DESCRIPTION
## Screenshots (if relevant)
![image](https://github.com/user-attachments/assets/e142d871-a0d2-40ca-a359-80088e59ddac)

## Describe your changes
setting showToolTip, gives the element a wrapper which defines a width.
## Issue ticket link
https://hdruk.atlassian.net/jira/software/c/projects/GAT/boards/51?assignee=712020%3A05fbbf0f-9386-469a-a212-84cfbf9cc587&selectedIssue=GAT-5688
## Checklist before requesting a review

-   [x] I have performed a self-review of my code
-   [ ] I have added appropriate unit tests
-   [ ] I have created mocks for unit tests (where appropriate)
-   [ ] The interface is responsive (where appropriate)
-   [ ] The interface is at least AA (where appropriate)
