### PR TITLE
hotfix: (GAT-5237) - data custodian slow call

### DIFF
--- a/.github/workflows/dev_deployment.yaml
+++ b/.github/workflows/dev_deployment.yaml
@@ -4,7 +4,7 @@ run-name: ${{ github.actor }} triggered deploy to DEV pipeline
 on:
   push:
     branches:
-      - "fix/GAT-5237-2"
+      - "dev"
 
 env:
   PROJECT_ID: "${{ secrets.PROJECT_ID }}"
@@ -24,7 +24,7 @@ jobs:
       - name: Checkout
         uses: actions/checkout@v4
         with:
-          ref: "fix/GAT-5237-2"
+          ref: "dev"
 
       - name: Read VERSION file
         id: getversion
@@ -73,7 +73,7 @@ jobs:
         id: checkout
         uses: actions/checkout@v4
         with:
-          ref: "fix/GAT-5237-2"
+          ref: "dev"
 
       - name: Google Auth
         id: auth

--- a/.github/workflows/dev_deployment.yaml
+++ b/.github/workflows/dev_deployment.yaml
@@ -4,7 +4,7 @@ run-name: ${{ github.actor }} triggered deploy to DEV pipeline
 on:
   push:
     branches:
-      - "dev"
+      - "fix/GAT-5237-2"
 
 env:
   PROJECT_ID: "${{ secrets.PROJECT_ID }}"
@@ -24,7 +24,7 @@ jobs:
       - name: Checkout
         uses: actions/checkout@v4
         with:
-          ref: "dev"
+          ref: "fix/GAT-5237-2"
 
       - name: Read VERSION file
         id: getversion
@@ -73,7 +73,7 @@ jobs:
         id: checkout
         uses: actions/checkout@v4
         with:
-          ref: "dev"
+          ref: "fix/GAT-5237-2"
 
       - name: Google Auth
         id: auth

