### PR TITLE
feat(GAT-6150): Allow API client ID to be regenerated

### DIFF
--- a/src/app/[locale]/account/team/[teamId]/(withLeftNav)/integrations/api-management/components/ApplicationAuthDetails/ApplicationAuthDetails.tsx
+++ b/src/app/[locale]/account/team/[teamId]/(withLeftNav)/integrations/api-management/components/ApplicationAuthDetails/ApplicationAuthDetails.tsx
@@ -1,28 +1,36 @@
+import { useTranslations } from "next-intl";
 import { Application } from "@/interfaces/Application";
+import Box from "@/components/Box";
 import BoxContainer from "@/components/BoxContainer";
+import Button from "@/components/Button";
+import Card from "@/components/Card";
 import CopyableCard from "@/components/CopyableCard";
 import Paper from "@/components/Paper";
 import Typography from "@/components/Typography";
 
 interface ApplicationAuthDetailsProps {
     application?: Application;
+    handleGenerateId: () => void;
 }
+
+const TRANSLATION_PATH = `pages.account.team.integrations.apiManagement`;
 
 const ApplicationAuthDetails = ({
     application,
+    handleGenerateId,
 }: ApplicationAuthDetailsProps) => {
+    const t = useTranslations(TRANSLATION_PATH);
+
     const credentials = [
         {
-            label: "App ID",
+            label: t("appId"),
             value: application?.app_id,
-            description:
-                "This is your App's unique ID. You will need it to make certain API calls.",
+            description: t("appDescription"),
         },
         {
-            label: "Client ID",
+            label: t("clientId"),
             value: application?.client_id,
-            description:
-                "This is your App's unique client ID. You will need it to make certain API calls.",
+            description: t("clientDescription"),
         },
     ];
 
@@ -34,14 +42,31 @@ const ApplicationAuthDetails = ({
                     marginBottom: "10px",
                     padding: 2,
                 }}>
-                <Typography variant="h2">Authentication credentials</Typography>
-                <Typography>
-                    These authentication credentials determine how your Private
-                    App interacts with HDR UK Gateway and its permissions.
-                </Typography>
+                <Typography variant="h2">{t("authTitle")}</Typography>
+                <Typography>{t("authIntro")}</Typography>
             </Paper>
 
             <BoxContainer>
+                <Card
+                    sx={{
+                        display: "grid",
+                        gridTemplateColumns: { laptop: "3fr 1fr" },
+                    }}>
+                    <Box>
+                        <Typography
+                            sx={{
+                                fontWeight: 600,
+                            }}>
+                            {t("authSettingsTitle")}
+                        </Typography>
+                        <Typography>{t("authSettingsIntro")}</Typography>
+                    </Box>
+                    <Box sx={{ justifySelf: { laptop: "flex-end" } }}>
+                        <Button onClick={handleGenerateId}>
+                            {t("generateClientId")}
+                        </Button>
+                    </Box>
+                </Card>
                 {credentials.map(cred => (
                     <CopyableCard key={cred.label} {...cred} />
                 ))}

--- a/src/app/[locale]/account/team/[teamId]/(withLeftNav)/integrations/api-management/components/ApplicationPermissions/ApplicationPermissions.tsx
+++ b/src/app/[locale]/account/team/[teamId]/(withLeftNav)/integrations/api-management/components/ApplicationPermissions/ApplicationPermissions.tsx
@@ -141,7 +141,7 @@ const ApplicationPermissions = ({
     // Auto set read permission to true if create, update or delete checked
     useEffect(() => {
         Object.entries(fieldGroups)
-            .filter(([_, fields]) => fields.some(Boolean))
+            .filter(([, fields]) => fields.some(Boolean))
             .forEach(([key]) => {
                 const readKey = `${key}.read` as ReadKey;
                 setValue(readKey, true);
@@ -231,25 +231,23 @@ const ApplicationPermissions = ({
 
         /* Only call `showBar` if form is `isDirty` ActionBar is not visible */
         if (formState.isDirty && !store.isVisible) {
-            !isTabView
-                ? handleSubmit(onSubmit)()
-                : showBar("PermissionChanges", {
-                      component: ChangesActionBar,
-                      cancelText: t("discard"),
-                      confirmText: t("save"),
-                      changeCount: 1,
-                      onSuccess: () =>
-                          showModal({
-                              title: t("modalTitle"),
-                              content: t("modalContent"),
-                              confirmText: t("save"),
-                              cancelText: t("cancel"),
-                              onSuccess: handleSubmit(onSubmit),
-                          }),
-                      onCancel: () => {
-                          reset(originalFormValues);
-                      },
-                  });
+            showBar("PermissionChanges", {
+                component: ChangesActionBar,
+                cancelText: t("discard"),
+                confirmText: t("save"),
+                changeCount: 1,
+                onSuccess: () =>
+                    showModal({
+                        title: t("modalTitle"),
+                        content: t("modalContent"),
+                        confirmText: t("save"),
+                        cancelText: t("cancel"),
+                        onSuccess: handleSubmit(onSubmit),
+                    }),
+                onCancel: () => {
+                    reset(originalFormValues);
+                },
+            });
         }
         if (!formState.isDirty && store.isVisible) {
             hideBar();

--- a/src/app/[locale]/account/team/[teamId]/(withLeftNav)/integrations/api-management/components/ApplicationTabs/ApplicationTabs.tsx
+++ b/src/app/[locale]/account/team/[teamId]/(withLeftNav)/integrations/api-management/components/ApplicationTabs/ApplicationTabs.tsx
@@ -1,20 +1,47 @@
 "use client";
 
+import { useTranslations } from "next-intl";
 import { useParams } from "next/navigation";
 import { Application } from "@/interfaces/Application";
 import Tabs from "@/components/Tabs";
 import useGet from "@/hooks/useGet";
+import useModal from "@/hooks/useModal";
+import usePatch from "@/hooks/usePatch";
 import apis from "@/config/apis";
 import ApplicationAuthDetails from "../ApplicationAuthDetails";
 import ApplicationPermissions from "../ApplicationPermissions";
 import EditApplicationForm from "../EditApplicationForm";
 
-const ApplicationTabs = () => {
-    const params = useParams<{ apiId: string }>();
+const TRANSLATION_PATH = `pages.account.team.integrations.apiManagement`;
 
-    const { data: application } = useGet<Application>(
-        params?.apiId ? `${apis.applicationsV1Url}/${params?.apiId}` : null
+const ApplicationTabs = () => {
+    const t = useTranslations(TRANSLATION_PATH);
+    const params = useParams<{ apiId: string }>();
+    const { showModal } = useModal();
+
+    const { data: application, mutate: mutateApplication } =
+        useGet<Application>(
+            params?.apiId ? `${apis.applicationsV1Url}/${params?.apiId}` : null
+        );
+
+    const generateClientId = usePatch(
+        `${apis.applicationsV1Url}/${application?.id}/clientid`,
+        {
+            itemName: "Application",
+        }
     );
+
+    const handleGenerateId = () => {
+        showModal({
+            title: t("generateIdTitle"),
+            content: t("generateIdMessage"),
+            confirmText: t("generateIdConfirm"),
+            cancelText: t("generateIdCancel"),
+            onSuccess: () => {
+                generateClientId("", {}).then(() => mutateApplication());
+            },
+        });
+    };
 
     const applicationTabs = [
         {
@@ -34,7 +61,12 @@ const ApplicationTabs = () => {
         {
             label: "Authentication",
             value: "Authentication",
-            content: <ApplicationAuthDetails application={application} />,
+            content: (
+                <ApplicationAuthDetails
+                    application={application}
+                    handleGenerateId={handleGenerateId}
+                />
+            ),
         },
     ];
 

--- a/src/components/ActionBar/ActionBar.tsx
+++ b/src/components/ActionBar/ActionBar.tsx
@@ -48,6 +48,7 @@ const ActionBar = () => {
                     confirmText={confirmText}
                     cancelText={cancelText}
                     confirmType={confirmType}
+                    shouldHideModal={false}
                 />
             </ButtonWrapper>
         </Wrapper>

--- a/src/components/Checkbox/Checkbox.tsx
+++ b/src/components/Checkbox/Checkbox.tsx
@@ -17,10 +17,6 @@ export interface CheckboxProps<TFieldValues extends FieldValues, TName>
     formControlSx?: SxProps;
     count?: number;
     id?: string;
-    onChange?: (
-        event: React.ChangeEvent<HTMLInputElement>,
-        checked: boolean
-    ) => void;
 }
 
 const Checkbox = <
@@ -39,7 +35,6 @@ const Checkbox = <
         formControlSx,
         count,
         id,
-        onChange,
         ...rest
     } = props;
 
@@ -67,7 +62,6 @@ const Checkbox = <
                         id={id || name}
                         {...rest}
                         {...fieldProps}
-                        {...(onChange ? { onChange } : {})}
                     />
                 }
                 label={

--- a/src/components/CopyableCard/CopyableCard.tsx
+++ b/src/components/CopyableCard/CopyableCard.tsx
@@ -14,7 +14,7 @@ const CopyableCard = ({ label, description, value }: CopyableCardProps) => {
         <Card
             sx={{
                 display: "grid",
-                gridTemplateColumns: "2fr 2fr",
+                gridTemplateColumns: { laptop: "2fr 2fr" },
             }}>
             <Box>
                 <Typography

--- a/src/components/CustomNotifications/ApiWarning/ApiWarning.tsx
+++ b/src/components/CustomNotifications/ApiWarning/ApiWarning.tsx
@@ -7,12 +7,16 @@ import Button from "@/components/Button";
 interface ApiWarningProps extends CustomContentProps {
     id: string;
     showDismissButton?: boolean;
+    title: string;
     action: ReactNode;
     message: string;
 }
 
 const ApiWarning = React.forwardRef<HTMLDivElement, ApiWarningProps>(
-    ({ id, message, action, showDismissButton = true }, ref) => {
+    (
+        { id, message, action, showDismissButton = true, title = "Warning" },
+        ref
+    ) => {
         const handleDismiss = useCallback(() => {
             closeSnackbar(id);
         }, [id]);
@@ -27,14 +31,16 @@ const ApiWarning = React.forwardRef<HTMLDivElement, ApiWarningProps>(
                         color: "#856505",
                         fontSize: "14px",
                     }}>
-                    <CardHeader
-                        title="Warning"
-                        subheaderTypographyProps={{
-                            color: "#856505",
-                            fontSize: "14px",
-                        }}
-                        titleTypographyProps={{ fontSize: "18px" }}
-                    />
+                    {title && (
+                        <CardHeader
+                            title={title}
+                            subheaderTypographyProps={{
+                                color: "#856505",
+                                fontSize: "14px",
+                            }}
+                            titleTypographyProps={{ fontSize: "18px" }}
+                        />
+                    )}
                     <CardContent>{message}</CardContent>
                     <CardActions style={{ justifyContent: "end", gap: "10px" }}>
                         {showDismissButton && (

--- a/src/components/ModalButtons/ModalButtons.tsx
+++ b/src/components/ModalButtons/ModalButtons.tsx
@@ -40,8 +40,8 @@ const ModalButtons = ({
             onSuccess(props);
         }
 
-        {
-            shouldHideModal && hideModal();
+        if (shouldHideModal) {
+            hideModal();
         }
     };
 
@@ -50,8 +50,8 @@ const ModalButtons = ({
             onCancel(props);
         }
 
-        {
-            shouldHideModal && hideModal();
+        if (shouldHideModal) {
+            hideModal();
         }
     };
 
@@ -60,8 +60,8 @@ const ModalButtons = ({
             tertiaryButton.onAction(props);
         }
 
-        {
-            shouldHideModal && hideModal();
+        if (shouldHideModal) {
+            hideModal();
         }
     };
 

--- a/src/components/ModalButtons/ModalButtons.tsx
+++ b/src/components/ModalButtons/ModalButtons.tsx
@@ -18,6 +18,7 @@ export interface ModalButtonProps {
         buttonText: string;
         buttonProps?: ButtonProps;
     };
+    shouldHideModal?: boolean;
 }
 
 const ModalButtons = ({
@@ -30,6 +31,7 @@ const ModalButtons = ({
     confirmText = "Confirm",
     confirmType = "button" as ConfirmType,
     tertiaryButton,
+    shouldHideModal = true,
 }: ModalButtonProps) => {
     const { hideDialog: hideModal } = useDialog();
 
@@ -37,21 +39,30 @@ const ModalButtons = ({
         if (typeof onSuccess === "function") {
             onSuccess(props);
         }
-        hideModal();
+
+        {
+            shouldHideModal && hideModal();
+        }
     };
 
     const handleCancel = (props: unknown) => {
         if (typeof onCancel === "function") {
             onCancel(props);
         }
-        hideModal();
+
+        {
+            shouldHideModal && hideModal();
+        }
     };
 
     const handleTertiary = (props: unknown) => {
         if (typeof tertiaryButton?.onAction === "function") {
             tertiaryButton.onAction(props);
         }
-        hideModal();
+
+        {
+            shouldHideModal && hideModal();
+        }
     };
 
     return (

--- a/src/config/messages/en.json
+++ b/src/config/messages/en.json
@@ -706,9 +706,28 @@
                             "permissions": {
                                 "title": "Permissions",
                                 "intro": "Use this form to assign the appropriate permissions for secure integration. Your App will only be allowed to use APIs for the permissions you have defined. App permissions are the responsibility of your ‘team’.",
-                                "helper": "Entities created via a Private App can only be managed (updated or deleted/archived) via the Private App. Entities created via another method (manual, HDR UK Datasets Integration) cannot be managed via the Private App."
+                                "helper": "Entities created via a Private App can only be managed (updated or deleted/archived) via the Private App. Entities created via another method (manual, HDR UK Datasets Integration) cannot be managed via the Private App.",
+                                "warning": "We recommend you update your client ID across all software using this Private App.",
+                                "modalTitle": "Are you sure you want to change permissions?",
+                                "modalContent": "When permissions are changed a notification is sent to all notification contacts set for this Private App, as well as Team Administrators and Developers. We recommend you generate a new client ID on the 'Authentication' tab.",
+                                "save": "Save",
+                                "cancel": "Exit without saving",
+                                "discard": "Discard"
                             }
-                        }
+                        },
+                        "generateIdTitle": "Are you sure you want to generate a new client ID?",
+                        "generateIdMessage": "Saving a new client ID for this Private App will cause any current integrations to fail until you update your system with the new client ID. A notification is sent to all notification contacts set for this Private App, as well as Team Administrators and Developers.",
+                        "generateIdConfirm": "Generate new client ID",
+                        "generateIdCancel": "Exit without generating",
+                        "appId": "App ID",
+                        "appDescription": "This is your App's unique ID. You will need it to make certain API calls.",
+                        "clientId": "Client ID",
+                        "clientDescription": "This is your App's unique client ID. You will need it to make certain API calls.",
+                        "authTitle": "Authentication credentials",
+                        "authIntro": "These authentication credentials determine how your Private App interacts with HDR UK Gateway and its permissions.",
+                        "authSettingsTitle": "Authentication settings",
+                        "authSettingsIntro": "These authentication credentials determine how your API interacts with HDR UK Gateway and its permissions.",
+                        "generateClientId": "Generate new client ID"
                     }
                 },
                 "dar": {

--- a/src/config/tables/apiPermissions.tsx
+++ b/src/config/tables/apiPermissions.tsx
@@ -6,10 +6,16 @@ import { capitalise } from "@/utils/general";
 
 const columnHelper = createColumnHelper<{ name: string; label: string }>();
 
+interface ColumnReadState {
+    collections: boolean;
+    tools: boolean;
+    datasets: boolean;
+    dur: boolean;
+}
+
 const getColumns = <T extends FieldValues>(
     control: Control<T>,
-    setValue: (name: string, value: boolean) => void,
-    watch: (name: string) => boolean
+    columnReadDisabled: ColumnReadState
 ): ColumnDef<{ name: string; label: string }>[] => {
     return [
         columnHelper.display({
@@ -29,47 +35,20 @@ const getColumns = <T extends FieldValues>(
                         {capitalise(key)}
                     </Box>
                 ),
-                cell: ({ row: { original } }) => {
-                    const readFieldName = `${original.name}.read`;
-
-                    const handleChange = (checked: boolean) => {
-                        setValue(`${original.name}.${key}`, checked);
-
-                        if (key !== "read") {
-                            if (checked) {
-                                setValue(readFieldName, true);
-                            } else {
-                                const createChecked = watch(
-                                    `${original.name}.create`
-                                );
-                                const updateChecked = watch(
-                                    `${original.name}.update`
-                                );
-                                const deleteChecked = watch(
-                                    `${original.name}.delete`
-                                );
-
-                                if (
-                                    !createChecked &&
-                                    !updateChecked &&
-                                    !deleteChecked
-                                ) {
-                                    setValue(readFieldName, false);
-                                }
-                            }
+                cell: ({ row: { original } }) => (
+                    <Checkbox
+                        size="large"
+                        control={control}
+                        name={`${original.name}.${key}`}
+                        formControlSx={{ mb: 0 }}
+                        disabled={
+                            key === "read" &&
+                            columnReadDisabled[
+                                original.name as keyof typeof columnReadDisabled
+                            ]
                         }
-                    };
-
-                    return (
-                        <Checkbox
-                            size="large"
-                            control={control}
-                            name={`${original.name}.${key}`}
-                            formControlSx={{ mb: 0 }}
-                            onChange={(_, checked) => handleChange(checked)}
-                        />
-                    );
-                },
+                    />
+                ),
             })
         ),
     ];


### PR DESCRIPTION
## Screenshots (if relevant)
![image](https://github.com/user-attachments/assets/ecd07589-4e8e-4df7-83d6-7c271c9e1352)
![image](https://github.com/user-attachments/assets/83ee7af7-d28d-4224-bfeb-c2786a690e84)
![image](https://github.com/user-attachments/assets/8fa0fd45-7401-4500-8aab-46d4f60e78fe)

## Describe your changes
- Fixes discovered bug where permissions can't be saved for an existing app
- Modal which displays when saving existing app permissions, confirming choice
- Functionality to generate a new client ID for app

## Issue ticket link
https://hdruk.atlassian.net/browse/GAT-6150

## Checklist before requesting a review

-   [ ] I have performed a self-review of my code
-   [ ] I have added appropriate unit tests
-   [ ] I have created mocks for unit tests (where appropriate)
-   [ ] The interface is responsive (where appropriate)
-   [ ] The interface is at least AA (where appropriate)
