### PR TITLE
fix(GAT-6521): Add image dimension validation

### DIFF
--- a/src/app/[locale]/account/profile/teams/components/CreateTeamForm/CreateTeamForm.tsx
+++ b/src/app/[locale]/account/profile/teams/components/CreateTeamForm/CreateTeamForm.tsx
@@ -30,19 +30,22 @@ import {
     teamFormFields,
     teamValidationSchema,
 } from "@/config/forms/team";
+import { ImageValidationError } from "@/consts/image";
 import { ROLE_CUSTODIAN_TEAM_ADMIN } from "@/consts/roles";
 import { Routes } from "@/consts/routes";
 
 const TRANSLATION_PATH_CREATE = "pages.account.profile.teams.create";
 const TRANSLATION_PATH_EDIT = "pages.account.profile.teams.edit";
 const TRANSLATION_PATH_COMMON = "common";
+const TRANSLATION_PATH_ERROR = "error";
 
 const CreateTeamForm = () => {
     const params = useParams<{
         teamId: string;
     }>();
     const t = useTranslations();
-    const [fileWarning, setFileWarning] = useState(false);
+    const [fileNotUploadedMessage, setFileNotUploadedMessage] =
+        useState<string>();
     const [imageUploaded, setImageUploaded] = useState(false);
     const [file, setFile] = useState<File>();
     const [createdTeamId, setCreatedTeamId] = useState<string | undefined>(
@@ -325,12 +328,10 @@ const CreateTeamForm = () => {
                                           )
                                 }
                                 error={
-                                    fileWarning
+                                    fileNotUploadedMessage
                                         ? {
                                               type: "",
-                                              message: t(
-                                                  `${TRANSLATION_PATH_CREATE}.aspectRatioError`
-                                              ),
+                                              message: fileNotUploadedMessage,
                                           }
                                         : undefined
                                 }
@@ -341,26 +342,29 @@ const CreateTeamForm = () => {
                                         `${TRANSLATION_PATH_CREATE}.fileSelectButtonText`
                                     )}
                                     acceptedFileTypes=".jpg,.png"
-                                    onBeforeUploadCheck={(
-                                        height: number,
-                                        width: number
-                                    ) => {
-                                        const aspectRatio =
-                                            (width || 0) / (height || 0);
-                                        return (
-                                            aspectRatio <= 2.5 &&
-                                            aspectRatio >= 1.5
-                                        );
-                                    }}
                                     onFileChange={(file: File) => {
                                         setFile(file);
-                                        setFileWarning(false);
+                                        setFileNotUploadedMessage(undefined);
                                     }}
                                     onFileCheckSucceeded={() => {
                                         setImageUploaded(true);
                                     }}
