### PR TITLE
fix: (GAT-5913) - collects add keywords

### DIFF
--- a/src/app/[locale]/account/team/[teamId]/(withLeftNav)/collections/[collectionId]/page.tsx
+++ b/src/app/[locale]/account/team/[teamId]/(withLeftNav)/collections/[collectionId]/page.tsx
@@ -1,7 +1,8 @@
 import { cookies } from "next/headers";
+import { ValueType } from "@/components/Autocomplete/Autocomplete";
 import CollectionForm from "@/components/CollectionForm";
 import ProtectedAccountRoute from "@/components/ProtectedAccountRoute";
-import { getTeam, getUser } from "@/utils/api";
+import { getKeywords, getTeam, getUser } from "@/utils/api";
 import metaData, { noFollowRobots } from "@/utils/metadata";
 import { getPermissions } from "@/utils/permissions";
 import { getTeamUser } from "@/utils/user";
@@ -24,12 +25,22 @@ export default async function CollectionEditPage({
     const team = await getTeam(cookieStore, teamId);
     const teamUser = getTeamUser(team?.users, user?.id);
     const permissions = getPermissions(user.roles, teamUser?.roles);
-
+    const keywords = await getKeywords(cookieStore);
+    const keywordOptions = keywords.map(data => {
+        return {
+            value: data.id as ValueType,
+            label: data.name,
+        };
+    });
     return (
         <ProtectedAccountRoute
             permissions={permissions}
             pagePermissions={["collections.update"]}>
-            <CollectionForm teamId={teamId} collectionId={collectionId} />
+            <CollectionForm
+                teamId={teamId}
+                collectionId={collectionId}
+                keywordOptions={keywordOptions}
+            />
         </ProtectedAccountRoute>
     );
 }

--- a/src/app/[locale]/account/team/[teamId]/(withLeftNav)/collections/create/page.tsx
+++ b/src/app/[locale]/account/team/[teamId]/(withLeftNav)/collections/create/page.tsx
@@ -1,7 +1,8 @@
 import { cookies } from "next/headers";
+import { ValueType } from "@/components/Autocomplete/Autocomplete";
 import CollectionForm from "@/components/CollectionForm";
 import ProtectedAccountRoute from "@/components/ProtectedAccountRoute";
-import { getTeam, getUser } from "@/utils/api";
+import { getKeywords, getTeam, getUser } from "@/utils/api";
 import metaData, { noFollowRobots } from "@/utils/metadata";
 import { getPermissions } from "@/utils/permissions";
 import { getTeamUser } from "@/utils/user";
@@ -24,12 +25,18 @@ export default async function CollectionCreatePage({
     const team = await getTeam(cookieStore, teamId);
     const teamUser = getTeamUser(team?.users, user?.id);
     const permissions = getPermissions(user.roles, teamUser?.roles);
-
+    const keywords = await getKeywords(cookieStore);
+    const keywordOptions = keywords.map(data => {
+        return {
+            value: data.id as ValueType,
+            label: data.name,
+        };
+    });
     return (
         <ProtectedAccountRoute
             permissions={permissions}
             pagePermissions={["collections.create"]}>
-            <CollectionForm teamId={teamId} />
+            <CollectionForm teamId={teamId} keywordOptions={keywordOptions} />
         </ProtectedAccountRoute>
     );
 }

--- a/src/app/actions/revalidateCache.ts
+++ b/src/app/actions/revalidateCache.ts
@@ -1,0 +1,7 @@
+"use server";
+
+import { revalidateTag } from "next/cache";
+
+export const revalidateCache = (tag: string) => {
+    revalidateTag(tag);
+};

--- a/src/components/CollectionForm/CollectionForm.tsx
+++ b/src/components/CollectionForm/CollectionForm.tsx
@@ -356,8 +356,8 @@ const CollectionForm = ({
                         // then use a new keyword
                         if (!clearKeywordsTag) {
                             clearKeywordsTag = true;
-                            keywordArray.push(y);
                         }
+                        keywordArray.push(y);
                     }
                 });
             }

