### PR TITLE
feat(GAT-5651): multiple dataset titles in federated publication search

### DIFF
--- a/src/app/[locale]/(logged-out)/search/components/Search/Search.tsx
+++ b/src/app/[locale]/(logged-out)/search/components/Search/Search.tsx
@@ -670,13 +670,15 @@ const Search = ({ filters }: SearchProps) => {
     const europePmcModalAction = () =>
         showDialog(() => (
             <PublicationSearchDialog
-                onSubmit={(query: string, type: string, datasetNamesArray: string[]) => {
+                onSubmit={(
+                    query: string,
+                    type: string,
+                    datasetNamesArray: string[]
+                ) => {
                     onQuerySubmit({
                         query,
                     });
-                    setDatasetNamesArray(
-                      datasetNamesArray,  
-                    );
+                    setDatasetNamesArray(datasetNamesArray);
                     setQueryParams({
                         ...queryParams,
                         pmc: type,

--- a/src/app/[locale]/(logged-out)/search/components/Search/Search.tsx
+++ b/src/app/[locale]/(logged-out)/search/components/Search/Search.tsx
@@ -196,6 +196,8 @@ const Search = ({ filters }: SearchProps) => {
         [FILTER_MATERIAL_TYPE]: getParamArray(FILTER_MATERIAL_TYPE),
     });
 
+    const [datasetNamesArray, setDatasetNamesArray] = useState<string[]>([]);
+
     const { handleDownload } = useSearch(
         queryParams.type,
         resultsView,
@@ -668,10 +670,13 @@ const Search = ({ filters }: SearchProps) => {
     const europePmcModalAction = () =>
         showDialog(() => (
             <PublicationSearchDialog
-                onSubmit={(query: string, type: string) => {
+                onSubmit={(query: string, type: string, datasetNamesArray: string[]) => {
                     onQuerySubmit({
                         query,
                     });
+                    setDatasetNamesArray(
+                      datasetNamesArray,  
+                    );
                     setQueryParams({
                         ...queryParams,
                         pmc: type,
@@ -683,6 +688,7 @@ const Search = ({ filters }: SearchProps) => {
                     });
                 }}
                 defaultQuery={queryParams.query}
+                datasetNamesArray={datasetNamesArray}
                 isDataset={queryParams.pmc === "dataset"}
             />
         ));

--- a/src/components/Autocomplete/Autocomplete.tsx
+++ b/src/components/Autocomplete/Autocomplete.tsx
@@ -1,5 +1,6 @@
 import { ReactNode } from "react";
 import { Control, FieldValues, Path, useController } from "react-hook-form";
+import ClearIcon from "@mui/icons-material/Clear";
 import {
     FilterOptionsState,
     InputAdornment,
@@ -46,6 +47,7 @@ export interface AutocompleteProps<T extends FieldValues> {
     id?: string;
     isLoadingOptions?: boolean;
     noOptionsText?: string;
+    clearIcon?: boolean;
 }
 
 interface SearchOptions {
@@ -74,6 +76,7 @@ const Autocomplete = <T extends FieldValues>(props: AutocompleteProps<T>) => {
         isLoadingOptions = false,
         noOptionsText = "No options",
         id,
+        clearIcon = false,
         ...restProps
     } = props;
 
@@ -200,6 +203,14 @@ const Autocomplete = <T extends FieldValues>(props: AutocompleteProps<T>) => {
                         <ListItemText>{item.label}</ListItemText>
                     </li>
                 )}
+                {...(clearIcon && {
+                    renderOption: (props, item, { selected }) => (
+                        <li {...props} key={item.value as string}>
+                            <ListItemText>{item.label}</ListItemText>
+                            {selected && <ClearIcon />}
+                        </li>
+                    ),
+                })}
                 noOptionsText={
                     isLoadingOptions ? <Loading size={30} /> : noOptionsText
                 }

--- a/src/components/CollectionForm/CollectionForm.tsx
+++ b/src/components/CollectionForm/CollectionForm.tsx
@@ -366,8 +366,7 @@ const CollectionForm = ({
             }
             return keywordArray;
         };
-        console.log(formData.description);
-        console.log(formData.description.length);
+
         const payload: CollectionSubmission = {
             ...formData,
             status,

--- a/src/components/CollectionForm/CollectionForm.tsx
+++ b/src/components/CollectionForm/CollectionForm.tsx
@@ -366,7 +366,8 @@ const CollectionForm = ({
             }
             return keywordArray;
         };
-
+        console.log(formData.description);
+        console.log(formData.description.length);
         const payload: CollectionSubmission = {
             ...formData,
             status,

--- a/src/modules/PublicationSearchDialog/PublicationSearchDialog.tsx
+++ b/src/modules/PublicationSearchDialog/PublicationSearchDialog.tsx
@@ -79,6 +79,7 @@ const PublicationSearchDialog = ({
             return option.label === value;
         },
         getChipLabel,
+        clearIcon: true,
     };
 
     const [searchParams, setSearchParams] = useState({

--- a/src/modules/PublicationSearchDialog/PublicationSearchDialog.tsx
+++ b/src/modules/PublicationSearchDialog/PublicationSearchDialog.tsx
@@ -74,7 +74,7 @@ const PublicationSearchDialog = ({
         multiple: true,
         isOptionEqualToValue: (
             option: { value: string | number; label: string },
-            value: string
+            value: string | number
         ) => {
             return option.label === value;
         },

--- a/src/modules/PublicationSearchDialog/PublicationSearchDialog.tsx
+++ b/src/modules/PublicationSearchDialog/PublicationSearchDialog.tsx
@@ -29,7 +29,7 @@ interface OptionType {
 }
 
 interface AddDatasetDialogProps {
-    onSubmit: (query: string, type: string) => void;
+    onSubmit: (query: string, type: string, datasetNamesArray: string[]) => void;
     defaultQuery?: string;
     datasetNamesArray?: string[];
     isDataset: boolean;
@@ -53,7 +53,7 @@ const PublicationSearchDialog = ({
                 isDataset && datasetNamesArray ? datasetNamesArray : [],
         },
     });
-
+    console.log('datasetNamesArray at top', datasetNamesArray);
     const searchFilter = {
         component: inputComponents.TextField,
         variant: "outlined",
@@ -65,34 +65,18 @@ const PublicationSearchDialog = ({
 
     const datasetTitleField = {
         component: inputComponents.Autocomplete,
-        name: "datasetName",
+        name: "datasetNames",
         placeholder: t("datasetNameField.placeholder"),
         label: t("datasetNameField.label"),
         canCreate: false,
         multiple: true,
         isOptionEqualToValue: (
             option: { value: string | number; label: string },
-            value: { value: string | number; label: string }
+            value: string
         ) => {
-            const comp = option.value === value.value;
-            console.log("option", option);
-            console.log("option.value", option.value);
-            console.log("value", value);
-            console.log("comp", comp);
-            return comp;
+            return comp = option.label === value;
         },
-        getChipLabel: (
-            options: { value: string | number; label: string }[],
-            value: { value: string | number; label: string }
-        ) => {
-            console.log("getChipLabel options", options);
-            console.log("getChipLabel value", value);
-            if (typeof value === "string") {
-                return value;
-            }
-
-            return options.find(option => option.value === value.value)?.label;
-        },
+        getChipLabel
     };
 
     const [searchParams, setSearchParams] = useState({
@@ -101,7 +85,7 @@ const PublicationSearchDialog = ({
     });
 
     const [query, setQuery] = useState(
-        isDataset && defaultQuery ? (isArray(defaultQuery) ? defaultQuery : defaultQuery.split(',')) : []
+        isDataset ? (datasetNamesArray ? datasetNamesArray.join(',') : "") : (defaultQuery ? defaultQuery : "")
     );
 
     const filterTitleDebounced = useDebounce(isArray(query) ? query.join(',') : query, 500);
@@ -128,9 +112,9 @@ const PublicationSearchDialog = ({
         prevOptions: OptionsType[],
         datasetOptions: OptionsType[]
     ) => {
-        const existingDatasetIds = prevOptions.map(option => option.value);
+        const existingDatasetIds = prevOptions.map(option => option.label);
         const newOptions = datasetOptions?.filter(
-            option => !existingDatasetIds.includes(option.value)
+            option => !existingDatasetIds.includes(option.label)
         );
         if (newOptions && newOptions.length) {
             return [...prevOptions, ...newOptions].sort((a, b) =>
@@ -147,7 +131,7 @@ const PublicationSearchDialog = ({
                 "latest_metadata.metadata.metadata.summary.title"
             );
             return {
-                value: dataset.id,
+                value: datasetTitle,
                 label: datasetTitle,
             };
         }) as OptionsType[];
@@ -209,7 +193,7 @@ const PublicationSearchDialog = ({
                 </Button>
                 <Button
                     onClick={() => {
-                        console.log('getValues("datasetName")', getValues("datasetName"));
+                        console.log('getValues("datasetNames")', getValues("datasetNames"));
                         console.log('getValues("search")', getValues("search"));
                         onSubmit(
                             getValues("datasetNames") ||

--- a/src/modules/PublicationSearchDialog/PublicationSearchDialog.tsx
+++ b/src/modules/PublicationSearchDialog/PublicationSearchDialog.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import { useEffect, useMemo, useState } from "react";
+import { useEffect, useState } from "react";
 import { useForm } from "react-hook-form";
 import { CircularProgress, Typography } from "@mui/material";
 import MuiDialogActions from "@mui/material/DialogActions";
@@ -29,7 +29,11 @@ interface OptionType {
 }
 
 interface AddDatasetDialogProps {
-    onSubmit: (query: string, type: string, datasetNamesArray: string[]) => void;
+    onSubmit: (
+        query: string,
+        type: string,
+        datasetNamesArray: string[]
+    ) => void;
     defaultQuery?: string;
     datasetNamesArray?: string[];
     isDataset: boolean;
@@ -44,8 +48,6 @@ const PublicationSearchDialog = ({
     const { hideDialog } = useDialog();
     const t = useTranslations(TRANSLATION_PATH);
 
-    console.log('PublicationSearchDialog defaultQuery', defaultQuery);
-    console.log('PublicationSearchDialog isDataset', isDataset);
     const { control, getValues, watch } = useForm({
         defaultValues: {
             search: !isDataset && defaultQuery ? defaultQuery : "",
@@ -53,7 +55,7 @@ const PublicationSearchDialog = ({
                 isDataset && datasetNamesArray ? datasetNamesArray : [],
         },
     });
-    console.log('datasetNamesArray at top', datasetNamesArray);
+
     const searchFilter = {
         component: inputComponents.TextField,
         variant: "outlined",
@@ -74,9 +76,9 @@ const PublicationSearchDialog = ({
             option: { value: string | number; label: string },
             value: string
         ) => {
-            return comp = option.label === value;
+            return option.label === value;
         },
-        getChipLabel
+        getChipLabel,
     };
 
     const [searchParams, setSearchParams] = useState({
@@ -85,10 +87,19 @@ const PublicationSearchDialog = ({
     });
 
     const [query, setQuery] = useState(
-        isDataset ? (datasetNamesArray ? datasetNamesArray.join(',') : "") : (defaultQuery ? defaultQuery : "")
+        isDataset
+            ? datasetNamesArray
+                ? datasetNamesArray.join(",")
+                : ""
+            : defaultQuery
+            ? defaultQuery
+            : ""
     );
 
-    const filterTitleDebounced = useDebounce(isArray(query) ? query.join(',') : query, 500);
+    const filterTitleDebounced = useDebounce(
+        isArray(query) ? query.join(",") : query,
+        500
+    );
 
     useEffect(() => {
         setSearchParams(previous => ({
@@ -193,8 +204,6 @@ const PublicationSearchDialog = ({
                 </Button>
                 <Button
                     onClick={() => {
-                        console.log('getValues("datasetNames")', getValues("datasetNames"));
-                        console.log('getValues("search")', getValues("search"));
                         onSubmit(
                             getValues("datasetNames") ||
                                 getValues("search") ||

--- a/src/modules/PublicationSearchDialog/PublicationSearchDialog.tsx
+++ b/src/modules/PublicationSearchDialog/PublicationSearchDialog.tsx
@@ -91,9 +91,7 @@ const PublicationSearchDialog = ({
             ? datasetNamesArray
                 ? datasetNamesArray.join(",")
                 : ""
-            : defaultQuery
-            ? defaultQuery
-            : ""
+            : defaultQuery || ""
     );
 
     const filterTitleDebounced = useDebounce(


### PR DESCRIPTION
## Screenshots (if relevant)

https://github.com/user-attachments/assets/e751c9be-6a6e-4389-95b3-9e7476644d58

## Describe your changes
User can now supply more than one dataset in the dataset title search bar for EuropePMC searches. These dataset titles persist until navigating to another page, or changing the search to Gateway publications only, and are shown in both the search bar and the URL.

Search results are the union of all search results from each dataset title, hence in the video, dataset A gives 18 results, dataset B gives 3 results, and searching for both together gives 21 results.

## Issue ticket link
https://hdruk.atlassian.net/browse/GAT-5651

## Checklist before requesting a review

-   [ ] I have performed a self-review of my code
-   [ ] I have added appropriate unit tests
-   [ ] I have created mocks for unit tests (where appropriate)
-   [ ] The interface is responsive (where appropriate)
-   [ ] The interface is at least AA (where appropriate)
