### PR TITLE
fix(GAT-5624): Fix rendering of Markdown on Tools landing page

### DIFF
--- a/src/app/[locale]/(logged-out)/tool/[toolId]/components/ToolContent/ToolContent.tsx
+++ b/src/app/[locale]/(logged-out)/tool/[toolId]/components/ToolContent/ToolContent.tsx
@@ -6,6 +6,7 @@ import { Tool } from "@/interfaces/Tool";
 import Box from "@/components/Box";
 import BoxContainer from "@/components/BoxContainer";
 import Link from "@/components/Link";
+import { MarkDownSanitizedWithHtml } from "@/components/MarkDownSanitizedWithHTML";
 import Paper from "@/components/Paper";
 import TooltipIcon from "@/components/TooltipIcon";
 import Typography from "@/components/Typography";
@@ -28,7 +29,7 @@ const ToolField = ({ type, value }: ToolFieldProps) => {
         case FieldType.LINK:
             return <Link href={value}>{value}</Link>;
         default:
-            return <Typography>{value}</Typography>;
+            return <MarkDownSanitizedWithHtml content={value} />;
     }
 };
 

--- a/src/app/[locale]/(logged-out)/tool/[toolId]/config.tsx
+++ b/src/app/[locale]/(logged-out)/tool/[toolId]/config.tsx
@@ -32,7 +32,7 @@ const toolFields: ToolSection[] = [
         sectionName: "resultsInsights",
         fields: [
             {
-                path: "description", // what is this suppose to be?
+                path: "results_insights",
                 type: FieldType.TEXT,
                 hideTooltip: true,
             },


### PR DESCRIPTION
## Screenshots (if relevant)

## Describe your changes
Use Markdown component for `description` and `results_insights`, and correct a bonus bug where `results_insights` was showing the wrong data.

Dependent on https://github.com/HDRUK/gateway-api-2/pull/1067

## Issue ticket link
https://hdruk.atlassian.net/browse/GAT-5624

## Checklist before requesting a review

-   [ ] I have performed a self-review of my code
-   [ ] I have added appropriate unit tests
-   [ ] I have created mocks for unit tests (where appropriate)
-   [ ] The interface is responsive (where appropriate)
-   [ ] The interface is at least AA (where appropriate)