--- a/src/config/apis.ts
+++ b/src/config/apis.ts
@@ -65,6 +65,7 @@ const apis = {
     formHydrationV1Url: `${apiV1Url}/form_hydration`,
     formHydrationV1UrlIP: `${apiV1IPUrl}/form_hydration`,
     keywordsV1Url: `${apiV1Url}/keywords`,
+    keywordsV1IPUUrl: `${apiV1IPUrl}/keywords`,
     categoriesV1Url: `${apiV1Url}/categories`,
     fileUploadV1Url: `${apiV1Url}/files`,
     fileProcessedV1Url: `${apiV1Url}/files/processed`,

--- a/src/config/forms/collection.tsx
+++ b/src/config/forms/collection.tsx
@@ -44,15 +44,13 @@ const formFields = [
         info: "E.g. NCS; charity; disease",
         name: "keywords",
         component: inputComponents.Autocomplete,
+        canCreate: true,
         multiple: true,
         isOptionEqualToValue: (
             option: { value: string | number; label: string },
             value: string | number
         ) => option.value === value,
-        getChipLabel: (
-            options: { value: string | number; label: string }[],
-            value: unknown
-        ) => options.find(option => option.value === value)?.label,
+        getChipLabel,
     },
     {
         label: "Collaborators (optional)",

--- a/src/utils/api.ts
+++ b/src/utils/api.ts
@@ -79,7 +79,7 @@ async function getKeywords(
     };
     return get<Keyword[]>(
         cookieStore,
-        `${apis.keywordsV1IPUUrl}?perPage=-1`,
+        `${apis.keywordsV1IPUrl}?perPage=-1`,
         cache
     );
 }

--- a/src/utils/api.ts
+++ b/src/utils/api.ts
@@ -8,6 +8,7 @@ import { DataUse } from "@/interfaces/DataUse";
 import { Dataset } from "@/interfaces/Dataset";
 import { Filter } from "@/interfaces/Filter";
 import { FormHydrationSchema } from "@/interfaces/FormHydration";
+import { Keyword } from "@/interfaces/Keyword";
 import { NetworkSummary } from "@/interfaces/NetworkSummary";
 import { GetOptions } from "@/interfaces/Response";
 import { Team } from "@/interfaces/Team";
@@ -37,7 +38,7 @@ async function get<T>(
     const nextConfig = {
         next: cache
             ? {
-                  tags: [cache.tag],
+                  tags: [cache.tag, "all"],
                   revalidate: cache.revalidate ? cache.revalidate : 2 * 60 * 60,
               }
             : undefined,
@@ -66,6 +67,19 @@ async function getFilters(
     return get<Filter[]>(
         cookieStore,
         `${apis.filtersV1UrlIP}?perPage=${FILTERS_PER_PAGE}`,
+        cache
+    );
+}
+
+async function getKeywords(
+    cookieStore: ReadonlyRequestCookies
+): Promise<Keyword[]> {
+    const cache: Cache = {
+        tag: "keywords",
+    };
+    return get<Keyword[]>(
+        cookieStore,
+        `${apis.keywordsV1IPUUrl}?perPage=-1`,
         cache
     );
 }
@@ -252,6 +266,7 @@ export {
     getDataset,
     getDataUse,
     getFilters,
+    getKeywords,
     getFormHydration,
     getNetworkSummary,
     getTeam,


### PR DESCRIPTION
## Screenshots (if relevant)
Original client side call (fair few times): -
![image](https://github.com/user-attachments/assets/92b4e1d7-6c8a-4146-962b-33e466624570)
Editing a collection in draft (new keyword visible)
![image](https://github.com/user-attachments/assets/2d61b27c-e340-4925-8434-35c7b9c38087)
New keyword appears in new colllection creation:
![image](https://github.com/user-attachments/assets/c511b831-c915-4651-9e00-7ab784fbf662)



## Describe your changes
I thought this issue was that you could not add a keyword as a whole, because when i went to try this I couldnt because nothing loaded... turned out the keyword endpoint took a while to load (also that call was happening like 5 times..). So I made this a serverside call and cached it... then i realised it was the ability to add in keywords not listed.. so now we have both... huzzah...

 - moved client side call to serverside, cached in revalidate tags
 - added in server action to clear tag once new keyword is added
 - added in the ability to add new keywords


## Issue ticket link
https://hdruk.atlassian.net/browse/GAT-5913
## Checklist before requesting a review

-   [ ] I have performed a self-review of my code
-   [ ] I have added appropriate unit tests
-   [ ] I have created mocks for unit tests (where appropriate)
-   [ ] The interface is responsive (where appropriate)
-   [ ] The interface is at least AA (where appropriate)