-                                    onFileCheckFailed={() => {
-                                        setFileWarning(true);
+                                    onFileCheckFailed={(
+                                        reason?: ImageValidationError
+                                    ) => {
+                                        const errorMessages = {
+                                            [ImageValidationError.RATIO]: `${TRANSLATION_PATH_ERROR}.imageAspectRatio`,
+                                            [ImageValidationError.SIZE]: `${TRANSLATION_PATH_ERROR}.imageDimensions`,
+                                            default: `${TRANSLATION_PATH_ERROR}.image`,
+                                        };
+
+                                        setFileNotUploadedMessage(
+                                            t(
+                                                errorMessages[
+                                                    reason as ImageValidationError
+                                                ] || errorMessages.default
+                                            )
+                                        );
                                     }}
                                     onFileUploaded={async response => {
                                         if (!createdTeamId) {

--- a/src/components/CollectionForm/CollectionForm.tsx
+++ b/src/components/CollectionForm/CollectionForm.tsx
@@ -46,6 +46,7 @@ import {
 } from "@/config/forms/collection";
 import { DataStatus } from "@/consts/application";
 import { AddIcon } from "@/consts/icons";
+import { ImageValidationError } from "@/consts/image";
 import { RouteName } from "@/consts/routeName";
 import { revalidateCache } from "@/app/actions/revalidateCache";
 
@@ -57,6 +58,7 @@ interface CollectionCreateProps {
 }
 
 const TRANSLATION_PATH_CREATE = "pages.account.team.collections.create";
+const TRANSLATION_PATH_ERROR = "error";
 
 const CollectionForm = ({
     teamId,
@@ -64,7 +66,8 @@ const CollectionForm = ({
     collectionId,
     keywordOptions,
 }: CollectionCreateProps) => {
-    const [fileNotUploaded, setFileNotUploaded] = useState(false);
+    const [fileNotUploadedMessage, setFileNotUploadedMessage] =
+        useState<string>();
     const [imageUploaded, setImageUploaded] = useState(false);
     const [searchName, setSearchName] = useState("");
     const [userOptions, setUserOptions] = useState<Option[]>([]);
@@ -469,6 +472,7 @@ const CollectionForm = ({
         editCollection,
         file,
         uploadFile,
+        fileNotUploadedMessage,
     ]);
 
     return (
@@ -515,12 +519,10 @@ const CollectionForm = ({
                                           )
                                 }
                                 error={
-                                    fileNotUploaded
+                                    fileNotUploadedMessage
                                         ? {
                                               type: "",
-                                              message: t(
-                                                  `${TRANSLATION_PATH_CREATE}.aspectRatioError`
-                                              ),
+                                              message: fileNotUploadedMessage,
                                           }
                                         : undefined
                                 }
@@ -530,27 +532,30 @@ const CollectionForm = ({
                                         `${TRANSLATION_PATH_CREATE}.fileSelectButtonText`
                                     )}
                                     acceptedFileTypes=".jpg,.png"
-                                    onBeforeUploadCheck={(
-                                        height: number,
-                                        width: number
-                                    ) => {
-                                        const aspectRatio =
-                                            (width || 0) / (height || 0);
-                                        return (
-                                            aspectRatio <= 2.5 &&
-                                            aspectRatio >= 1.5
-                                        );
-                                    }}
                                     onFileChange={(file: File) => {
-                                        setFileNotUploaded(false);
+                                        setFileNotUploadedMessage(undefined);
                                         setFile(file);
                                     }}
                                     onFileCheckSucceeded={() => {
-                                        setFileNotUploaded(false);
+                                        setFileNotUploadedMessage(undefined);
                                         setImageUploaded(true);
                                     }}
-                                    onFileCheckFailed={() => {
-                                        setFileNotUploaded(true);
+                                    onFileCheckFailed={(
+                                        reason?: ImageValidationError
+                                    ) => {
+                                        const errorMessages = {
+                                            [ImageValidationError.RATIO]: `${TRANSLATION_PATH_ERROR}.imageAspectRatio`,
+                                            [ImageValidationError.SIZE]: `${TRANSLATION_PATH_ERROR}.imageDimensions`,
+                                            default: `${TRANSLATION_PATH_ERROR}.image`,
+                                        };
+
+                                        setFileNotUploadedMessage(
+                                            t(
+                                                errorMessages[
+                                                    reason as ImageValidationError
+                                                ] || errorMessages.default
+                                            )
+                                        );
                                     }}
                                     sx={{ py: 2 }}
                                     showUploadButton={false}

--- a/src/components/UploadFile/UploadFile.tsx
+++ b/src/components/UploadFile/UploadFile.tsx
@@ -246,6 +246,10 @@ const UploadFile = ({
                                 uploadSx={{ display: "none" }}
                                 acceptFileTypes={acceptedFileTypes}
                                 onFileChange={async (file: File) => {
+                                    if (!file) {
+                                        return;
+                                    }
+
                                     if (file.type.startsWith("image/")) {
                                         validateImageDimensions(file)
                                             .then(() => {

--- a/src/components/UploadFile/UploadFile.tsx
+++ b/src/components/UploadFile/UploadFile.tsx
@@ -9,6 +9,8 @@ import usePost from "@/hooks/usePost";
 import notificationService from "@/services/notification";
 import apis from "@/config/apis";
 import { DeleteForeverOutlinedIcon } from "@/consts/icons";
+import { ImageValidationError } from "@/consts/image";
+import { validateImageDimensions } from "@/utils/imageValidation";
 import Button from "../Button";
 import FormInputWrapper from "../FormInputWrapper";
 import Link from "../Link";
@@ -31,8 +33,7 @@ export interface UploadFileProps {
     acceptedFileTypes?: string;
     fileSelectButtonText?: string;
     isUploading?: Dispatch<SetStateAction<boolean>>;
-    onBeforeUploadCheck?: (height: number, width: number) => boolean;
-    onFileCheckFailed?: () => void;
+    onFileCheckFailed?: (reason?: ImageValidationError) => void;
     onFileCheckSucceeded?: (response: FileUpload) => void;
     onFileChange?: (file: File) => void;
     onFileUploaded?: (uploadResponse?: FileUpload) => void;
@@ -59,7 +60,6 @@ const UploadFile = ({
     acceptedFileTypes,
     fileSelectButtonText,
     isUploading,
-    onBeforeUploadCheck,
     onFileCheckFailed,
     onFileCheckSucceeded,
     onFileChange,
@@ -166,39 +166,6 @@ const UploadFile = ({
         // eslint-disable-next-line react-hooks/exhaustive-deps
     }, [fileId, fileScanStatus]);
 
-    const imageValidation = async (file: File) => {
-        try {
-            await new Promise((resolve, reject) => {
-                const reader = new FileReader();
-                reader.readAsDataURL(file);
-                reader.onload = function (e) {
-                    const image = new Image();
-                    image.src = e?.target?.result as string;
-                    image.onload = function () {
-                        if (onBeforeUploadCheck) {
-                            const checked = onBeforeUploadCheck(
-                                image.height,
-                                image.width
-                            );
-                            return checked
-                                ? resolve(null)
-                                : reject(
-                                      new Error(
-                                          "The image does not pass it's checks"
-                                      )
-                                  );
-                        }
-
-                        return resolve(true);
-                    };
-                };
-            });
-            return true;
-        } catch (_) {
-            return false;
-        }
-    };
-
     const onSubmit = async () => {
         if (!file) {
             return;
@@ -278,15 +245,20 @@ const UploadFile = ({
                                 name="upload"
                                 uploadSx={{ display: "none" }}
                                 acceptFileTypes={acceptedFileTypes}
-                                onFileChange={(file: File) => {
+                                onFileChange={async (file: File) => {
                                     if (file.type.startsWith("image/")) {
-                                        imageValidation(file).then(result => {
-                                            setFile(file);
-                                            onFileChange?.(file);
-                                            if (!result) {
-                                                onFileCheckFailed?.();
-                                            }
-                                        });
+                                        validateImageDimensions(file)
+                                            .then(() => {
+                                                setFile(file);
+                                                onFileChange?.(file);
+                                            })
+                                            .catch(
+                                                (
+                                                    reason: ImageValidationError
+                                                ) => {
+                                                    onFileCheckFailed?.(reason);
+                                                }
+                                            );
                                     } else {
                                         setFile(file);
                                         onFileChange?.(file);

--- a/src/config/messages/en.json
+++ b/src/config/messages/en.json
@@ -106,6 +106,11 @@
             }
         }
     },
+    "error": {
+        "image": "An error occured when reading your file.",
+        "imageAspectRatio": "File needs to be of approximately of aspect ratio 2:1 (width:height).",
+        "imageDimensions": "File needs to be at least 600px wide, by 300px high."
+    },
     "common": {
         "companyNameShort": "HDR UK",
         "companyNameLong": "Health Data Research UK",
@@ -305,7 +310,6 @@
                         "title": "Add Team’s details",
                         "text": "Add details of the data publisher team you want to create on the Gateway",
                         "aspectRatioInfo": "Please note the aspect ratio of the image should be approximately 2:1 (width:height)",
-                        "aspectRatioError": "Warning: File should approximately have an aspect ratio of 2:1 (width:height)",
                         "addImageSuccess": "Image Uploaded",
                         "fileSelectButtonText": "Choose logo"
                     },
@@ -616,7 +620,6 @@
                         "addImages": "Collection image cover (recommended)",
                         "addImagesInfo": "Upload an image W700 x H350 (1:0.5). If your image is of a lower resolution a default Gateway Collection image will be displayed on the Collection until a higher resolution image is uploaded.",
                         "addImageSuccess": "Image uploaded",
-                        "aspectRatioError": "File needs to be of approximately of aspect ratio 2:1 (width:height)",
                         "fileSelectButtonText": "Upload file",
                         "addResources": "Add resources",
                         "addResourcesInfo": "Link resources in the Gateway to your Collection",

--- a/src/consts/image.ts
+++ b/src/consts/image.ts
@@ -1,0 +1,4 @@
+export enum ImageValidationError {
+    RATIO = "ratio",
+    SIZE = "size",
+}

--- a/src/utils/imageValidation.test.ts
+++ b/src/utils/imageValidation.test.ts
@@ -1,0 +1,95 @@
+import { ImageValidationError } from "@/consts/image";
+import { validateImageDimensions } from "./imageValidation";
+
+describe("validateImageDimensions", () => {
+    let originalImage: typeof Image;
+    let originalFileReader: typeof FileReader;
+
+    let mockWidth = 0;
+    let mockHeight = 0;
+
+    beforeEach(() => {
+        originalImage = global.Image;
+        originalFileReader = global.FileReader;
+
+        // @ts-expect-error for mocking constructor
+        global.FileReader = function createMockFileReader() {
+            return {
+                readAsDataURL: jest.fn(function mockReadAsDataURL() {
+                    if (typeof this.onload === "function") {
+                        this.onload({
+                            target: { result: "data:image/png;base64,fake" },
+                        } as ProgressEvent<FileReader>);
+                    }
+                }),
+                onload: null,
+            } as unknown as FileReader;
+        };
+
+        // @ts-expect-error for mocking constructor
+        global.Image = function createMockImage(): HTMLImageElement {
+            const mock = {
+                width: 0,
+                height: 0,
+                onload: null as
+                    | ((this: GlobalEventHandlers, ev: Event) => void)
+                    | null,
+                onerror: null as
+                    | ((this: GlobalEventHandlers, ev: Event) => void)
+                    | null,
+                onabort: null as
+                    | ((this: GlobalEventHandlers, ev: UIEvent) => void)
+                    | null,
+                set src(_val: string) {
+                    setTimeout(function triggerImageLoad() {
+                        mock.width = mockWidth;
+                        mock.height = mockHeight;
+                        if (typeof mock.onload === "function") {
+                            mock.onload.call(
+                                mock as unknown as GlobalEventHandlers,
+                                new Event("load")
+                            );
+                        }
+                    }, 0);
+                },
+            };
+
+            return mock as unknown as HTMLImageElement;
+        };
+    });
+
+    afterEach(() => {
+        global.Image = originalImage;
+        global.FileReader = originalFileReader;
+        jest.clearAllMocks();
+    });
+
+    it("returns true for valid image dimensions and ratio", async () => {
+        mockWidth = 800;
+        mockHeight = 400;
+        const file = new File(["dummy"], "test.jpg", { type: "image/jpeg" });
+
+        const result = await validateImageDimensions(file);
+        expect(result).toBe(true);
+    });
+
+    it("returns ImageValidationError.SIZE for small image", async () => {
+        mockWidth = 500;
+        mockHeight = 200;
+        const file = new File(["dummy"], "test.jpg", { type: "image/jpeg" });
+
+        await expect(validateImageDimensions(file)).rejects.toBe(
+            ImageValidationError.SIZE
+        );
+    });
+
+    it("returns ImageValidationError.RATIO for invalid ratio", async () => {
+        mockWidth = 1000;
+        mockHeight = 300;
+        const file = new File(["dummy"], "test.jpg", { type: "image/jpeg" });
+
+        await expect(validateImageDimensions(file)).rejects.toBe(
+            ImageValidationError.RATIO
+        );
+    });
+});

--- a/src/utils/imageValidation.ts
+++ b/src/utils/imageValidation.ts
@@ -1,0 +1,37 @@
+import { ImageValidationError } from "@/consts/image";
+
+export type ImageCheckResult = boolean | ImageValidationError;
+
+export const validateImageDimensions = (
+    file: File,
+    minWidth = 600,
+    minHeight = 300,
+    minRatio = 1.5,
+    maxRatio = 2.5
+): Promise<ImageCheckResult> => {
+    return new Promise((resolve, reject) => {
+        const reader = new FileReader();
+
+        reader.onload = e => {
+            const img = new Image();
+            img.src = e?.target?.result as string;
+
+            img.onload = () => {
+                const { width, height } = img;
+                const ratio = width / height;
+
+                if (width < minWidth || height < minHeight) {
+                    reject(ImageValidationError.SIZE);
+                } else if (ratio < minRatio || ratio > maxRatio) {
+                    reject(ImageValidationError.RATIO);
+                } else {
+                    resolve(true);
+                }
+            };
+
+            img.onerror = () => reject();
+        };
+
+        reader.readAsDataURL(file);
+    });
+};


### PR DESCRIPTION
## Screenshots (if relevant)
![image](https://github.com/user-attachments/assets/ae6469a2-d9b3-4623-8044-238faee2bb4b)
![image](https://github.com/user-attachments/assets/6928e652-d765-4d12-bc8d-fc74622783b6)

## Describe your changes
Moves image validation logic to a util, add check for image dimensions. Customise error message depending on image error found

## Issue ticket link
https://hdruk.atlassian.net/browse/GAT-6521

## Checklist before requesting a review

-   [x] I have performed a self-review of my code
-   [x] I have added appropriate unit tests
-   [ ] I have created mocks for unit tests (where appropriate)
-   [ ] The interface is responsive (where appropriate)
-   [ ] The interface is at least AA (where appropriate)
