### PR TITLE
fix: (GAT-6143) unable to change data custodian

### DIFF
--- a/.github/workflows/dev_deployment.yaml
+++ b/.github/workflows/dev_deployment.yaml
@@ -4,7 +4,7 @@ run-name: ${{ github.actor }} triggered deploy to DEV pipeline
 on:
   push:
     branches:
-      - "fix/GAT-6143"
+      - "dev"
 
 env:
   PROJECT_ID: "${{ secrets.PROJECT_ID }}"
@@ -24,7 +24,7 @@ jobs:
       - name: Checkout
         uses: actions/checkout@v4
         with:
-          ref: "fix/GAT-6143"
+          ref: "dev"
 
       - name: Read VERSION file
         id: getversion
@@ -73,7 +73,7 @@ jobs:
         id: checkout
         uses: actions/checkout@v4
         with:
-          ref: "fix/GAT-6143"
+          ref: "dev"
 
       - name: Google Auth
         id: auth

--- a/.github/workflows/dev_deployment.yaml
+++ b/.github/workflows/dev_deployment.yaml
@@ -4,7 +4,7 @@ run-name: ${{ github.actor }} triggered deploy to DEV pipeline
 on:
   push:
     branches:
-      - "dev"
+      - "fix/GAT-6143"
 
 env:
   PROJECT_ID: "${{ secrets.PROJECT_ID }}"
@@ -24,7 +24,7 @@ jobs:
       - name: Checkout
         uses: actions/checkout@v4
         with:
-          ref: "dev"
+          ref: "fix/GAT-6143"
 
       - name: Read VERSION file
         id: getversion
@@ -73,7 +73,7 @@ jobs:
         id: checkout
         uses: actions/checkout@v4
         with:
-          ref: "dev"
+          ref: "fix/GAT-6143"
 
       - name: Google Auth
         id: auth

