### PR TITLE
Use updated_at from db, not in schema

### DIFF
--- a/src/components/DatasetCard/DatasetCard.tsx
+++ b/src/components/DatasetCard/DatasetCard.tsx
@@ -26,7 +26,8 @@ const DatasetCard = ({ dataset, actions }: DatasetCardProps) => {
 
     if (!latestMetadata) return null;
 
-    const { updated_at, gwdmVersion } = latestMetadata;
+    const { updated_at } = dataset;
+    const { gwdmVersion } = latestMetadata;
 
     const title = get(latestMetadata, "summary.title") as unknown as string;
     const publisherName = get(

--- a/src/interfaces/Dataset.ts
+++ b/src/interfaces/Dataset.ts
@@ -190,6 +190,7 @@ interface Dataset {
     pid: string | null;
     versions: VersionItem[];
     updated: string;
+    updated_at: string;
     create_origin: CreateOrigin;
     latest_metadata?: VersionItem;
     durs_count: number;


### PR DESCRIPTION
## Screenshots (if relevant)
![image](https://github.com/user-attachments/assets/b83cfbcd-d067-431b-b5ef-684cc2c62bf1)


## Describe your changes
Grab `updated_at` from database, field doesn't exist in schema 

## Issue ticket link

## Checklist before requesting a review

-   [ ] I have performed a self-review of my code
-   [ ] I have added appropriate unit tests
-   [ ] I have created mocks for unit tests (where appropriate)
-   [ ] The interface is responsive (where appropriate)
-   [ ] The interface is at least AA (where appropriate)
