### PR TITLE
fix(GAT-6303): Allow dev only to see page

### DIFF
--- a/src/app/[locale]/account/team/[teamId]/(withLeftNav)/team-management/page.tsx
+++ b/src/app/[locale]/account/team/[teamId]/(withLeftNav)/team-management/page.tsx
@@ -24,11 +24,15 @@ export default async function TeamManagementPage({
     const team = await getTeam(cookieStore, teamId);
     const teamUser = getTeamUser(team?.users, user?.id);
     const permissions = getPermissions(user.roles, teamUser?.roles);
+    const isOnlyDev =
+        teamUser?.roles?.length === 1 &&
+        teamUser.roles[0]?.name === "developer";
 
     return (
         <ProtectedAccountRoute
             permissions={permissions}
-            pagePermissions={["roles.read"]}>
+            pagePermissions={["roles.read"]}
+            allowDevOnly={isOnlyDev}>
             <TeamManagement permissions={permissions} team={team} />
         </ProtectedAccountRoute>
     );

--- a/src/app/[locale]/account/team/[teamId]/(withLeftNav)/team-management/page.tsx
+++ b/src/app/[locale]/account/team/[teamId]/(withLeftNav)/team-management/page.tsx
@@ -5,6 +5,7 @@ import metaData, { noFollowRobots } from "@/utils/metadata";
 import { getPermissions } from "@/utils/permissions";
 import { getTeamUser } from "@/utils/user";
 import TeamManagement from "./components/TeamManagement";
+import { ROLE_CUSTODIAN_DEVELOPER } from "@/consts/roles";
 
 export const metadata = metaData(
     {
@@ -26,7 +27,7 @@ export default async function TeamManagementPage({
     const permissions = getPermissions(user.roles, teamUser?.roles);
     const isOnlyDev =
         teamUser?.roles?.length === 1 &&
-        teamUser.roles[0]?.name === "developer";
+        teamUser.roles[0]?.name === ROLE_CUSTODIAN_DEVELOPER;
 
     return (
         <ProtectedAccountRoute

--- a/src/app/[locale]/account/team/[teamId]/(withLeftNav)/team-management/page.tsx
+++ b/src/app/[locale]/account/team/[teamId]/(withLeftNav)/team-management/page.tsx
@@ -1,11 +1,11 @@
 import { cookies } from "next/headers";
 import ProtectedAccountRoute from "@/components/ProtectedAccountRoute";
+import { ROLE_CUSTODIAN_DEVELOPER } from "@/consts/roles";
 import { getTeam, getUser } from "@/utils/api";
 import metaData, { noFollowRobots } from "@/utils/metadata";
 import { getPermissions } from "@/utils/permissions";
 import { getTeamUser } from "@/utils/user";
 import TeamManagement from "./components/TeamManagement";
-import { ROLE_CUSTODIAN_DEVELOPER } from "@/consts/roles";
 
 export const metadata = metaData(
     {

--- a/src/components/ProtectedAccountRoute/ProtectedAccountRoute.tsx
+++ b/src/components/ProtectedAccountRoute/ProtectedAccountRoute.tsx
@@ -7,6 +7,7 @@ interface ProtectedAccountRouteProps {
     loggedInOnly?: boolean;
     permissions?: { [key: string]: boolean };
     pagePermissions?: string[];
+    allowDevOnly: boolean;
     children: ReactNode;
 }
 
@@ -14,6 +15,7 @@ const ProtectedAccountRoute = async ({
     loggedInOnly,
     permissions,
     pagePermissions,
+    allowDevOnly = false,
     children,
 }: ProtectedAccountRouteProps) => {
     if (loggedInOnly) return children;
@@ -22,7 +24,7 @@ const ProtectedAccountRoute = async ({
     const userHasPermission =
         permissions && hasPermissions(permissions, pagePermissions);
 
-    if (!userHasPermission) {
+    if (!userHasPermission && !allowDevOnly) {
         redirect(RouteName.ERROR_403);
     }
 


### PR DESCRIPTION
## Screenshots (if relevant)
![image](https://github.com/user-attachments/assets/76a2f57f-2123-4c2e-b9be-a038c403f1ad)

## Describe your changes
Allow dev to see the team management page, giving them access to the side navigation
## Issue ticket link
https://hdruk.atlassian.net/jira/software/c/projects/GAT/boards/51?assignee=712020%3A05fbbf0f-9386-469a-a212-84cfbf9cc587&selectedIssue=GAT-6303
## Checklist before requesting a review

-   [x] I have performed a self-review of my code
-   [ ] I have added appropriate unit tests
-   [ ] I have created mocks for unit tests (where appropriate)
-   [ ] The interface is responsive (where appropriate)
-   [ ] The interface is at least AA (where appropriate)
