### PR TITLE
Feat/gat 6136: Update search result card component for Datasets & BioSamples

### DIFF
--- a/src/app/[locale]/(logged-out)/search/components/ResultCard/ResultCard.tsx
+++ b/src/app/[locale]/(logged-out)/search/components/ResultCard/ResultCard.tsx
@@ -1,6 +1,6 @@
 import { useCallback, useEffect, useRef, useState } from "react";
 import { Bookmark, BookmarkBorder } from "@mui/icons-material";
-import { Divider, ListItem, ListItemButton, ListItemText } from "@mui/material";
+import { Divider, ListItem, ListItemText } from "@mui/material";
 import { get } from "lodash";
 import uniqueId from "lodash/uniqueId";
 import { useTranslations } from "next-intl";
@@ -77,10 +77,6 @@ const ResultCard = ({
     const deleteLibrary = useDelete(apis.librariesV1Url, {
         itemName: `Library item`,
     });
-
-    const handleClickItem = useCallback(() => {
-        router.push(`/${RouteName.DATASET_ITEM}/${datasetId}`);
-    }, [datasetId, router]);
 
     const handleClickQuickView = (
         event: React.MouseEvent<HTMLButtonElement>

--- a/src/app/[locale]/(logged-out)/search/components/ResultCard/ResultCard.tsx
+++ b/src/app/[locale]/(logged-out)/search/components/ResultCard/ResultCard.tsx
@@ -1,10 +1,10 @@
-import { useCallback, useEffect, useRef, useState } from "react";
+import { useEffect, useRef, useState } from "react";
 import { Bookmark, BookmarkBorder } from "@mui/icons-material";
 import { Divider, ListItem, ListItemText } from "@mui/material";
 import { get } from "lodash";
 import uniqueId from "lodash/uniqueId";
 import { useTranslations } from "next-intl";
-import { usePathname, useRouter, useSearchParams } from "next/navigation";
+import { usePathname, useSearchParams } from "next/navigation";
 import { KeyedMutator } from "swr";
 import { Library, NewLibrary } from "@/interfaces/Library";
 import { SearchResultDataset } from "@/interfaces/Search";
@@ -44,7 +44,6 @@ const ResultCard = ({
 }: ResultCardProps) => {
     const t = useTranslations(TRANSLATION_PATH);
     const { current: resultId } = useRef(uniqueId("result-title-"));
-    const router = useRouter();
     const pathname = usePathname();
     const searchParams = useSearchParams();
     const { showDialog } = useDialog();

--- a/src/app/[locale]/(logged-out)/search/components/ResultCard/ResultCard.tsx
+++ b/src/app/[locale]/(logged-out)/search/components/ResultCard/ResultCard.tsx
@@ -222,7 +222,11 @@ const ResultCard = ({
                                     marginBottom={2}>
                                     {metadata.summary.shortTitle}
                                 </Link>
-                                <div style={{ textAlign: "end" }}>
+                                <div
+                                    style={{
+                                        display: "flex",
+                                        textAlign: "end",
+                                    }}>
                                     <Button
                                         onClick={handleToggleLibraryItem}
                                         variant="outlined"
@@ -241,7 +245,7 @@ const ResultCard = ({
                                                 <BookmarkBorder color="secondary" />
                                             )
                                         }
-                                        sx={{ mb: 1 }}>
+                                        sx={{ alignSelf: "flex-start" }}>
                                         {isLibraryToggled
                                             ? t("removeFromLibrary")
                                             : t("addToLibrary")}
@@ -262,7 +266,11 @@ const ResultCard = ({
                                                 style={{ color: "white" }}
                                             />
                                         }
-                                        sx={{ ml: 2, mb: 1 }}
+                                        sx={{
+                                            ml: 2,
+                                            px: 3,
+                                            alignSelf: "flex-start",
+                                        }}
                                         onClick={handleOpenDropdownMenu}>
                                         {t("actions")}
                                     </Button>

--- a/src/app/[locale]/(logged-out)/search/components/ResultCard/ResultCard.tsx
+++ b/src/app/[locale]/(logged-out)/search/components/ResultCard/ResultCard.tsx
@@ -292,7 +292,9 @@ const ResultCard = ({
                         secondary={
                             <section aria-describedby={resultId}>
                                 {isNumber && (
-                                    <Link href={linkHref}>
+                                    <Link
+                                        href={linkHref}
+                                        sx={{ display: "inline-block" }}>
                                         <Typography
                                             // eslint-disable-next-line
                                             aria-description="Data Custodian"

--- a/src/app/[locale]/(logged-out)/search/components/ResultCard/ResultCard.tsx
+++ b/src/app/[locale]/(logged-out)/search/components/ResultCard/ResultCard.tsx
@@ -212,114 +212,95 @@ const ResultCard = ({
                     style={{ width: "100%" }}
                     // eslint-disable-next-line
                     aria-description={`Result for ${metadata.summary.shortTitle}`}>
-                    <ListItemButton onClick={handleClickItem}>
-                        <ListItemText
-                            primary={
-                                <ResultTitle>
-                                    <span
-                                        id={resultId}
-                                        role="heading"
-                                        aria-level={3}>
-                                        {metadata.summary.shortTitle}
-                                    </span>
-                                    <div style={{ textAlign: "end" }}>
-                                        <Button
-                                            onClick={handleToggleLibraryItem}
-                                            variant="outlined"
-                                            aria-label={
-                                                isLibraryToggled
-                                                    ? t("removeFromLibrary")
-                                                    : `${t(
-                                                          "addToLibrary"
-                                                      )} for ${
-                                                          metadata.summary
-                                                              .shortTitle
-                                                      }`
-                                            }
-                                            startIcon={
-                                                isLibraryToggled ? (
-                                                    <Bookmark color="secondary" />
-                                                ) : (
-                                                    <BookmarkBorder color="secondary" />
-                                                )
-                                            }
-                                            sx={{ mb: 1 }}>
-                                            {isLibraryToggled
+                    <ListItemText
+                        disableTypography
+                        sx={{ padding: 2, paddingBottom: 1, m: 0 }}
+                        primary={
+                            <ResultTitle>
+                                <Link
+                                    id={resultId}
+                                    href={`${RouteName.DATASET_ITEM}/${datasetId}`}
+                                    role="heading"
+                                    aria-level={3}
+                                    fontSize={16}
+                                    fontWeight={600}
+                                    marginBottom={2}>
+                                    {metadata.summary.shortTitle}
+                                </Link>
+                                <div style={{ textAlign: "end" }}>
+                                    <Button
+                                        onClick={handleToggleLibraryItem}
+                                        variant="outlined"
+                                        aria-label={
+                                            isLibraryToggled
                                                 ? t("removeFromLibrary")
-                                                : t("addToLibrary")}
-                                        </Button>
-                                        <Button
-                                            aria-label={`${t("actions")} for ${
-                                                metadata.summary.shortTitle
-                                            }`}
-                                            variant="contained"
-                                            startIcon={
-                                                <SpeechBubbleIcon
-                                                    sx={{ fill: "white" }}
-                                                />
-                                            }
-                                            endIcon={
-                                                <ChevronThinIcon
-                                                    fontSize="medium"
-                                                    style={{ color: "white" }}
-                                                />
-                                            }
-                                            sx={{ ml: 2, mb: 1 }}
-                                            onClick={handleOpenDropdownMenu}>
-                                            {t("actions")}
-                                        </Button>
-                                        <MenuDropdown
-                                            handleClose={() =>
-                                                setAnchorElement(null)
-                                            }
-                                            menuItems={menuItems}
-                                            anchorElement={anchorElement}
-                                            title={metadata.summary.shortTitle}
-                                            stopPropagation
-                                        />
-                                    </div>
-                                </ResultTitle>
-                            }
-                            primaryTypographyProps={{
-                                color: "primary",
-                                fontWeight: 600,
-                                fontSize: 16,
-                                mb: 1.5,
-                            }}
-                            disableTypography
-                            secondary={
-                                <section aria-describedby={resultId}>
-                                    {isNumber && (
-                                        <Link href={linkHref}>
-                                            <Typography
-                                                // eslint-disable-next-line
-                                        aria-description="Data Custodian"
-                                                sx={{
-                                                    textDecoration: "uppercase",
-                                                    fontWeight: 400,
-                                                    fontSize: 16,
-                                                    color: "black",
-                                                    mb: 1.5,
-                                                }}>
-                                                {metadata.summary.publisher
-                                                    .name !== undefined
-                                                    ? metadata.summary.publisher
-                                                          .name
-                                                    : metadata.summary.publisher
-                                                          .publisherName}
-                                            </Typography>
-                                        </Link>
-                                    )}
-
-                                    {!isNumber && (
+                                                : `${t("addToLibrary")} for ${
+                                                      metadata.summary
+                                                          .shortTitle
+                                                  }`
+                                        }
+                                        startIcon={
+                                            isLibraryToggled ? (
+                                                <Bookmark color="secondary" />
+                                            ) : (
+                                                <BookmarkBorder color="secondary" />
+                                            )
+                                        }
+                                        sx={{ mb: 1 }}>
+                                        {isLibraryToggled
+                                            ? t("removeFromLibrary")
+                                            : t("addToLibrary")}
+                                    </Button>
+                                    <Button
+                                        aria-label={`${t("actions")} for ${
+                                            metadata.summary.shortTitle
+                                        }`}
+                                        variant="contained"
+                                        startIcon={
+                                            <SpeechBubbleIcon
+                                                sx={{ fill: "white" }}
+                                            />
+                                        }
+                                        endIcon={
+                                            <ChevronThinIcon
+                                                fontSize="medium"
+                                                style={{ color: "white" }}
+                                            />
+                                        }
+                                        sx={{ ml: 2, mb: 1 }}
+                                        onClick={handleOpenDropdownMenu}>
+                                        {t("actions")}
+                                    </Button>
+                                    <MenuDropdown
+                                        handleClose={() =>
+                                            setAnchorElement(null)
+                                        }
+                                        menuItems={menuItems}
+                                        anchorElement={anchorElement}
+                                        title={metadata.summary.shortTitle}
+                                        stopPropagation
+                                    />
+                                </div>
+                            </ResultTitle>
+                        }
+                        primaryTypographyProps={{
+                            color: "primary",
+                            fontWeight: 600,
+                            fontSize: 16,
+                            mb: 1.5,
+                        }}
+                        secondary={
+                            <section aria-describedby={resultId}>
+                                {isNumber && (
+                                    <Link href={linkHref}>
                                         <Typography
                                             // eslint-disable-next-line
-                                        aria-description="Data Custodian"
+                                            aria-description="Data Custodian"
                                             sx={{
                                                 textDecoration: "uppercase",
                                                 fontWeight: 400,
-                                                fontSize: 16,
-                                                color: "black",
+                                                fontSize: 14,
+                                                color: "secondary",
                                                 mb: 1.5,
                                             }}>
                                             {metadata.summary.publisher.name !==
@@ -329,50 +310,69 @@ const ResultCard = ({
                                                 : metadata.summary.publisher
                                                       .publisherName}
                                         </Typography>
-                                    )}
-                                    <Highlight
-                                        sx={{ mb: 1.5 }}
-                                        component="div"
-                                        variant="body2"
-                                        color="text.gray"
-                                        dangerouslySetInnerHTML={{
-                                            __html: formattedText,
-                                        }}
-                                    />
-                                    <Box
+                                    </Link>
+                                )}
+
+                                {!isNumber && (
+                                    <Typography
+                                        // eslint-disable-next-line
+                                        aria-description="Data Custodian"
                                         sx={{
-                                            p: 0,
-                                            display: "flex",
-                                            justifyContent: "space-between",
+                                            textDecoration: "uppercase",
+                                            fontWeight: 400,
+                                            fontSize: 14,
+                                            color: "secondary",
+                                            mb: 1.5,
                                         }}>
-                                        <Typography
+                                        {metadata.summary.publisher.name !==
+                                        undefined
+                                            ? metadata.summary.publisher.name
+                                            : metadata.summary.publisher
+                                                  .publisherName}
+                                    </Typography>
+                                )}
+                                <Highlight
+                                    sx={{ mb: 1.5 }}
+                                    component="div"
+                                    variant="body2"
+                                    color="text.gray"
+                                    dangerouslySetInnerHTML={{
+                                        __html: formattedText,
+                                    }}
+                                />
+                                <Box
+                                    sx={{
+                                        p: 0,
+                                        display: "flex",
+                                        justifyContent: "space-between",
+                                    }}>
+                                    <Typography
+                                        color="secondary"
+                                        sx={{ fontSize: 16 }}>
+                                        {t("populationSize")}:{" "}
+                                        {getPopulationSize(
+                                            metadata,
+                                            t("populationSizeNotReported")
+                                        )}
+                                    </Typography>
+                                    <Typography
+                                        color="secondary"
+                                        sx={{ fontSize: 16 }}>
+                                        {t("dateLabel")}:{" "}
+                                        {getDateRange(metadata)}
+                                    </Typography>
+                                    <Typography>
+                                        <Button
+                                            onClick={handleClickQuickView}
                                             color="secondary"
-                                            sx={{ fontSize: 16 }}>
-                                            {t("populationSize")}:{" "}
-                                            {getPopulationSize(
-                                                metadata,
-                                                t("populationSizeNotReported")
-                                            )}
-                                        </Typography>
-                                        <Typography
-                                            color="secondary"
-                                            sx={{ fontSize: 16 }}>
-                                            {t("dateLabel")}:{" "}
-                                            {getDateRange(metadata)}
-                                        </Typography>
-                                        <Typography>
-                                            <Button
-                                                onClick={handleClickQuickView}
-                                                color="secondary"
-                                                variant="outlined">
-                                                {t("showAll")}
-                                            </Button>
-                                        </Typography>
-                                    </Box>
-                                </section>
-                            }
-                        />
-                    </ListItemButton>
+                                            variant="outlined">
+                                            {t("showAll")}
+                                        </Button>
+                                    </Typography>
+                                </Box>
+                            </section>
+                        }
+                    />
                 </section>
             </ListItem>
 


### PR DESCRIPTION
## Screenshots (if relevant)

https://github.com/user-attachments/assets/2e5808ca-d32b-4a2c-9d22-d2f6fe940d35

## Describe your changes
Dataset Result Card is no longer fully clickable - only the title and Data Custodian text are clickable.
Formatting updated as per design.

## Issue ticket link
https://hdruk.atlassian.net/browse/GAT-6136

## Checklist before requesting a review

-   [ ] I have performed a self-review of my code
-   [ ] I have added appropriate unit tests
-   [ ] I have created mocks for unit tests (where appropriate)
-   [ ] The interface is responsive (where appropriate)
-   [ ] The interface is at least AA (where appropriate)
