### PR TITLE
feat(GAT-4828): Display keywords to as chips rather than buttons

### DIFF
--- a/src/modules/DatasetQuickViewDialog/DatasetQuickViewDialog.tsx
+++ b/src/modules/DatasetQuickViewDialog/DatasetQuickViewDialog.tsx
@@ -48,7 +48,7 @@ const DatasetQuickViewDialog = ({ result }: DatasetQuickViewDialogProps) => {
                         <EllipsisCharacterLimit
                             key={word}
                             text={word}
-                            isButton
+                            isChip
                             characterLimit={CHARACTER_LIMIT}
                         />
                     ))}


### PR DESCRIPTION
## Screenshots (if relevant)
![image](https://github.com/user-attachments/assets/34aeb0dd-18cf-48e8-a969-bb6910d9bb41)

## Describe your changes
Display keywords to as chips rather than buttons

## Issue ticket link
https://hdruk.atlassian.net/browse/GAT-4828

## Checklist before requesting a review

-   [ ] I have performed a self-review of my code
-   [ ] I have added appropriate unit tests
-   [ ] I have created mocks for unit tests (where appropriate)
-   [ ] The interface is responsive (where appropriate)
-   [ ] The interface is at least AA (where appropriate)
