### PR TITLE
fix(GAT-5988): Add guards to Collection, Dataset and DataUse pages so that only ACTIVE entities display

### DIFF
--- a/src/app/[locale]/(logged-out)/collection/[collectionId]/page.tsx
+++ b/src/app/[locale]/(logged-out)/collection/[collectionId]/page.tsx
@@ -36,7 +36,10 @@ export default async function CollectionItemPage({
     const collection = await getReducedCollection(cookieStore, collectionId, {
         suppressError: true,
     });
-    if (!collection) notFound();
+
+    // Note that the status check is only required under v1 - under v2, we can use 
+    // an endpoint that will not show the data if not active
+    if (!collection || collection?.status !== "ACTIVE") notFound();
 
     const {
         name,

--- a/src/app/[locale]/(logged-out)/collection/[collectionId]/page.tsx
+++ b/src/app/[locale]/(logged-out)/collection/[collectionId]/page.tsx
@@ -37,7 +37,7 @@ export default async function CollectionItemPage({
         suppressError: true,
     });
 
-    // Note that the status check is only required under v1 - under v2, we can use 
+    // Note that the status check is only required under v1 - under v2, we can use
     // an endpoint that will not show the data if not active
     if (!collection || collection?.status !== "ACTIVE") notFound();
 

--- a/src/app/[locale]/(logged-out)/collection/[collectionId]/page.tsx
+++ b/src/app/[locale]/(logged-out)/collection/[collectionId]/page.tsx
@@ -11,6 +11,7 @@ import Typography from "@/components/Typography";
 import ActiveListSidebar from "@/modules/ActiveListSidebar";
 import { StaticImages } from "@/config/images";
 import { AspectRatioImage } from "@/config/theme";
+import { DataStatus } from "@/consts/application";
 import { getReducedCollection } from "@/utils/api";
 import metaData from "@/utils/metadata";
 import { toTitleCase } from "@/utils/string";
@@ -39,7 +40,7 @@ export default async function CollectionItemPage({
 
     // Note that the status check is only required under v1 - under v2, we can use
     // an endpoint that will not show the data if not active
-    if (!collection || collection?.status !== "ACTIVE") notFound();
+    if (!collection || collection?.status !== DataStatus.ACTIVE) notFound();
 
     const {
         name,

--- a/src/app/[locale]/(logged-out)/data-use/[dataUseId]/page.tsx
+++ b/src/app/[locale]/(logged-out)/data-use/[dataUseId]/page.tsx
@@ -31,7 +31,7 @@ export default async function DataUseItemPage({
         suppressError: true,
     });
 
-    // Note that the status check is only required under v1 - under v2, we can use 
+    // Note that the status check is only required under v1 - under v2, we can use
     // an endpoint that will not show the data if not active
     if (!data || data?.status !== "ACTIVE") notFound();
 

--- a/src/app/[locale]/(logged-out)/data-use/[dataUseId]/page.tsx
+++ b/src/app/[locale]/(logged-out)/data-use/[dataUseId]/page.tsx
@@ -31,7 +31,9 @@ export default async function DataUseItemPage({
         suppressError: true,
     });
 
-    if (!data) notFound();
+    // Note that the status check is only required under v1 - under v2, we can use 
+    // an endpoint that will not show the data if not active
+    if (!data || data?.status !== "ACTIVE") notFound();
 
     const populatedSections = dataUseFields.filter(section =>
         section.fields.some(field => !isEmpty(get(data, field.path)))

--- a/src/app/[locale]/(logged-out)/data-use/[dataUseId]/page.tsx
+++ b/src/app/[locale]/(logged-out)/data-use/[dataUseId]/page.tsx
@@ -6,6 +6,7 @@ import Box from "@/components/Box";
 import LayoutDataItemPage from "@/components/LayoutDataItemPage";
 import Typography from "@/components/Typography";
 import ActiveListSidebar from "@/modules/ActiveListSidebar";
+import { DataStatus } from "@/consts/application";
 import { getDataUse } from "@/utils/api";
 import metaData from "@/utils/metadata";
 import ActionBar from "./components/ActionBar";
@@ -33,7 +34,7 @@ export default async function DataUseItemPage({
 
     // Note that the status check is only required under v1 - under v2, we can use
     // an endpoint that will not show the data if not active
-    if (!data || data?.status !== "ACTIVE") notFound();
+    if (!data || data?.status !== DataStatus.ACTIVE) notFound();
 
     const populatedSections = dataUseFields.filter(section =>
         section.fields.some(field => !isEmpty(get(data, field.path)))

--- a/src/app/[locale]/(logged-out)/dataset/[datasetId]/page.tsx
+++ b/src/app/[locale]/(logged-out)/dataset/[datasetId]/page.tsx
@@ -55,7 +55,9 @@ export default async function DatasetItemPage({
         }
     );
 
-    if (!data) notFound();
+    // Note that the status check is only required under v1 - under v2, we can use 
+    // an endpoint that will not show the data if not active
+    if (!data || data?.status !== "ACTIVE") notFound();
 
     let googleRecommendedDataset: Dataset | undefined;
 

--- a/src/app/[locale]/(logged-out)/dataset/[datasetId]/page.tsx
+++ b/src/app/[locale]/(logged-out)/dataset/[datasetId]/page.tsx
@@ -55,7 +55,7 @@ export default async function DatasetItemPage({
         }
     );
 
-    // Note that the status check is only required under v1 - under v2, we can use 
+    // Note that the status check is only required under v1 - under v2, we can use
     // an endpoint that will not show the data if not active
     if (!data || data?.status !== "ACTIVE") notFound();
 

--- a/src/app/[locale]/(logged-out)/dataset/[datasetId]/page.tsx
+++ b/src/app/[locale]/(logged-out)/dataset/[datasetId]/page.tsx
@@ -7,6 +7,7 @@ import BoxContainer from "@/components/BoxContainer";
 import LayoutDataItemPage from "@/components/LayoutDataItemPage";
 import Typography from "@/components/Typography";
 import ActiveListSidebar from "@/modules/ActiveListSidebar";
+import { DataStatus } from "@/consts/application";
 import { getDataset } from "@/utils/api";
 import { getLatestVersion } from "@/utils/dataset";
 import metaData from "@/utils/metadata";
@@ -57,7 +58,7 @@ export default async function DatasetItemPage({
 
     // Note that the status check is only required under v1 - under v2, we can use
     // an endpoint that will not show the data if not active
-    if (!data || data?.status !== "ACTIVE") notFound();
+    if (!data || data?.status !== DataStatus.ACTIVE) notFound();
 
     let googleRecommendedDataset: Dataset | undefined;
 

--- a/src/app/[locale]/(logged-out)/tool/[toolId]/page.tsx
+++ b/src/app/[locale]/(logged-out)/tool/[toolId]/page.tsx
@@ -9,6 +9,7 @@ import LayoutDataItemPage from "@/components/LayoutDataItemPage";
 import PublicationsContent from "@/components/PublicationsContent";
 import Typography from "@/components/Typography";
 import ActiveListSidebar from "@/modules/ActiveListSidebar";
+import { DataStatus } from "@/consts/application";
 import { getTool } from "@/utils/api";
 import metaData from "@/utils/metadata";
 import ActionBar from "./components/ActionBar";
@@ -36,7 +37,7 @@ export default async function ToolPage({
 
     // Note that the status check is only required under v1 - under v2, we can use
     // an endpoint that will not show the data if not active
-    if (!data || data?.status !== "ACTIVE") notFound();
+    if (!data || data?.status !== DataStatus.ACTIVE) notFound();
 
     const populatedSections = toolFields.filter(section =>
         section.fields.some(field => !isEmpty(get(data, field.path)))

--- a/src/app/[locale]/(logged-out)/tool/[toolId]/page.tsx
+++ b/src/app/[locale]/(logged-out)/tool/[toolId]/page.tsx
@@ -34,7 +34,7 @@ export default async function ToolPage({
         suppressError: true,
     });
 
-    // Note that the status check is only required under v1 - under v2, we can use 
+    // Note that the status check is only required under v1 - under v2, we can use
     // an endpoint that will not show the data if not active
     if (!data || data?.status !== "ACTIVE") notFound();
 

--- a/src/app/[locale]/(logged-out)/tool/[toolId]/page.tsx
+++ b/src/app/[locale]/(logged-out)/tool/[toolId]/page.tsx
@@ -34,7 +34,9 @@ export default async function ToolPage({
         suppressError: true,
     });
 
-    if (!data) notFound();
+    // Note that the status check is only required under v1 - under v2, we can use 
+    // an endpoint that will not show the data if not active
+    if (!data || data?.status !== "ACTIVE") notFound();
 
     const populatedSections = toolFields.filter(section =>
         section.fields.some(field => !isEmpty(get(data, field.path)))

--- a/src/interfaces/Collection.ts
+++ b/src/interfaces/Collection.ts
@@ -16,6 +16,7 @@ interface ReducedCollection {
     dur: ReducedDataUse[] | [];
     dataset_versions?: ReducedDataset[] | [];
     publications: ReducedPublication[] | [];
+    status: DataStatus | undefined;
 }
 
 interface Collection {


### PR DESCRIPTION
## Screenshots (if relevant)

## Describe your changes
Draft or archived should never display via these urls.

I've added notes as reminders that we won't need these checks once we move to V2 endpoints, as those endpoints will check the status themselves.

## Issue ticket link
https://hdruk.atlassian.net/browse/GAT-5988

## Checklist before requesting a review

-   [ ] I have performed a self-review of my code
-   [ ] I have added appropriate unit tests
-   [ ] I have created mocks for unit tests (where appropriate)
-   [ ] The interface is responsive (where appropriate)
-   [ ] The interface is at least AA (where appropriate)
