### PR TITLE
fix: (GAT-5787)  - queryParam Arrays

### DIFF
--- a/src/app/[locale]/(logged-out)/search/components/Search/Search.tsx
+++ b/src/app/[locale]/(logged-out)/search/components/Search/Search.tsx
@@ -174,7 +174,7 @@ const Search = ({ filters }: SearchProps) => {
         [FILTER_GEOGRAPHIC_LOCATION]: getParamArray(FILTER_GEOGRAPHIC_LOCATION),
         [FILTER_DATE_RANGE]: getParamArray(FILTER_DATE_RANGE, true),
         [FILTER_ORGANISATION_NAME]: getParamArray(FILTER_ORGANISATION_NAME),
-        [FILTER_DATA_SET_TITLES]: getParamArray(FILTER_DATA_SET_TITLES),
+        [FILTER_DATA_SET_TITLES]: searchParams?.getAll(FILTER_DATA_SET_TITLES),
         [FILTER_DATA_TYPE]: getParamArray(FILTER_DATA_TYPE),
         [FILTER_DATA_SUBTYPE]: getParamArray(FILTER_DATA_SUBTYPE),
         [FILTER_PUBLICATION_DATE]: getParamArray(FILTER_PUBLICATION_DATE, true),

--- a/src/app/[locale]/(logged-out)/search/components/Search/Search.tsx
+++ b/src/app/[locale]/(logged-out)/search/components/Search/Search.tsx
@@ -221,6 +221,22 @@ const Search = ({ filters }: SearchProps) => {
         }
     }, [queryParams.type, resultsView]);
 
+    const removeArrayQueryAndPush = (paramKey: string, paramValue: string) => {
+        const currentParams = new URLSearchParams(searchParams?.toString());
+
+        const newParams = new URLSearchParams();
+        for (const [key, value] of currentParams.entries()) {
+            if (!(key === paramKey && value === paramValue)) {
+                newParams.append(key, value);
+            }
+        }
+
+        router.push(`?${newParams.toString()}`),
+            {
+                scroll: false,
+            };
+    };
+
     const updatePath = useCallback(
         (key: string, value: string) => {
             router.push(`${pathname}?${updateQueryString(key, value)}`, {
@@ -426,7 +442,11 @@ const Search = ({ filters }: SearchProps) => {
         }
 
         setQueryParams({ ...queryParams, [filterType]: filtered });
-        updatePath(filterType, filtered.join(","));
+        if (filterType === FILTER_DATA_SET_TITLES) {
+            removeArrayQueryAndPush(filterType, removedFilter);
+        } else {
+            updatePath(filterType, filtered.join(","));
+        }
     };
 
     const handleChangeView = (viewType: ViewType) => {

--- a/src/app/[locale]/(logged-out)/search/components/Search/Search.tsx
+++ b/src/app/[locale]/(logged-out)/search/components/Search/Search.tsx
@@ -223,17 +223,17 @@ const Search = ({ filters }: SearchProps) => {
 
     const removeArrayQueryAndPush = (paramKey: string, paramValue: string) => {
         const currentParams = new URLSearchParams(searchParams?.toString());
-    
+
         const newParams = new URLSearchParams(
-            Array.from(currentParams.entries())
-                .filter(([key, value]) => !(key === paramKey && value === paramValue))
+            Array.from(currentParams.entries()).filter(
+                ([key, value]) => !(key === paramKey && value === paramValue)
+            )
         );
-    
+
         router.push(`?${newParams.toString()}`, {
             scroll: false,
         });
     };
-    
 
     const updatePath = useCallback(
         (key: string, value: string) => {

--- a/src/app/[locale]/(logged-out)/search/components/Search/Search.tsx
+++ b/src/app/[locale]/(logged-out)/search/components/Search/Search.tsx
@@ -223,19 +223,17 @@ const Search = ({ filters }: SearchProps) => {
 
     const removeArrayQueryAndPush = (paramKey: string, paramValue: string) => {
         const currentParams = new URLSearchParams(searchParams?.toString());
-
-        const newParams = new URLSearchParams();
-        for (const [key, value] of currentParams.entries()) {
-            if (!(key === paramKey && value === paramValue)) {
-                newParams.append(key, value);
-            }
-        }
-
-        router.push(`?${newParams.toString()}`),
-            {
-                scroll: false,
-            };
+    
+        const newParams = new URLSearchParams(
+            Array.from(currentParams.entries())
+                .filter(([key, value]) => !(key === paramKey && value === paramValue))
+        );
+    
+        router.push(`?${newParams.toString()}`, {
+            scroll: false,
+        });
     };
+    
 
     const updatePath = useCallback(
         (key: string, value: string) => {


### PR DESCRIPTION
## Screenshots (if relevant)
Before:
![image](https://github.com/user-attachments/assets/5e75f5cd-b271-43c5-a057-c574ce801767)

After: 
![image](https://github.com/user-attachments/assets/f0bf1314-e79d-4f27-babe-0b39d266ad21)

## Describe your changes
Query param arrays should not be comma delimited, they should be set as web standards: see [mozzila](https://developer.mozilla.org/en-US/docs/Web/API/URLSearchParams/getAll)
So from: /datasetExample?filter=1,2,3
To: 
/datasetExample?filter=1&filter=2&filter=3

Only datasetTitles will be changed for now with hopefully minimal fallout as I can't see anything generating comma delimited in the app.


## Issue ticket link
https://hdruk.atlassian.net/jira/software/c/projects/GAT/boards/51?assignee=712020%3A05fbbf0f-9386-469a-a212-84cfbf9cc587&selectedIssue=GAT-5787
## Checklist before requesting a review

-   [ ] I have performed a self-review of my code
-   [ ] I have added appropriate unit tests
-   [ ] I have created mocks for unit tests (where appropriate)
-   [ ] The interface is responsive (where appropriate)
-   [ ] The interface is at least AA (where appropriate)
