### PR TITLE
fix: (GAT-6143) unable to change data custodian

### DIFF
--- a/src/app/[locale]/account/team/[teamId]/(withoutLeftNav)/datasets/components/CreateDataset/CreateDataset.tsx
+++ b/src/app/[locale]/account/team/[teamId]/(withoutLeftNav)/datasets/components/CreateDataset/CreateDataset.tsx
@@ -201,7 +201,7 @@ const CreateDataset = ({
         "Dataset Version": "1.0.0",
         "revision version": "1.0.0",
         "revision url": "http://www.example.com/",
-        identifier: teamId,
+        identifier: defaultTeamId,
         "Metadata Issued Datetime": today,
         "Last Modified Datetime": today,
         "Name of data provider": "--",


### PR DESCRIPTION
## Screenshots (if relevant)
Before:
![image](https://github.com/user-attachments/assets/9c6c4ac9-6ca9-4004-b441-bd3fa7c45315)

After:
![image](https://github.com/user-attachments/assets/c5d66e2c-2052-48d8-8a3e-d0a853a55702)

## Describe your changes
Original fix works, but after saving and coming back it defaults to the teamId in the url not the one from the dataset.
This will use the defaultTeamid from the server side logic

## Issue ticket link
https://hdruk.atlassian.net/jira/software/c/projects/GAT/boards/51?assignee=712020%3A05fbbf0f-9386-469a-a212-84cfbf9cc587&selectedIssue=GAT-6143
## Checklist before requesting a review

-   [ ] I have performed a self-review of my code
-   [ ] I have added appropriate unit tests
-   [ ] I have created mocks for unit tests (where appropriate)
-   [ ] The interface is responsive (where appropriate)
-   [ ] The interface is at least AA (where appropriate)
