### PR TITLE
Feat/gat 6180: update news/events and release pages to handle multiple years

### DIFF
--- a/mocks/data/cms/v1/cms.data.ts
+++ b/mocks/data/cms/v1/cms.data.ts
@@ -146,6 +146,15 @@ const generateEventsV1 = (data = {}): CMSPostsResponse<EventNode> => {
                         .toISOString(),
                     "2"
                 ),
+                generateEventNode(
+                    faker.date
+                        .between(
+                            "2025-01-01T00:00:00.000Z",
+                            "2025-03-01T00:00:00.000Z"
+                        )
+                        .toISOString(),
+                    "3"
+                ),
             ],
         },
         ...data,

--- a/mocks/data/cms/v1/cms.data.ts
+++ b/mocks/data/cms/v1/cms.data.ts
@@ -155,6 +155,15 @@ const generateEventsV1 = (data = {}): CMSPostsResponse<EventNode> => {
                         .toISOString(),
                     "3"
                 ),
+                generateEventNode(
+                    faker.date
+                        .between(
+                            "2026-01-01T00:00:00.000Z",
+                            "2026-03-01T00:00:00.000Z"
+                        )
+                        .toISOString(),
+                    "3"
+                ),
             ],
         },
         ...data,

--- a/src/app/[locale]/(logged-out)/news/events/components/Content/Content.tsx
+++ b/src/app/[locale]/(logged-out)/news/events/components/Content/Content.tsx
@@ -28,11 +28,14 @@ const Content = ({ data }: ContentProps) => {
     const tab = params?.get("tab") || "news";
 
     const generatedData = useMemo(() => {
-        const years = rangeRight(currentYear, currentYear + 2).map(String);
+        const years = rangeRight(2024, currentYear + 2).map(String);
 
         return years.map(year => {
             const dataByYear = getNewsEventsByYear(data, year);
-
+            // Next year's tab should only show if it contains an item
+            if (Number(year) === currentYear + 1 && dataByYear.length === 0) {
+                return {};
+            }
             return {
                 label: year,
                 value: year,
@@ -90,7 +93,8 @@ const Content = ({ data }: ContentProps) => {
                     </div>
                 ),
             };
-        });
+        })
+        .filter((yearTab: object) => Object.keys(yearTab).length > 0);
     }, [data]);
 
     return (

--- a/src/app/[locale]/(logged-out)/news/events/components/Content/Content.tsx
+++ b/src/app/[locale]/(logged-out)/news/events/components/Content/Content.tsx
@@ -30,71 +30,83 @@ const Content = ({ data }: ContentProps) => {
     const generatedData = useMemo(() => {
         const years = rangeRight(2024, currentYear + 2).map(String);
 
-        return years.map(year => {
-            const dataByYear = getNewsEventsByYear(data, year);
-            // Next year's tab should only show if it contains an item
-            if (Number(year) === currentYear + 1 && dataByYear.length === 0) {
-                return {};
-            }
-            return {
-                label: year,
-                value: year,
-                content: (
-                    <div>
-                        {!dataByYear.length ? (
-                            <Box component="p" sx={{ px: 2 }}>
-                                {t("noResults", {
-                                    year,
-                                })}
-                            </Box>
-                        ) : (
-                            <Grid container rowSpacing={4} columnSpacing={4}>
-                                {dataByYear.map(item => {
-                                    return (
-                                        <Grid
-                                            item
-                                            desktop={3}
-                                            tablet={4}
-                                            mobile={12}>
-                                            <NewsSummaryCard
-                                                summary={item.newsFields.text}
-                                                imageLink={
-                                                    item.newsFields?.image?.node
-                                                        ?.mediaItemUrl
-                                                }
-                                                imageAlt={
-                                                    item.newsFields?.image?.node
-                                                        ?.altText
-                                                }
-                                                headline={
-                                                    item.newsFields.headline
-                                                }
-                                                date={item.newsFields.date}
-                                                url={
-                                                    item.newsFields?.link
-                                                        ?.url ||
-                                                    `/${
-                                                        tab === "news"
-                                                            ? RouteName.NEWS_ARTICLE
-                                                            : RouteName.EVENT_ARTICLE
-                                                    }/${item.slug}`
-                                                }
-                                                buttonText={
-                                                    item.newsFields?.link
-                                                        ?.title || t("readMore")
-                                                }
-                                                key={item.newsFields.headline}
-                                            />
-                                        </Grid>
-                                    );
-                                })}
-                            </Grid>
-                        )}
-                    </div>
-                ),
-            };
-        })
-        .filter((yearTab: object) => Object.keys(yearTab).length > 0);
+        return years
+            .map(year => {
+                const dataByYear = getNewsEventsByYear(data, year);
+                // Next year's tab should only show if it contains an item
+                if (
+                    Number(year) === currentYear + 1 &&
+                    dataByYear.length === 0
+                ) {
+                    return {};
+                }
+                return {
+                    label: year,
+                    value: year,
+                    content: (
+                        <div>
+                            {!dataByYear.length ? (
+                                <Box component="p" sx={{ px: 2 }}>
+                                    {t("noResults", {
+                                        year,
+                                    })}
+                                </Box>
+                            ) : (
+                                <Grid
+                                    container
+                                    rowSpacing={4}
+                                    columnSpacing={4}>
+                                    {dataByYear.map(item => {
+                                        return (
+                                            <Grid
+                                                item
+                                                desktop={3}
+                                                tablet={4}
+                                                mobile={12}>
+                                                <NewsSummaryCard
+                                                    summary={
+                                                        item.newsFields.text
+                                                    }
+                                                    imageLink={
+                                                        item.newsFields?.image
+                                                            ?.node?.mediaItemUrl
+                                                    }
+                                                    imageAlt={
+                                                        item.newsFields?.image
+                                                            ?.node?.altText
+                                                    }
+                                                    headline={
+                                                        item.newsFields.headline
+                                                    }
+                                                    date={item.newsFields.date}
+                                                    url={
+                                                        item.newsFields?.link
+                                                            ?.url ||
+                                                        `/${
+                                                            tab === "news"
+                                                                ? RouteName.NEWS_ARTICLE
+                                                                : RouteName.EVENT_ARTICLE
+                                                        }/${item.slug}`
+                                                    }
+                                                    buttonText={
+                                                        item.newsFields?.link
+                                                            ?.title ||
+                                                        t("readMore")
+                                                    }
+                                                    key={
+                                                        item.newsFields.headline
+                                                    }
+                                                />
+                                            </Grid>
+                                        );
+                                    })}
+                                </Grid>
+                            )}
+                        </div>
+                    ),
+                };
+            })
+            .filter((yearTab: object) => Object.keys(yearTab).length > 0);
     }, [data]);
 
     return (

--- a/src/app/[locale]/(logged-out)/news/events/page.test.tsx
+++ b/src/app/[locale]/(logged-out)/news/events/page.test.tsx
@@ -9,13 +9,17 @@ jest.mock("@/utils/cms", () => ({
     getNews: async () => newsV1.posts.edges,
 }));
 
-jest.useFakeTimers().setSystemTime(new Date("2024-01-01"));
+jest.useFakeTimers().setSystemTime(new Date("2025-01-01"));
 
 describe("NewsEvents", () => {
     it("renders the news content", async () => {
         const Result = await NewsEventsPage();
 
         render(Result);
+
+        act(() => {
+            mockRouter.setCurrentUrl("/news_events?tab=news&year=2024");
+        });
 
         await waitFor(() => {
             expect(
@@ -35,7 +39,7 @@ describe("NewsEvents", () => {
         render(Result);
 
         act(() => {
-            mockRouter.setCurrentUrl("/news_events?tab=news&year=2025");
+            mockRouter.setCurrentUrl("/news_events?tab=news");
         });
 
         await waitFor(() => {
@@ -57,12 +61,12 @@ describe("NewsEvents", () => {
         await waitFor(() => {
             expect(
                 screen.getByText(
-                    eventsV1.posts.edges[0].node.newsFields.headline
+                    eventsV1.posts.edges[2].node.newsFields.headline
                 )
             ).toBeInTheDocument();
             expect(
                 screen.queryByText(
-                    newsV1.posts.edges[0].node.newsFields.headline
+                    newsV1.posts.edges[1].node.newsFields.headline
                 )
             ).not.toBeInTheDocument();
         });
@@ -74,18 +78,18 @@ describe("NewsEvents", () => {
         render(Result);
 
         act(() => {
-            mockRouter.setCurrentUrl("/news_events?tab=events&year=2025");
+            mockRouter.setCurrentUrl("/news_events?tab=events&year=2026");
         });
 
         await waitFor(() => {
             expect(
                 screen.getByText(
-                    eventsV1.posts.edges[2].node.newsFields.headline
+                    eventsV1.posts.edges[3].node.newsFields.headline
                 )
             ).toBeInTheDocument();
             expect(
                 screen.queryByText(
-                    newsV1.posts.edges[2].node.newsFields.headline
+                    newsV1.posts.edges[1].node.newsFields.headline
                 )
             ).not.toBeInTheDocument();
         });

--- a/src/app/[locale]/(logged-out)/news/events/page.test.tsx
+++ b/src/app/[locale]/(logged-out)/news/events/page.test.tsx
@@ -67,4 +67,27 @@ describe("NewsEvents", () => {
             ).not.toBeInTheDocument();
         });
     });
+
+    it("renders the events content for next year if content is available", async () => {
+        const Result = await NewsEventsPage();
+
+        render(Result);
+
+        act(() => {
+            mockRouter.setCurrentUrl("/news_events?tab=events&year=2025");
+        });
+
+        await waitFor(() => {
+            expect(
+                screen.getByText(
+                    eventsV1.posts.edges[2].node.newsFields.headline
+                )
+            ).toBeInTheDocument();
+            expect(
+                screen.queryByText(
+                    newsV1.posts.edges[2].node.newsFields.headline
+                )
+            ).not.toBeInTheDocument();
+        });
+    });
 });

--- a/src/app/[locale]/(logged-out)/news/releases/components/ReleaseTabs/ReleaseTabs.test.tsx
+++ b/src/app/[locale]/(logged-out)/news/releases/components/ReleaseTabs/ReleaseTabs.test.tsx
@@ -22,7 +22,7 @@ const mockedReleases: ReleaseNode[] = [
 ];
 
 describe("ReleaseTabs", () => {
-    it("renders tabs with release content", () => {
+    it("renders tabs with release content up to this year", () => {
         render(<ReleaseTabs allReleases={mockedReleases} />);
 
         const tab2024 = screen.getByText("2024");
@@ -42,48 +42,7 @@ describe("ReleaseTabs", () => {
             screen.getByText(mockedReleases[1].node.content)
         ).toBeInTheDocument();
 
-        const tab2025 = screen.getByText("2025");
-
-        expect(tab2025).toBeInTheDocument();
-
-        expect(
-            screen.getByText(mockedReleases[2].node.title)
-        ).toBeInTheDocument();
-        expect(
-            screen.getByText(mockedReleases[2].node.content)
-        ).toBeInTheDocument();
-    });
-
-    it("doesn't render a tab for next year unless there is release content", () => {
-        render(<ReleaseTabs allReleases={mockedReleases.slice(0, 2)} />);
-
-        const tab2024 = screen.getByText("2024");
-
-        expect(tab2024).toBeInTheDocument();
-
-        expect(
-            screen.getByText(mockedReleases[0].node.title)
-        ).toBeInTheDocument();
-        expect(
-            screen.getByText(mockedReleases[0].node.content)
-        ).toBeInTheDocument();
-        expect(
-            screen.getByText(mockedReleases[1].node.title)
-        ).toBeInTheDocument();
-        expect(
-            screen.getByText(mockedReleases[1].node.content)
-        ).toBeInTheDocument();
-
-        const tab2025 = screen.getByText("2025");
-
-        expect(tab2025).not.toBeInTheDocument();
-
-        expect(
-            screen.getByText(mockedReleases[2].node.title)
-        ).not.toBeInTheDocument();
-        expect(
-            screen.getByText(mockedReleases[2].node.content)
-        ).not.toBeInTheDocument();
+        expect(screen.queryByText("2025")).not.toBeInTheDocument();
     });
 
     it("displays a message for a year with no releases", () => {

--- a/src/app/[locale]/(logged-out)/news/releases/components/ReleaseTabs/ReleaseTabs.test.tsx
+++ b/src/app/[locale]/(logged-out)/news/releases/components/ReleaseTabs/ReleaseTabs.test.tsx
@@ -35,6 +35,55 @@ describe("ReleaseTabs", () => {
         expect(
             screen.getByText(mockedReleases[0].node.content)
         ).toBeInTheDocument();
+        expect(
+            screen.getByText(mockedReleases[1].node.title)
+        ).toBeInTheDocument();
+        expect(
+            screen.getByText(mockedReleases[1].node.content)
+        ).toBeInTheDocument();
+
+        const tab2025 = screen.getByText("2025");
+
+        expect(tab2025).toBeInTheDocument();
+
+        expect(
+            screen.getByText(mockedReleases[2].node.title)
+        ).toBeInTheDocument();
+        expect(
+            screen.getByText(mockedReleases[2].node.content)
+        ).toBeInTheDocument();
+    });
+
+    it("doesn't render a tab for next year unless there is release content", () => {
+        render(<ReleaseTabs allReleases={mockedReleases.slice(0, 2)} />);
+
+        const tab2024 = screen.getByText("2024");
+
+        expect(tab2024).toBeInTheDocument();
+
+        expect(
+            screen.getByText(mockedReleases[0].node.title)
+        ).toBeInTheDocument();
+        expect(
+            screen.getByText(mockedReleases[0].node.content)
+        ).toBeInTheDocument();
+        expect(
+            screen.getByText(mockedReleases[1].node.title)
+        ).toBeInTheDocument();
+        expect(
+            screen.getByText(mockedReleases[1].node.content)
+        ).toBeInTheDocument();
+
+        const tab2025 = screen.getByText("2025");
+
+        expect(tab2025).not.toBeInTheDocument();
+
+        expect(
+            screen.getByText(mockedReleases[2].node.title)
+        ).not.toBeInTheDocument();
+        expect(
+            screen.getByText(mockedReleases[2].node.content)
+        ).not.toBeInTheDocument();
     });
 
     it("displays a message for a year with no releases", () => {

--- a/src/app/[locale]/(logged-out)/news/releases/components/ReleaseTabs/ReleaseTabs.tsx
+++ b/src/app/[locale]/(logged-out)/news/releases/components/ReleaseTabs/ReleaseTabs.tsx
@@ -68,7 +68,6 @@ const ReleaseTabs = ({ allReleases }: ReleaseTabProps) => {
                     </div>
                 ),
             };
-
             return hydratedReleases;
         });
     }, [allReleases, expanded, years]);

--- a/src/app/[locale]/(logged-out)/news/releases/components/ReleaseTabs/ReleaseTabs.tsx
+++ b/src/app/[locale]/(logged-out)/news/releases/components/ReleaseTabs/ReleaseTabs.tsx
@@ -25,59 +25,52 @@ const ReleaseTabs = ({ allReleases }: ReleaseTabProps) => {
     const [expanded, setExpanded] = useState<string | null>(null);
     const t = useTranslations(TRANSLATIONS_NAMESPACE_RELEASES);
     const currentYear = dayjs().year();
-    const years = rangeRight(2024, currentYear + 2).map(String);
+    const years = rangeRight(2024, currentYear + 1).map(String);
 
     const handleChange = (isExpanded: boolean, panel: string) => {
         setExpanded(isExpanded ? panel : null);
     };
 
     const generatedReleases = useMemo(() => {
-        return years
-            .map(year => {
-                const releases = getReleaseByYear(allReleases, year);
-                // Next year's tab should only show if it contains a release
-                if (Number(year) === currentYear + 1 && releases.length === 0) {
-                    return {};
-                }
-                const hydratedReleases = {
-                    label: year,
-                    value: year,
-                    content: (
-                        <div>
-                            {!releases.length && (
-                                <Box component="p" sx={{ px: 2 }}>
-                                    {t("noResults", {
-                                        year,
-                                    })}
-                                </Box>
-                            )}
-                            {releases.map((release, index) => (
-                                <Accordion
-                                    key={release.date}
-                                    defaultExpanded={
-                                        expanded === release.id || index === 0
-                                    }
-                                    heading={
-                                        <Typography>{release.title}</Typography>
-                                    }
-                                    onChange={(event, isExpanded) =>
-                                        handleChange(isExpanded, release.id)
-                                    }
-                                    contents={
-                                        <HTMLContent
-                                            content={release.content}
-                                        />
-                                    }
-                                    iconLeft
-                                />
-                            ))}
-                        </div>
-                    ),
-                };
+        return years.map(year => {
+            const releases = getReleaseByYear(allReleases, year);
 
-                return hydratedReleases;
-            })
-            .filter((yearTab: object) => Object.keys(yearTab).length > 0);
+            const hydratedReleases = {
+                label: year,
+                value: year,
+                content: (
+                    <div>
+                        {!releases.length && (
+                            <Box component="p" sx={{ px: 2 }}>
+                                {t("noResults", {
+                                    year,
+                                })}
+                            </Box>
+                        )}
+                        {releases.map((release, index) => (
+                            <Accordion
+                                key={release.date}
+                                defaultExpanded={
+                                    expanded === release.id || index === 0
+                                }
+                                heading={
+                                    <Typography>{release.title}</Typography>
+                                }
+                                onChange={(event, isExpanded) =>
+                                    handleChange(isExpanded, release.id)
+                                }
+                                contents={
+                                    <HTMLContent content={release.content} />
+                                }
+                                iconLeft
+                            />
+                        ))}
+                    </div>
+                ),
+            };
+
+            return hydratedReleases;
+        });
     }, [allReleases, expanded, years]);
 
     return (

--- a/src/app/[locale]/(logged-out)/news/releases/components/ReleaseTabs/ReleaseTabs.tsx
+++ b/src/app/[locale]/(logged-out)/news/releases/components/ReleaseTabs/ReleaseTabs.tsx
@@ -25,51 +25,59 @@ const ReleaseTabs = ({ allReleases }: ReleaseTabProps) => {
     const [expanded, setExpanded] = useState<string | null>(null);
     const t = useTranslations(TRANSLATIONS_NAMESPACE_RELEASES);
     const currentYear = dayjs().year();
-    const years = rangeRight(currentYear, currentYear + 1).map(String);
+    const years = rangeRight(2024, currentYear + 2).map(String);
 
     const handleChange = (isExpanded: boolean, panel: string) => {
         setExpanded(isExpanded ? panel : null);
     };
 
     const generatedReleases = useMemo(() => {
-        return years.map(year => {
-            const releases = getReleaseByYear(allReleases, year);
+        return years
+            .map(year => {
+                const releases = getReleaseByYear(allReleases, year);
+                // Next year's tab should only show if it contains a release
+                if (Number(year) === currentYear + 1 && releases.length === 0) {
+                    return {};
+                }
+                const hydratedReleases = {
+                    label: year,
+                    value: year,
+                    content: (
+                        <div>
+                            {!releases.length && (
+                                <Box component="p" sx={{ px: 2 }}>
+                                    {t("noResults", {
+                                        year,
+                                    })}
+                                </Box>
+                            )}
+                            {releases.map((release, index) => (
+                                <Accordion
+                                    key={release.date}
+                                    defaultExpanded={
+                                        expanded === release.id || index === 0
+                                    }
+                                    heading={
+                                        <Typography>{release.title}</Typography>
+                                    }
+                                    onChange={(event, isExpanded) =>
+                                        handleChange(isExpanded, release.id)
+                                    }
+                                    contents={
+                                        <HTMLContent
+                                            content={release.content}
+                                        />
+                                    }
+                                    iconLeft
+                                />
+                            ))}
+                        </div>
+                    ),
+                };
 
-            const hydratedReleases = {
-                label: year,
-                value: year,
-                content: (
-                    <div>
-                        {!releases.length && (
-                            <Box component="p" sx={{ px: 2 }}>
-                                {t("noResults", {
-                                    year,
-                                })}
-                            </Box>
-                        )}
-                        {releases.map((release, index) => (
-                            <Accordion
-                                key={release.date}
-                                defaultExpanded={
-                                    expanded === release.id || index === 0
-                                }
-                                heading={
-                                    <Typography>{release.title}</Typography>
-                                }
-                                onChange={(event, isExpanded) =>
-                                    handleChange(isExpanded, release.id)
-                                }
-                                contents={
-                                    <HTMLContent content={release.content} />
-                                }
-                                iconLeft
-                            />
-                        ))}
-                    </div>
-                ),
-            };
-            return hydratedReleases;
-        });
+                return hydratedReleases;
+            })
+            .filter((yearTab: object) => Object.keys(yearTab).length > 0);
     }, [allReleases, expanded, years]);
 
     return (


### PR DESCRIPTION
## Screenshots (if relevant)
Releases:
1. No releases this year (2025) 
![image](https://github.com/user-attachments/assets/2c260b0d-f7ba-45c0-87f5-c1093e9dd131)
2. Releases this year (2025)
![image](https://github.com/user-attachments/assets/b69a9eb2-f386-4974-914e-8d9ddf871715)
3. Releases for next year (2026) don't show: 
![image](https://github.com/user-attachments/assets/a052ad2c-379c-4f57-a7b6-751fbde0a864)

News/events:
1. No News/Events this year (2025):
![image](https://github.com/user-attachments/assets/cf365e01-62aa-4f7a-9859-561beb85be8a)
2. News/Events this year
![image](https://github.com/user-attachments/assets/c32c8955-ce0c-4e9e-9a16-a4a6f9870e2b)
3. News/Events for next year also shows when present
![image](https://github.com/user-attachments/assets/8afa67a0-7e46-40b5-942f-cb1b5d624f6c)

## Describe your changes
Releases page now starts from 2024 and concludes in the current year.
News/events page starts in 2024 and concludes in the current year _unless_ there's content for next year, which it also shows.

## Issue ticket link
https://hdruk.atlassian.net/browse/GAT-6180

## Checklist before requesting a review

-   [ ] I have performed a self-review of my code
-   [ ] I have added appropriate unit tests
-   [ ] I have created mocks for unit tests (where appropriate)
-   [ ] The interface is responsive (where appropriate)
-   [ ] The interface is at least AA (where appropriate)
