### PR TITLE
fix(gat-5800): Re-enable Cohort Discovery Access Request button when previous request has been rejected

### DIFF
--- a/src/app/[locale]/(logged-out)/about/cohort-discovery-request/components/CohortDisoveryRequestForm/CohortDisoveryRequestForm.tsx
+++ b/src/app/[locale]/(logged-out)/about/cohort-discovery-request/components/CohortDisoveryRequestForm/CohortDisoveryRequestForm.tsx
@@ -61,7 +61,10 @@ const CohortDisoveryRequestForm = ({
     if (!isUserLoading && !isAccessLoading) {
         if (accessData?.redirect_url) {
             redirect(accessData?.redirect_url);
-        } else if (userData?.request_status) {
+        } else if (
+            userData?.request_status &&
+            userData.request_status === "APPROVED"
+        ) {
             redirect(`/${RouteName.ABOUT}/${RouteName.COHORT_DISCOVERY}`);
         }
     }

--- a/src/app/[locale]/(logged-out)/about/cohort-discovery/components/CtaOverride/CtaOverride.tsx
+++ b/src/app/[locale]/(logged-out)/about/cohort-discovery/components/CtaOverride/CtaOverride.tsx
@@ -56,7 +56,9 @@ const CtaOverride = ({ ctaLink }: { ctaLink: CtaLink }) => {
     }, [accessData, isClicked, isLoggedIn]);
 
     const isDisabled =
-        isLoggedIn && userData ? userData.request_status !== "APPROVED" : false;
+        isLoggedIn && userData
+            ? !["APPROVED", "REJECTED"].includes(userData.request_status)
+            : false;
 
     return (
         <Box sx={{ display: "flex" }}>


### PR DESCRIPTION
## Screenshots (if relevant)

## Describe your changes
Re-enable button when REJECTED, and then check the exact value of the request status later on.

## Issue ticket link
https://hdruk.atlassian.net/browse/GAT-5800

## Checklist before requesting a review

-   [ ] I have performed a self-review of my code
-   [ ] I have added appropriate unit tests
-   [ ] I have created mocks for unit tests (where appropriate)
-   [ ] The interface is responsive (where appropriate)
-   [ ] The interface is at least AA (where appropriate)
