### PR TITLE
fix(GAT-6215): Correctly display images with spaces in filenames

### DIFF
--- a/.github/workflows/dev_deployment.yaml
+++ b/.github/workflows/dev_deployment.yaml
@@ -4,7 +4,7 @@ run-name: ${{ github.actor }} triggered deploy to DEV pipeline
 on:
   push:
     branches:
-      - "dev"
+      - "fix/gat-6215-2"
 
 env:
   PROJECT_ID: "${{ secrets.PROJECT_ID }}"
@@ -24,7 +24,7 @@ jobs:
       - name: Checkout
         uses: actions/checkout@v4
         with:
-          ref: "dev"
+          ref: "fix/gat-6215-2"
 
       - name: Read VERSION file
         id: getversion
@@ -73,7 +73,7 @@ jobs:
         id: checkout
         uses: actions/checkout@v4
         with:
-          ref: "dev"
+          ref: "fix/gat-6215-2"
 
       - name: Google Auth
         id: auth

--- a/.github/workflows/dev_deployment.yaml
+++ b/.github/workflows/dev_deployment.yaml
@@ -4,7 +4,7 @@ run-name: ${{ github.actor }} triggered deploy to DEV pipeline
 on:
   push:
     branches:
-      - "fix/gat-6215-2"
+      - "dev"
 
 env:
   PROJECT_ID: "${{ secrets.PROJECT_ID }}"
@@ -24,7 +24,7 @@ jobs:
       - name: Checkout
         uses: actions/checkout@v4
         with:
-          ref: "fix/gat-6215-2"
+          ref: "dev"
 
       - name: Read VERSION file
         id: getversion
@@ -73,7 +73,7 @@ jobs:
         id: checkout
         uses: actions/checkout@v4
         with:
-          ref: "fix/gat-6215-2"
+          ref: "dev"
 
       - name: Google Auth
         id: auth

--- a/src/components/CollectionCard/CollectionCard.tsx
+++ b/src/components/CollectionCard/CollectionCard.tsx
@@ -63,7 +63,7 @@ const CollectionCard = ({ collection, actions }: CollectionCardProps) => {
                             alignItems: "center",
                             textAlign: "center",
                             color: colors.white,
-                            backgroundImage: hasImage && `url(${image_link})`,
+                            ...(hasImage ? { backgroundImage: `url("${image_link}")` } : {}),
                             background:
                                 !hasImage &&
                                 `linear-gradient(to right, ${theme.palette.secondary.main},${theme.palette.primary.main})`,

--- a/src/components/CollectionCard/CollectionCard.tsx
+++ b/src/components/CollectionCard/CollectionCard.tsx
@@ -63,7 +63,9 @@ const CollectionCard = ({ collection, actions }: CollectionCardProps) => {
                             alignItems: "center",
                             textAlign: "center",
                             color: colors.white,
-                            ...(hasImage ? { backgroundImage: `url("${image_link}")` } : {}),
+                            ...(hasImage
+                                ? { backgroundImage: `url("${image_link}")` }
+                                : {}),
                             background:
                                 !hasImage &&
                                 `linear-gradient(to right, ${theme.palette.secondary.main},${theme.palette.primary.main})`,

--- a/src/components/CollectionCard/CollectionCard.tsx
+++ b/src/components/CollectionCard/CollectionCard.tsx
@@ -63,7 +63,7 @@ const CollectionCard = ({ collection, actions }: CollectionCardProps) => {
                             alignItems: "center",
                             textAlign: "center",
                             color: colors.white,
-                            backgroundImage: hasImage && `url(${encodeURIComponent(image_link)})`,
+                            backgroundImage: hasImage && `url(${image_link})`,
                             background:
                                 !hasImage &&
                                 `linear-gradient(to right, ${theme.palette.secondary.main},${theme.palette.primary.main})`,

--- a/src/components/CollectionCard/CollectionCard.tsx
+++ b/src/components/CollectionCard/CollectionCard.tsx
@@ -63,7 +63,7 @@ const CollectionCard = ({ collection, actions }: CollectionCardProps) => {
                             alignItems: "center",
                             textAlign: "center",
                             color: colors.white,
-                            backgroundImage: hasImage && `url(${image_link})`,
+                            backgroundImage: hasImage && `url(${encodeURIComponent(image_link)})`,
                             background:
                                 !hasImage &&
                                 `linear-gradient(to right, ${theme.palette.secondary.main},${theme.palette.primary.main})`,


### PR DESCRIPTION
## Screenshots (if relevant)

## Describe your changes
Correct the syntax and reduce the payload when the Collection image doesn't exist.

Works in tandem with https://github.com/HDRUK/gateway-api-2/pull/1123

## Issue ticket link
https://hdruk.atlassian.net/browse/GAT-6215

## Checklist before requesting a review

-   [ ] I have performed a self-review of my code
-   [ ] I have added appropriate unit tests
-   [ ] I have created mocks for unit tests (where appropriate)
-   [ ] The interface is responsive (where appropriate)
-   [ ] The interface is at least AA (where appropriate)
