### PR TITLE
fix(GAT-6424): funders_and_sponsors as array

### DIFF
--- a/src/app/[locale]/account/team/[teamId]/(withLeftNav)/data-uses/[dataUseId]/components/EditDataUse.tsx
+++ b/src/app/[locale]/account/team/[teamId]/(withLeftNav)/data-uses/[dataUseId]/components/EditDataUse.tsx
@@ -146,7 +146,7 @@ const EditDataUse = () => {
                 : {}),
             ...(typeof formData?.other_approval_committees === "string"
                 ? {
-                    other_approval_committees: (
+                      other_approval_committees: (
                           formData.other_approval_committees as string
                       ).split(","),
                   }

--- a/src/app/[locale]/account/team/[teamId]/(withLeftNav)/data-uses/[dataUseId]/components/EditDataUse.tsx
+++ b/src/app/[locale]/account/team/[teamId]/(withLeftNav)/data-uses/[dataUseId]/components/EditDataUse.tsx
@@ -135,7 +135,6 @@ const EditDataUse = () => {
         if (!existingDataUse) {
             return;
         }
-name
         const edited = {
             ...formData,
             ...(typeof formData?.funders_and_sponsors === "string"

--- a/src/app/[locale]/account/team/[teamId]/(withLeftNav)/data-uses/[dataUseId]/components/EditDataUse.tsx
+++ b/src/app/[locale]/account/team/[teamId]/(withLeftNav)/data-uses/[dataUseId]/components/EditDataUse.tsx
@@ -135,13 +135,20 @@ const EditDataUse = () => {
         if (!existingDataUse) {
             return;
         }
-
+name
         const edited = {
             ...formData,
             ...(typeof formData?.funders_and_sponsors === "string"
                 ? {
                       funders_and_sponsors: (
                           formData.funders_and_sponsors as string
+                      ).split(","),
+                  }
+                : {}),
+            ...(typeof formData?.other_approval_committees === "string"
+                ? {
+                    other_approval_committees: (
+                          formData.other_approval_committees as string
                       ).split(","),
                   }
                 : {}),


### PR DESCRIPTION
## Screenshots (if relevant)
![image](https://github.com/user-attachments/assets/fa4a6c36-b555-4a42-ac85-74b91fc84a4c)
![image](https://github.com/user-attachments/assets/42051fe0-f7d4-4572-93b3-2a42a30ba8a9)

## Describe your changes
Same fix as GAT-6200, field should be posted as an array of strings.
## Issue ticket link

## Checklist before requesting a review

-   [x] I have performed a self-review of my code
-   [ ] I have added appropriate unit tests
-   [ ] I have created mocks for unit tests (where appropriate)
-   [ ] The interface is responsive (where appropriate)
-   [ ] The interface is at least AA (where appropriate)
