### PR TITLE
fix: (GAT-5567) don't show zero filters

### DIFF
--- a/src/components/FilterSection/FilterSection.tsx
+++ b/src/components/FilterSection/FilterSection.tsx
@@ -58,15 +58,27 @@ const FilterSection = <
     });
 
     const checkboxes = useMemo(() => {
-        return filterItem.buckets.filter(
-            bucket =>
+        return filterItem.buckets
+            .filter(bucket =>
                 bucket?.label
                     ?.toString()
                     ?.toLowerCase()
-                    ?.includes(field.value?.toLowerCase() || "") &&
-                bucket?.count !== 0
-        );
-    }, [filterItem.buckets, field.value]);
+                    ?.includes(field.value?.toLowerCase() || "")
+            )
+            .map(bucket => {
+                const updatedCount = countsDisabled
+                    ? undefined
+                    : !isEmpty(counts)
+                    ? counts[bucket.label] || 0
+                    : bucket.count;
+
+                return {
+                    ...bucket,
+                    count: updatedCount,
+                };
+            })
+            .filter(bucket => bucket.count !== 0);
+    }, [filterItem.buckets, field.value, countsDisabled, counts]);
 
     if (!filterItem.buckets.length)
         return <Typography>{noFilterLabel || t("noFilters")}</Typography>;
@@ -81,11 +93,6 @@ const FilterSection = <
         style: CSSProperties;
     }) => {
         const formattedRow = cloneDeep(checkboxes[index]);
-        formattedRow.count = countsDisabled
-            ? undefined
-            : !isEmpty(counts)
-            ? counts[checkboxes[index].label] || 0
-            : checkboxes[index].count;
         return (
             <div key={key} style={style}>
                 <CheckboxControlled


### PR DESCRIPTION
## Screenshots (if relevant)
![image](https://github.com/user-attachments/assets/e34f08c4-d76f-46de-b0eb-2a85d089fad4)
![image](https://github.com/user-attachments/assets/f45340f0-7888-454e-b080-bb101a5bd5bc)
![image](https://github.com/user-attachments/assets/d7dc3bce-df36-4fc8-8ae2-439592e3b62c)
![image](https://github.com/user-attachments/assets/84ee20c0-4684-416d-bf5d-696be5c9309d)
![image](https://github.com/user-attachments/assets/2628eea1-9098-4440-a7a3-5b1bfb800c50)

## Describe your changes
Combined the logic that was done inside the render to the parent, this will give us the correct height and count for each filter.
## Issue ticket link
https://hdruk.atlassian.net/jira/software/c/projects/GAT/boards/51?assignee=712020%3A05fbbf0f-9386-469a-a212-84cfbf9cc587&selectedIssue=GAT-5567
## Checklist before requesting a review

-   [ ] I have performed a self-review of my code
-   [ ] I have added appropriate unit tests
-   [ ] I have created mocks for unit tests (where appropriate)
-   [ ] The interface is responsive (where appropriate)
-   [ ] The interface is at least AA (where appropriate)