--- a/src/app/[locale]/account/team/[teamId]/(withoutLeftNav)/datasets/[datasetId]/page.tsx
+++ b/src/app/[locale]/account/team/[teamId]/(withoutLeftNav)/datasets/[datasetId]/page.tsx
@@ -66,15 +66,16 @@ export default async function TeamDatasetPage({
     );
 
     const isNotTeamId = Number.isNaN(Number(dataCustodianIdentifier));
+    const dataCustodianId = isNotTeamId
+        ? await getTeamIdFromPid(cookieStore, dataCustodianIdentifier || "")
+        : dataCustodianIdentifier;
 
     const formJSON = await getFormHydration(
         cookieStore,
         SCHEMA_NAME,
         SCHEMA_VERSION,
         dataTypes,
-        isNotTeamId
-            ? await getTeamIdFromPid(cookieStore, dataCustodianIdentifier || "")
-            : dataCustodianIdentifier
+        dataCustodianId
     );
 
     return (
@@ -86,6 +87,7 @@ export default async function TeamDatasetPage({
                     formJSON={formJSON}
                     teamId={Number(teamId)}
                     user={user}
+                    defaultTeamId={Number(dataCustodianId)}
                 />
             </BoxContainer>
         </ProtectedAccountRoute>

--- a/src/app/[locale]/account/team/[teamId]/(withoutLeftNav)/datasets/components/CreateDataset/CreateDataset.tsx
+++ b/src/app/[locale]/account/team/[teamId]/(withoutLeftNav)/datasets/components/CreateDataset/CreateDataset.tsx
@@ -84,6 +84,7 @@ interface CreateDatasetProps {
     formJSON: FormHydrationSchema;
     teamId: number;
     user: AuthUser;
+    defaultTeamId: number;
 }
 
 type FormValues = Record<string, unknown>;
@@ -98,7 +99,12 @@ const getMetadata = (isDraft: boolean) =>
 
 const today = getToday();
 
-const CreateDataset = ({ formJSON, teamId, user }: CreateDatasetProps) => {
+const CreateDataset = ({
+    formJSON,
+    teamId,
+    user,
+    defaultTeamId,
+}: CreateDatasetProps) => {
     const [formJSONDynamic, setFormJSONDynamic] = useState<
         FormHydrationSchema | undefined
     >();
@@ -719,7 +725,7 @@ const CreateDataset = ({ formJSON, teamId, user }: CreateDatasetProps) => {
                         }}
                         teamOptions={teamOptions}
                         handleOnUserInputChange={handleOnUserInputChange}
-                        defaultTeamId={watchId}
+                        defaultTeamId={defaultTeamId}
                         isLoadingTeams={isLoadingTeams}
                     />
                 )}

--- a/src/app/[locale]/account/team/[teamId]/(withoutLeftNav)/datasets/components/CreateDataset/CreateDataset.tsx
+++ b/src/app/[locale]/account/team/[teamId]/(withoutLeftNav)/datasets/components/CreateDataset/CreateDataset.tsx
@@ -99,7 +99,12 @@ const getMetadata = (isDraft: boolean) =>
 
 const today = getToday();
 
-const CreateDataset = ({ formJSON, teamId, user, defaultTeamId }: CreateDatasetProps) => {
+const CreateDataset = ({
+    formJSON,
+    teamId,
+    user,
+    defaultTeamId,
+}: CreateDatasetProps) => {
     const [formJSONDynamic, setFormJSONDynamic] = useState<
         FormHydrationSchema | undefined
     >();

--- a/src/app/[locale]/account/team/[teamId]/(withoutLeftNav)/datasets/components/CreateDataset/CreateDataset.tsx
+++ b/src/app/[locale]/account/team/[teamId]/(withoutLeftNav)/datasets/components/CreateDataset/CreateDataset.tsx
@@ -84,7 +84,7 @@ interface CreateDatasetProps {
     formJSON: FormHydrationSchema;
     teamId: number;
     user: AuthUser;
-    defaultTeamId: number;
+    defaultTeamId: string;
 }
 
 type FormValues = Record<string, unknown>;
@@ -99,12 +99,7 @@ const getMetadata = (isDraft: boolean) =>
 
 const today = getToday();
 
-const CreateDataset = ({
-    formJSON,
-    teamId,
-    user,
-    defaultTeamId,
-}: CreateDatasetProps) => {
+const CreateDataset = ({ formJSON, teamId, user, defaultTeamId }: CreateDatasetProps) => {
     const [formJSONDynamic, setFormJSONDynamic] = useState<
         FormHydrationSchema | undefined
     >();
@@ -725,7 +720,10 @@ const CreateDataset = ({
                         }}
                         teamOptions={teamOptions}
                         handleOnUserInputChange={handleOnUserInputChange}
-                        defaultTeamId={defaultTeamId}
+                        setDataCustodian={(value: number) =>
+                            setValue(DATA_CUSTODIAN_ID, value)
+                        }
+                        defaultTeamId={watchId ?? defaultTeamId}
                         isLoadingTeams={isLoadingTeams}
                     />
                 )}

--- a/src/app/[locale]/account/team/[teamId]/(withoutLeftNav)/datasets/components/CreateDataset/CreateDataset.tsx
+++ b/src/app/[locale]/account/team/[teamId]/(withoutLeftNav)/datasets/components/CreateDataset/CreateDataset.tsx
@@ -84,7 +84,7 @@ interface CreateDatasetProps {
     formJSON: FormHydrationSchema;
     teamId: number;
     user: AuthUser;
-    defaultTeamId: string;
+    defaultTeamId: number;
 }
 
 type FormValues = Record<string, unknown>;
@@ -110,7 +110,7 @@ const CreateDataset = ({
     >();
 
     const [currentTeamId, setCurrentTeamId] = useState<number>(
-        Number(defaultTeamId)
+        defaultTeamId
     );
 
     const [searchName, setSearchName] = useState("");
@@ -316,7 +316,7 @@ const CreateDataset = ({
         defaultValues: defaultFormValues,
     });
 
-    const watchId = watch(DATA_CUSTODIAN_ID) ?? defaultTeamId;
+    const watchId = watch(DATA_CUSTODIAN_ID);
     const watchType = watch(DATASET_TYPE);
 
     // This is a bit of a hack
@@ -336,11 +336,6 @@ const CreateDataset = ({
         if (!watchId) return;
         setCurrentTeamId(watchId);
     }, [watchId]);
-
-    // useEffect(() => {
-    //     if (!teamIdFromPid) return;
-    //     setValue(DATA_CUSTODIAN_ID, Number(defaultTeamId));
-    // }, [teamIdFromPid]);
 
     const updateDataCustodian = (formJSONUpdated: FormHydrationSchema) => {
         const custodianOverrides = DATA_CUSTODIAN_FIELDS.reduce((acc, key) => {

--- a/src/app/[locale]/account/team/[teamId]/(withoutLeftNav)/datasets/components/CreateDataset/CreateDataset.tsx
+++ b/src/app/[locale]/account/team/[teamId]/(withoutLeftNav)/datasets/components/CreateDataset/CreateDataset.tsx
@@ -109,9 +109,7 @@ const CreateDataset = ({
         FormHydrationSchema | undefined
     >();
 
-    const [currentTeamId, setCurrentTeamId] = useState<number>(
-        defaultTeamId
-    );
+    const [currentTeamId, setCurrentTeamId] = useState<number>(defaultTeamId);
 
     const [searchName, setSearchName] = useState("");
     const searchNameDebounced = useDebounce(searchName, 500);

--- a/src/app/[locale]/account/team/[teamId]/(withoutLeftNav)/datasets/components/CreateDataset/CreateDataset.tsx
+++ b/src/app/[locale]/account/team/[teamId]/(withoutLeftNav)/datasets/components/CreateDataset/CreateDataset.tsx
@@ -109,6 +109,10 @@ const CreateDataset = ({
         FormHydrationSchema | undefined
     >();
 
+    const [currentTeamId, setCurrentTeamId] = useState<number>(
+        Number(defaultTeamId)
+    );
+
     const [searchName, setSearchName] = useState("");
     const searchNameDebounced = useDebounce(searchName, 500);
 
@@ -312,7 +316,7 @@ const CreateDataset = ({
         defaultValues: defaultFormValues,
     });
 
-    const watchId = watch(DATA_CUSTODIAN_ID);
+    const watchId = watch(DATA_CUSTODIAN_ID) ?? defaultTeamId;
     const watchType = watch(DATASET_TYPE);
 
     // This is a bit of a hack
@@ -328,17 +332,15 @@ const CreateDataset = ({
         }
     );
 
-    const { data: teamIdFromPid } = useGet<number>(
-        `${apis.teamsV1Url}/${watchId}/id`,
-        {
-            shouldFetch: !watchIdIsNumber,
-        }
-    );
-
     useEffect(() => {
-        if (!teamIdFromPid) return;
-        setValue(DATA_CUSTODIAN_ID, teamIdFromPid);
-    }, [teamIdFromPid]);
+        if (!watchId) return;
+        setCurrentTeamId(watchId);
+    }, [watchId]);
+
+    // useEffect(() => {
+    //     if (!teamIdFromPid) return;
+    //     setValue(DATA_CUSTODIAN_ID, Number(defaultTeamId));
+    // }, [teamIdFromPid]);
 
     const updateDataCustodian = (formJSONUpdated: FormHydrationSchema) => {
         const custodianOverrides = DATA_CUSTODIAN_FIELDS.reduce((acc, key) => {
@@ -728,7 +730,7 @@ const CreateDataset = ({
                         setDataCustodian={(value: number) =>
                             setValue(DATA_CUSTODIAN_ID, value)
                         }
-                        defaultTeamId={watchId ?? defaultTeamId}
+                        defaultTeamId={currentTeamId}
                         isLoadingTeams={isLoadingTeams}
                     />
                 )}

--- a/src/app/[locale]/account/team/[teamId]/(withoutLeftNav)/datasets/components/IntroScreen/IntroScreen.tsx
+++ b/src/app/[locale]/account/team/[teamId]/(withoutLeftNav)/datasets/components/IntroScreen/IntroScreen.tsx
@@ -71,6 +71,7 @@ interface IntroScreenProps {
     teamOptions?: OptionsType[];
     isLoadingTeams: boolean;
     setDatasetType: (value: string[]) => void;
+    setDataCustodian: (value: number) => void;
     handleOnUserInputChange: (e: React.ChangeEvent, value: string) => void;
 }
 
@@ -80,6 +81,7 @@ const IntroScreen = ({
     teamOptions,
     isLoadingTeams,
     setDatasetType,
+    setDataCustodian,
     handleOnUserInputChange,
 }: IntroScreenProps) => {
     const t = useTranslations(
@@ -98,15 +100,15 @@ const IntroScreen = ({
         setSelectedCheckboxes(updatedCheckboxes);
     };
 
-    const { control, watch, setValue } = useForm({
+    const { control, watch } = useForm({
         defaultValues: { custodianId: defaultTeamId },
     });
-    const watchCustodian = watch("custodianId");
+    const watchSort = watch("custodianId");
 
     useEffect(() => {
-        if (!watchCustodian) return;
-        setValue("custodianId", watchCustodian);
-    }, [watchCustodian]);
+        if (!watchSort) return;
+        setDataCustodian(watchSort);
+    }, [watchSort]);
     return (
         <>
             <Paper

--- a/src/app/[locale]/account/team/[teamId]/(withoutLeftNav)/datasets/components/IntroScreen/IntroScreen.tsx
+++ b/src/app/[locale]/account/team/[teamId]/(withoutLeftNav)/datasets/components/IntroScreen/IntroScreen.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import { useState } from "react";
+import { useEffect, useState } from "react";
 import { useForm } from "react-hook-form";
 import { useTranslations } from "next-intl";
 import { OptionsType } from "@/components/Autocomplete/Autocomplete";
@@ -98,10 +98,15 @@ const IntroScreen = ({
         setSelectedCheckboxes(updatedCheckboxes);
     };
 
-    const { control } = useForm({
+    const { control, watch, setValue } = useForm({
         defaultValues: { custodianId: defaultTeamId },
     });
+    const watchCustodian = watch("custodianId");
 
+    useEffect(() => {
+        if (!watchCustodian) return;
+        setValue("custodianId", watchCustodian);
+    }, [watchCustodian]);
     return (
         <>
             <Paper

--- a/src/app/[locale]/account/team/[teamId]/(withoutLeftNav)/datasets/create/page.tsx
+++ b/src/app/[locale]/account/team/[teamId]/(withoutLeftNav)/datasets/create/page.tsx
@@ -47,6 +47,7 @@ export default async function CreateDatasetPage({
                     formJSON={formJSON}
                     teamId={Number(teamId)}
                     user={user}
+                    defaultTeamId={teamId}
                 />
             </BoxContainer>
         </ProtectedAccountRoute>


### PR DESCRIPTION
## Screenshots (if relevant)

## Describe your changes
When creating a custodian, if you go forwards and backwards it will change back to the default, (handled in the watch and useEffect)
When editing similiar behaviour but it also shows the PID, it needs the ID.
## Issue ticket link

## Checklist before requesting a review

-   [ ] I have performed a self-review of my code
-   [ ] I have added appropriate unit tests
-   [ ] I have created mocks for unit tests (where appropriate)
-   [ ] The interface is responsive (where appropriate)
-   [ ] The interface is at least AA (where appropriate)