--- a/src/app/[locale]/(logged-out)/search/components/DataCustodianNetwork/DataCustodianNetwork.tsx
+++ b/src/app/[locale]/(logged-out)/search/components/DataCustodianNetwork/DataCustodianNetwork.tsx
@@ -39,7 +39,7 @@ const SkeletonCard = () => (
         {[1, 2, 3].map(item => (
             <BoxStacked
                 key={item}
-                sx={{ aspectRatio: "1.9 / 1", minHeight: 130 }}>
+                sx={{ aspectRatio: "1.9 / 1", minHeight: 130, opacity: "0.5" }}>
                 <Skeleton
                     variant="rectangular"
                     width={300}

--- a/src/app/[locale]/(logged-out)/search/components/DataCustodianNetwork/DataCustodianNetwork.tsx
+++ b/src/app/[locale]/(logged-out)/search/components/DataCustodianNetwork/DataCustodianNetwork.tsx
@@ -5,6 +5,7 @@ import { SearchResultDataCustodianCol } from "@/interfaces/Search";
 import Box from "@/components/Box";
 import BoxStacked from "@/components/BoxStacked";
 import CardStacked from "@/components/CardStacked";
+import Paper from "@/components/Paper";
 import Typography from "@/components/Typography";
 import usePostSwr from "@/hooks/usePostSwr";
 import apis from "@/config/apis";
@@ -82,12 +83,17 @@ const DataCustodianNetwork = ({ searchParams }: DataCustodianNetworkProps) => {
                 sx={{ mt: 1, mb: 1, textDecoration: "underline" }}>
                 {t("dataCustodianNetworks")}
             </Typography>
+            {!isLoading && !data?.length && (
+                <Paper>
+                    <Box sx={{ pb: 2 }}>{t("noResults")}</Box>
+                </Paper>
+            )}
+
             <ResultsList variant="tiled">
                 {isLoading && <SkeletonCard />}
-                {!isLoading && !data?.length && (
-                    <Typography>No results found</Typography>
-                )}
+
                 {!isLoading &&
+                    data?.length &&
                     data?.map((result: SearchResultDataCustodianCol) => (
                         <CardStacked
                             key={result.id}

--- a/src/app/[locale]/(logged-out)/search/components/DataCustodianNetwork/DataCustodianNetwork.tsx
+++ b/src/app/[locale]/(logged-out)/search/components/DataCustodianNetwork/DataCustodianNetwork.tsx
@@ -4,7 +4,6 @@ import { SearchResultDataCustodianCol } from "@/interfaces/Search";
 import Box from "@/components/Box";
 import CardStacked from "@/components/CardStacked";
 import Typography from "@/components/Typography";
-import useGet from "@/hooks/useGet";
 import usePostSwr from "@/hooks/usePostSwr";
 import apis from "@/config/apis";
 import { StaticImages } from "@/config/images";
@@ -24,13 +23,7 @@ const SEARCH_PER_PAGE = 3;
 const DataCustodianNetwork = ({ searchParams }: DataCustodianNetworkProps) => {
     const t = useTranslations(TRANSLATION_PATH);
 
-    const { data: getData, mutate: mutateGet } = useGet<
-        SearchResultDataCustodianCol[]
-    >(apis.dataCustodianNetworkV1Url);
-
-    const { data: postData, mutate: mutatePost } = usePostSwr<
-        SearchResultDataCustodianCol[]
-    >(
+    const { data, mutate } = usePostSwr<SearchResultDataCustodianCol[]>(
         `${apis.searchV1Url}/data_provider_colls?view_type=mini&perPage=${SEARCH_PER_PAGE}`,
         {
             query: searchParams.query,
@@ -39,13 +32,8 @@ const DataCustodianNetwork = ({ searchParams }: DataCustodianNetworkProps) => {
     );
 
     useEffect(() => {
-        if (searchParams.query !== "") {
-            mutatePost();
-        } else {
-            mutateGet();
-        }
-    }, [searchParams, mutateGet, mutatePost]);
-    const data = postData ?? getData;
+        mutate();
+    }, [searchParams, mutate]);
 
     if (!data?.length) {
         return null;

--- a/src/app/[locale]/(logged-out)/search/components/DataCustodianNetwork/DataCustodianNetwork.tsx
+++ b/src/app/[locale]/(logged-out)/search/components/DataCustodianNetwork/DataCustodianNetwork.tsx
@@ -4,7 +4,6 @@ import { SearchResultDataCustodianCol } from "@/interfaces/Search";
 import Box from "@/components/Box";
 import CardStacked from "@/components/CardStacked";
 import Typography from "@/components/Typography";
-import useGet from "@/hooks/useGet";
 import usePostSwr from "@/hooks/usePostSwr";
 import apis from "@/config/apis";
 import { StaticImages } from "@/config/images";
@@ -24,15 +23,7 @@ const SEARCH_PER_PAGE = 3;
 const DataCustodianNetwork = ({ searchParams }: DataCustodianNetworkProps) => {
     const t = useTranslations(TRANSLATION_PATH);
 
-    const hasQuery = searchParams.query !== "";
-
-    const { data: getData, mutate: mutateGet } = useGet<
-        SearchResultDataCustodianCol[]
-    >(apis.dataCustodianNetworkV1Url);
-
-    const { data: postData, mutate: mutatePost } = usePostSwr<
-        SearchResultDataCustodianCol[]
-    >(
+    const { data, mutate } = usePostSwr<SearchResultDataCustodianCol[]>(
         `${apis.searchV1Url}/data_provider_colls?view_type=mini&perPage=${SEARCH_PER_PAGE}`,
         {
             query: searchParams.query,
@@ -41,13 +32,8 @@ const DataCustodianNetwork = ({ searchParams }: DataCustodianNetworkProps) => {
     );
 
     useEffect(() => {
-        if (hasQuery) {
-            mutatePost();
-        } else {
-            mutateGet();
-        }
-    }, [searchParams, mutateGet, mutatePost]);
-    const data = !hasQuery ? getData : postData;
+        mutate();
+    }, [searchParams, mutate]);
 
     if (!data?.length) {
         return null;

--- a/src/app/[locale]/(logged-out)/search/components/DataCustodianNetwork/DataCustodianNetwork.tsx
+++ b/src/app/[locale]/(logged-out)/search/components/DataCustodianNetwork/DataCustodianNetwork.tsx
@@ -33,53 +33,47 @@ interface DataCustodianNetworkProps {
     };
 }
 
-const SkeletonCard = () => {
-    return (
-        <>
-            {[1, 2, 3].map(item => (
-                <BoxStacked
-                    key={item} // Assign a unique key for each child
-                    sx={{ aspectRatio: "1.9 / 1", minHeight: 130 }}>
-                    <Skeleton
-                        variant="rectangular"
-                        width={300}
-                        height={160}
-                        animation="wave"
-                    />
-                </BoxStacked>
-            ))}
-        </>
-    );
-};
+const SkeletonCard = () => (
+    <>
+        {[1, 2, 3].map(item => (
+            <BoxStacked
+                key={item}
+                sx={{ aspectRatio: "1.9 / 1", minHeight: 130 }}>
+                <Skeleton
+                    variant="rectangular"
+                    width={300}
+                    height={160}
+                    animation="wave"
+                />
+            </BoxStacked>
+        ))}
+    </>
+);
 
 const TRANSLATION_PATH = "pages.search";
 const SEARCH_PER_PAGE = 3;
 
 const DataCustodianNetwork = ({ searchParams }: DataCustodianNetworkProps) => {
     const t = useTranslations(TRANSLATION_PATH);
-    let filters: DataCustodianNetworkFilterType;
-    if (searchParams?.filters && searchParams?.filters?.collection) {
-        filters = {
-            dataProviderColl: searchParams.filters?.collection,
-        };
-    }
+
+    const dataCustodianFilters: DataCustodianNetworkFilterType | undefined =
+        searchParams?.filters?.collection
+            ? { dataProviderColl: searchParams.filters.collection }
+            : undefined;
+
     const { data, mutate, isLoading } = usePostSwr<
         SearchResultDataCustodianCol[]
     >(
         `${apis.searchV1Url}/data_provider_colls?view_type=mini&perPage=${SEARCH_PER_PAGE}`,
         {
             query: searchParams.query,
-            filters: searchParams.filters,
+            filters: dataCustodianFilters,
         }
     );
 
     useEffect(() => {
         mutate();
     }, [searchParams, mutate]);
-
-    // if (!data?.length) {
-    //     return null;
-    // }
 
     return (
         <Box sx={{ mb: 1, p: 0 }}>
@@ -90,10 +84,13 @@ const DataCustodianNetwork = ({ searchParams }: DataCustodianNetworkProps) => {
             </Typography>
             <ResultsList variant="tiled">
                 {isLoading && <SkeletonCard />}
-                {!data?.length && <>No results found</>}
+                {!isLoading && !data?.length && (
+                    <Typography>No results found</Typography>
+                )}
                 {!isLoading &&
                     data?.map((result: SearchResultDataCustodianCol) => (
                         <CardStacked
+                            key={result.id}
                             href={`${RouteName.DATA_CUSTODIAN_NETWORK_ITEM}/${result.id}`}
                             title={result.name}
                             imgUrl={

--- a/src/app/[locale]/(logged-out)/search/components/DataCustodianNetwork/DataCustodianNetwork.tsx
+++ b/src/app/[locale]/(logged-out)/search/components/DataCustodianNetwork/DataCustodianNetwork.tsx
@@ -47,7 +47,7 @@ const DataCustodianNetwork = ({ searchParams }: DataCustodianNetworkProps) => {
             mutateGet();
         }
     }, [searchParams, mutateGet, mutatePost]);
-    const data = hasQuery ? getData : postData;
+    const data = !hasQuery ? getData : postData;
 
     if (!data?.length) {
         return null;

--- a/src/app/[locale]/(logged-out)/search/components/DataCustodianNetwork/DataCustodianNetwork.tsx
+++ b/src/app/[locale]/(logged-out)/search/components/DataCustodianNetwork/DataCustodianNetwork.tsx
@@ -4,6 +4,7 @@ import { SearchResultDataCustodianCol } from "@/interfaces/Search";
 import Box from "@/components/Box";
 import CardStacked from "@/components/CardStacked";
 import Typography from "@/components/Typography";
+import useGet from "@/hooks/useGet";
 import usePostSwr from "@/hooks/usePostSwr";
 import apis from "@/config/apis";
 import { StaticImages } from "@/config/images";
@@ -23,7 +24,13 @@ const SEARCH_PER_PAGE = 3;
 const DataCustodianNetwork = ({ searchParams }: DataCustodianNetworkProps) => {
     const t = useTranslations(TRANSLATION_PATH);
 
-    const { data, mutate } = usePostSwr<SearchResultDataCustodianCol[]>(
+    const { data: getData, mutate: mutateGet } = useGet<
+        SearchResultDataCustodianCol[]
+    >(apis.dataCustodianNetworkV1Url);
+
+    const { data: postData, mutate: mutatePost } = usePostSwr<
+        SearchResultDataCustodianCol[]
+    >(
         `${apis.searchV1Url}/data_provider_colls?view_type=mini&perPage=${SEARCH_PER_PAGE}`,
         {
             query: searchParams.query,
@@ -32,8 +39,13 @@ const DataCustodianNetwork = ({ searchParams }: DataCustodianNetworkProps) => {
     );
 
     useEffect(() => {
-        mutate();
-    }, [searchParams, mutate]);
+        if (searchParams.query !== "") {
+            mutatePost();
+        } else {
+            mutateGet();
+        }
+    }, [searchParams, mutateGet, mutatePost]);
+    const data = postData ?? getData;
 
     if (!data?.length) {
         return null;

--- a/src/app/[locale]/(logged-out)/search/components/DataCustodianNetwork/DataCustodianNetwork.tsx
+++ b/src/app/[locale]/(logged-out)/search/components/DataCustodianNetwork/DataCustodianNetwork.tsx
@@ -12,10 +12,24 @@ import { StaticImages } from "@/config/images";
 import { RouteName } from "@/consts/routeName";
 import ResultsList from "../ResultsList";
 
+interface FiltersType {
+    collection: {
+        dataSetTitles?: string[];
+        publisherName?: string[];
+    };
+}
+
+interface DataCustodianNetworkFilterType {
+    dataProviderColl: {
+        dataSetTitles?: string[];
+        publisherName?: string[];
+    };
+}
+
 interface DataCustodianNetworkProps {
     searchParams: {
         query?: string;
-        filters?: unknown;
+        filters?: FiltersType;
     };
 }
 
@@ -43,6 +57,12 @@ const SEARCH_PER_PAGE = 3;
 
 const DataCustodianNetwork = ({ searchParams }: DataCustodianNetworkProps) => {
     const t = useTranslations(TRANSLATION_PATH);
+    let filters: DataCustodianNetworkFilterType;
+    if (searchParams?.filters && searchParams?.filters?.collection) {
+        filters = {
+            dataProviderColl: searchParams.filters?.collection,
+        };
+    }
     const { data, mutate, isLoading } = usePostSwr<
         SearchResultDataCustodianCol[]
     >(

--- a/src/app/[locale]/(logged-out)/search/components/DataCustodianNetwork/DataCustodianNetwork.tsx
+++ b/src/app/[locale]/(logged-out)/search/components/DataCustodianNetwork/DataCustodianNetwork.tsx
@@ -1,10 +1,9 @@
 import { useEffect } from "react";
-import { Skeleton } from "@mui/material";
 import { useTranslations } from "next-intl";
 import { SearchResultDataCustodianCol } from "@/interfaces/Search";
 import Box from "@/components/Box";
-import BoxStacked from "@/components/BoxStacked";
 import CardStacked from "@/components/CardStacked";
+import CardStackedSkeleton from "@/components/CardStacked/CardStackedSkeleton";
 import Paper from "@/components/Paper";
 import Typography from "@/components/Typography";
 import usePostSwr from "@/hooks/usePostSwr";
@@ -23,44 +22,41 @@ interface FiltersType {
 interface DataCustodianNetworkFilterType {
     datacustodiannetwork: {
         datasetTitles?: string[];
-        publisherName?: string[];
+        publisherNames?: string[];
     };
 }
 
 interface DataCustodianNetworkProps {
-    searchParams: {
+    searchParams?: {
         query?: string;
         filters?: FiltersType;
     };
 }
 
-const SkeletonCard = () => (
-    <>
-        {[1, 2, 3].map(item => (
-            <BoxStacked
-                key={item}
-                sx={{ aspectRatio: "1.9 / 1", minHeight: 130, opacity: "0.5" }}>
-                <Skeleton
-                    variant="rectangular"
-                    width={300}
-                    height={160}
-                    animation="wave"
-                />
-            </BoxStacked>
-        ))}
-    </>
-);
-
 const TRANSLATION_PATH = "pages.search";
 const SEARCH_PER_PAGE = 3;
 
-const DataCustodianNetwork = ({ searchParams }: DataCustodianNetworkProps) => {
+const DataCustodianNetwork = ({
+    searchParams = {},
+}: DataCustodianNetworkProps) => {
     const t = useTranslations(TRANSLATION_PATH);
 
-    const dataCustodianFilters: DataCustodianNetworkFilterType | undefined =
-        searchParams?.filters?.collection
-            ? { datacustodiannetwork: searchParams.filters.collection }
-            : undefined;
+    const generateDataCustodianFilters = ():
+        | DataCustodianNetworkFilterType
+        | undefined => {
+        const { filters } = searchParams;
+        if (filters?.collection) {
+            return {
+                datacustodiannetwork: {
+                    datasetTitles: filters.collection.datasetTitles,
+                    publisherNames: filters.collection.publisherName,
+                },
+            };
+        }
+        return undefined;
+    };
+
+    const dataCustodianFilters = generateDataCustodianFilters();
 
     const { data, mutate, isLoading } = usePostSwr<
         SearchResultDataCustodianCol[]
@@ -88,13 +84,11 @@ const DataCustodianNetwork = ({ searchParams }: DataCustodianNetworkProps) => {
                     <Box sx={{ pb: 2 }}>{t("noResults")}</Box>
                 </Paper>
             )}
-
             <ResultsList variant="tiled">
-                {isLoading && <SkeletonCard />}
-
+                {isLoading &&
+                    [1, 2, 3].map(item => <CardStackedSkeleton key={item} />)}
                 {!isLoading &&
-                    data?.length &&
-                    data?.map((result: SearchResultDataCustodianCol) => (
+                    data?.map(result => (
                         <CardStacked
                             key={result.id}
                             href={`${RouteName.DATA_CUSTODIAN_NETWORK_ITEM}/${result.id}`}

--- a/src/app/[locale]/(logged-out)/search/components/DataCustodianNetwork/DataCustodianNetwork.tsx
+++ b/src/app/[locale]/(logged-out)/search/components/DataCustodianNetwork/DataCustodianNetwork.tsx
@@ -1,7 +1,9 @@
 import { useEffect } from "react";
+import { Skeleton } from "@mui/material";
 import { useTranslations } from "next-intl";
 import { SearchResultDataCustodianCol } from "@/interfaces/Search";
 import Box from "@/components/Box";
+import BoxStacked from "@/components/BoxStacked";
 import CardStacked from "@/components/CardStacked";
 import Typography from "@/components/Typography";
 import usePostSwr from "@/hooks/usePostSwr";
@@ -17,13 +19,33 @@ interface DataCustodianNetworkProps {
     };
 }
 
+const SkeletonCard = () => {
+    return (
+        <>
+            {[1, 2, 3].map(item => (
+                <BoxStacked
+                    key={item} // Assign a unique key for each child
+                    sx={{ aspectRatio: "1.9 / 1", minHeight: 130 }}>
+                    <Skeleton
+                        variant="rectangular"
+                        width={300}
+                        height={160}
+                        animation="wave"
+                    />
+                </BoxStacked>
+            ))}
+        </>
+    );
+};
+
 const TRANSLATION_PATH = "pages.search";
 const SEARCH_PER_PAGE = 3;
 
 const DataCustodianNetwork = ({ searchParams }: DataCustodianNetworkProps) => {
     const t = useTranslations(TRANSLATION_PATH);
-
-    const { data, mutate } = usePostSwr<SearchResultDataCustodianCol[]>(
+    const { data, mutate, isLoading } = usePostSwr<
+        SearchResultDataCustodianCol[]
+    >(
         `${apis.searchV1Url}/data_provider_colls?view_type=mini&perPage=${SEARCH_PER_PAGE}`,
         {
             query: searchParams.query,
@@ -35,9 +57,9 @@ const DataCustodianNetwork = ({ searchParams }: DataCustodianNetworkProps) => {
         mutate();
     }, [searchParams, mutate]);
 
-    if (!data?.length) {
-        return null;
-    }
+    // if (!data?.length) {
+    //     return null;
+    // }
 
     return (
         <Box sx={{ mb: 1, p: 0 }}>
@@ -47,15 +69,18 @@ const DataCustodianNetwork = ({ searchParams }: DataCustodianNetworkProps) => {
                 {t("dataCustodianNetworks")}
             </Typography>
             <ResultsList variant="tiled">
-                {data?.map((result: SearchResultDataCustodianCol) => (
-                    <CardStacked
-                        href={`${RouteName.DATA_CUSTODIAN_NETWORK_ITEM}/${result.id}`}
-                        title={result.name}
-                        imgUrl={
-                            result?.img_url || StaticImages.BASE.placeholder
-                        }
-                    />
-                ))}
+                {isLoading && <SkeletonCard />}
+                {!data?.length && <>No results found</>}
+                {!isLoading &&
+                    data?.map((result: SearchResultDataCustodianCol) => (
+                        <CardStacked
+                            href={`${RouteName.DATA_CUSTODIAN_NETWORK_ITEM}/${result.id}`}
+                            title={result.name}
+                            imgUrl={
+                                result?.img_url || StaticImages.BASE.placeholder
+                            }
+                        />
+                    ))}
             </ResultsList>
         </Box>
     );

--- a/src/app/[locale]/(logged-out)/search/components/DataCustodianNetwork/DataCustodianNetwork.tsx
+++ b/src/app/[locale]/(logged-out)/search/components/DataCustodianNetwork/DataCustodianNetwork.tsx
@@ -4,6 +4,7 @@ import { SearchResultDataCustodianCol } from "@/interfaces/Search";
 import Box from "@/components/Box";
 import CardStacked from "@/components/CardStacked";
 import Typography from "@/components/Typography";
+import useGet from "@/hooks/useGet";
 import usePostSwr from "@/hooks/usePostSwr";
 import apis from "@/config/apis";
 import { StaticImages } from "@/config/images";
@@ -23,7 +24,15 @@ const SEARCH_PER_PAGE = 3;
 const DataCustodianNetwork = ({ searchParams }: DataCustodianNetworkProps) => {
     const t = useTranslations(TRANSLATION_PATH);
 
-    const { data, mutate } = usePostSwr<SearchResultDataCustodianCol[]>(
+    const hasQuery = searchParams.query !== "";
+
+    const { data: getData, mutate: mutateGet } = useGet<
+        SearchResultDataCustodianCol[]
+    >(apis.dataCustodianNetworkV1Url);
+
+    const { data: postData, mutate: mutatePost } = usePostSwr<
+        SearchResultDataCustodianCol[]
+    >(
         `${apis.searchV1Url}/data_provider_colls?view_type=mini&perPage=${SEARCH_PER_PAGE}`,
         {
             query: searchParams.query,
@@ -32,8 +41,13 @@ const DataCustodianNetwork = ({ searchParams }: DataCustodianNetworkProps) => {
     );
 
     useEffect(() => {
-        mutate();
-    }, [searchParams, mutate]);
+        if (hasQuery) {
+            mutatePost();
+        } else {
+            mutateGet();
+        }
+    }, [searchParams, mutateGet, mutatePost]);
+    const data = hasQuery ? getData : postData;
 
     if (!data?.length) {
         return null;

--- a/src/app/[locale]/(logged-out)/search/components/DataCustodianNetwork/DataCustodianNetwork.tsx
+++ b/src/app/[locale]/(logged-out)/search/components/DataCustodianNetwork/DataCustodianNetwork.tsx
@@ -15,14 +15,14 @@ import ResultsList from "../ResultsList";
 
 interface FiltersType {
     collection: {
-        dataSetTitles?: string[];
+        datasetTitles?: string[];
         publisherName?: string[];
     };
 }
 
 interface DataCustodianNetworkFilterType {
-    dataProviderColl: {
-        dataSetTitles?: string[];
+    datacustodiannetwork: {
+        datasetTitles?: string[];
         publisherName?: string[];
     };
 }
@@ -59,7 +59,7 @@ const DataCustodianNetwork = ({ searchParams }: DataCustodianNetworkProps) => {
 
     const dataCustodianFilters: DataCustodianNetworkFilterType | undefined =
         searchParams?.filters?.collection
-            ? { dataProviderColl: searchParams.filters.collection }
+            ? { datacustodiannetwork: searchParams.filters.collection }
             : undefined;
 
     const { data, mutate, isLoading } = usePostSwr<

--- a/src/components/CardStacked/CardStacked.tsx
+++ b/src/components/CardStacked/CardStacked.tsx
@@ -13,6 +13,8 @@ export interface CardStackedProps {
     boxStackedProps?: BoxStackedProps;
 }
 
+export const boxStackedSX = { aspectRatio: "1.9 / 1", minHeight: 130 };
+
 export default function CardStacked({
     href,
     imgUrl,
@@ -21,9 +23,7 @@ export default function CardStacked({
     chipProps,
 }: CardStackedProps) {
     return (
-        <BoxStacked
-            sx={{ aspectRatio: "1.9 / 1", minHeight: 130 }}
-            {...boxStackedProps}>
+        <BoxStacked sx={boxStackedSX} {...boxStackedProps}>
             <Box
                 component={Link}
                 href={href}

--- a/src/components/CardStacked/CardStackedSkeleton.tsx
+++ b/src/components/CardStacked/CardStackedSkeleton.tsx
@@ -1,0 +1,25 @@
+import { Skeleton } from "@mui/material";
+import BoxStacked from "@/components/BoxStacked";
+import { BoxStackedProps } from "@/components/BoxStacked/BoxStacked";
+import { boxStackedSX } from "./CardStacked";
+
+export interface CardStackedSkeletonProps {
+    boxStackedProps?: BoxStackedProps;
+}
+
+export default function CardStackedSkeleton({
+    boxStackedProps,
+}: CardStackedSkeletonProps) {
+    return (
+        <BoxStacked
+            sx={{ ...boxStackedSX, opacity: "0.75" }}
+            {...boxStackedProps}>
+            <Skeleton
+                variant="rectangular"
+                width={300}
+                height="100%"
+                animation="wave"
+            />
+        </BoxStacked>
+    );
+}


### PR DESCRIPTION
## Screenshots (if relevant)
Loading: 
![image](https://github.com/user-attachments/assets/c9b4ca19-2ad1-48f2-b1f6-fedde8e9c33c)

Zero results: 
![image](https://github.com/user-attachments/assets/a19a042c-3a1a-4f1a-897a-eb16993bafad)

## Describe your changes
The post call when first loading takes 3-6-8 seconds to load everything. Spoken to Loki with stephen to have skeleton loaders until we can look at getting them to be returned quicker.
The filters are also in the incorrect key for this request, so change them over.



## Issue ticket link
https://hdruk.atlassian.net/jira/software/c/projects/GAT/boards/51?assignee=712020%3A05fbbf0f-9386-469a-a212-84cfbf9cc587&selectedIssue=GAT-5237
## Checklist before requesting a review

-   [ ] I have performed a self-review of my code
-   [ ] I have added appropriate unit tests
-   [ ] I have created mocks for unit tests (where appropriate)
-   [ ] The interface is responsive (where appropriate)
-   [ ] The interface is at least AA (where appropriate)
