### PR TITLE
fix(GAT-6261): validate pid in metadata

### DIFF
--- a/src/app/[locale]/account/team/[teamId]/(withLeftNav)/datasets/upload/components/UploadDataset/UploadDataset.tsx
+++ b/src/app/[locale]/account/team/[teamId]/(withLeftNav)/datasets/upload/components/UploadDataset/UploadDataset.tsx
@@ -42,7 +42,6 @@ const UploadDataset = ({ teamId, teamPid }: UploadDatasetProps) => {
                 if (!dataCustodianId) {
                     SetErrorMessage(t("errorNoPid", { teamPid }));
                 } else if (teamPid !== dataCustodianId) {
-                    SetErrorMessage(t("errorNoPid", { teamPid }));
                     SetErrorMessage(
                         t("errorNoMatchingPid", { dataCustodianId, teamPid })
                     );

--- a/src/app/[locale]/account/team/[teamId]/(withLeftNav)/datasets/upload/components/UploadDataset/UploadDataset.tsx
+++ b/src/app/[locale]/account/team/[teamId]/(withLeftNav)/datasets/upload/components/UploadDataset/UploadDataset.tsx
@@ -1,6 +1,7 @@
 "use client";
 
 import { useState } from "react";
+import Alert from "@mui/material/Alert";
 import { useTranslations } from "next-intl";
 import { useRouter } from "next/navigation";
 import { FileUpload } from "@/interfaces/FileUpload";
@@ -15,6 +16,7 @@ import { RouteName } from "@/consts/routeName";
 
 interface UploadDatasetProps {
     teamId: string;
+    teamPid: string;
 }
 
 const SCHEMA_VERSION = process.env.NEXT_PUBLIC_SCHEMA_VERSION;
@@ -23,10 +25,35 @@ const TRANSLATION_PATH = "pages.account.team.datasets.components.UploadDataset";
 const FILE_TYPE = ".json";
 const FILE_DOWNLOAD_NAME = `HDRUK_${SCHEMA_VERSION}.template.json`;
 
-const UploadDataset = ({ teamId }: UploadDatasetProps) => {
+const UploadDataset = ({ teamId, teamPid }: UploadDatasetProps) => {
     const t = useTranslations(TRANSLATION_PATH);
+    const [errorMessage, SetErrorMessage] = useState<string>("");
 
     const { push } = useRouter();
+
+    const checkIfPidMatches = (file: unknown) => {
+        SetErrorMessage("");
+        const reader = new FileReader();
+        reader.onload = function (event) {
+            try {
+                const jsonData = JSON.parse(event.target.result);
+                const dataCustodianId =
+                    jsonData.summary?.dataCustodian?.identifier;
+                if (!dataCustodianId) {
+                    SetErrorMessage(t("errorNoPid", { teamPid }));
+                } else if (teamPid !== dataCustodianId) {
+                    SetErrorMessage(t("errorNoPid", { teamPid }));
+                    SetErrorMessage(
+                        t("errorNoMatchingPid", { dataCustodianId, teamPid })
+                    );
+                }
+            } catch (error) {
+                console.error("Error parsing JSON:", error);
+            }
+        };
+
+        reader.readAsText(file);
+    };
 
     const [createdDatasetId, setCreatedDatasetId] = useState<number>();
     const [isUploading, setIsUploading] = useState<boolean>(false);
@@ -60,9 +87,14 @@ const UploadDataset = ({ teamId }: UploadDatasetProps) => {
                             onFileUploaded={(file: FileUpload) =>
                                 setCreatedDatasetId(file.id)
                             }
+                            onFileChange={checkIfPidMatches}
                             isUploading={setIsUploading}
                             acceptedFileTypes={FILE_TYPE}
+                            showUploadButton={errorMessage === ""}
                         />
+                        {errorMessage !== "" && (
+                            <Alert severity="error">{errorMessage}</Alert>
+                        )}
                     </Box>
                 </Paper>
             )}

--- a/src/app/[locale]/account/team/[teamId]/(withLeftNav)/datasets/upload/page.tsx
+++ b/src/app/[locale]/account/team/[teamId]/(withLeftNav)/datasets/upload/page.tsx
@@ -31,7 +31,7 @@ export default async function UploadDatasetPage({
             permissions={permissions}
             pagePermissions={["datasets.create"]}>
             <BoxContainer sx={{ mt: "14px" }}>
-                <UploadDataset teamId={teamId} />
+                <UploadDataset teamId={teamId} teamPid={team.pid} />
             </BoxContainer>
         </ProtectedAccountRoute>
     );

--- a/src/config/messages/en.json
+++ b/src/config/messages/en.json
@@ -536,7 +536,9 @@
                             "downloadButtonText": "Download metadata template",
                             "successMessage": "Dataset successfully created",
                             "upload": "Upload",
-                            "returnButtonText": "View dataset in 'Drafts' tab"
+                            "returnButtonText": "View dataset in 'Drafts' tab",
+                            "errorNoMatchingPid": "The summary.dataCustodian.identifier is: {dataCustodianId} which does not match your teams identifier: {teamPid}.",
+                            "errorNoPid": "Missing summary.dataCustodian.identifier your teams identifier is: {teamPid} please add in, this identifier before uploading."
                         }
                     }
                 },

--- a/src/interfaces/Team.ts
+++ b/src/interfaces/Team.ts
@@ -3,6 +3,7 @@ import { User } from "@/interfaces/User";
 
 interface Team {
     id: number;
+    pid: string;
     name: string;
     enabled: boolean;
     allows_messaging: boolean;


### PR DESCRIPTION
## Screenshots (if relevant)
Incorrect Pids cause the pages to crash, so validate the pid in the onboarding.

![image](https://github.com/user-attachments/assets/068c5427-21d5-4b94-9388-7402e1274502)
![image](https://github.com/user-attachments/assets/6f742d8f-19f6-4f5e-aa93-b2af5a0763c9)
![image](https://github.com/user-attachments/assets/2ad9ad00-bb96-4621-ba0b-b47e70e22d43)

## Describe your changes
Validate the pid in the metadata against the pid on the team.

## Issue ticket link

## Checklist before requesting a review

-   [x] I have performed a self-review of my code
-   [ ] I have added appropriate unit tests
-   [ ] I have created mocks for unit tests (where appropriate)
-   [ ] The interface is responsive (where appropriate)
-   [ ] The interface is at least AA (where appropriate)
