### PR TITLE
fix(GAT-6760): Populate autocomplete options correctly

### DIFF
--- a/src/app/[locale]/account/team/[teamId]/(withLeftNav)/data-uses/[dataUseId]/components/EditDataUse.tsx
+++ b/src/app/[locale]/account/team/[teamId]/(withLeftNav)/data-uses/[dataUseId]/components/EditDataUse.tsx
@@ -193,15 +193,22 @@ const EditDataUse = () => {
         );
     };
 
-    const [keywordOptions, setKeywordsOptions] = useState<string[]>([]);
-    const [outputOptions, setOutputOptions] = useState<string[]>([]);
+    const [keywordOptions, setKeywordsOptions] = useState<OptionsType[]>([]);
+    const [outputOptions, setOutputOptions] = useState<OptionsType[]>([]);
 
     useEffect(() => {
         if (!keywords) {
             return;
         }
 
-        setKeywordsOptions(keywords.map(keyword => keyword.name));
+        setKeywordsOptions(
+            keywords.map(data => {
+                return {
+                    label: data.name,
+                    value: data.name,
+                };
+            }) as OptionsType[]
+        );
     }, [keywords]);
 
     const existingResearchLinks = existingDataUse?.non_gateway_outputs;
@@ -211,7 +218,14 @@ const EditDataUse = () => {
             return;
         }
 
-        setOutputOptions(existingResearchLinks);
+        setOutputOptions(
+            existingResearchLinks.map(data => {
+                return {
+                    label: data,
+                    value: data,
+                };
+            }) as OptionsType[]
+        );
     }, [existingResearchLinks]);
 
     useEffect(() => {


### PR DESCRIPTION
## Screenshots (if relevant)
![image](https://github.com/user-attachments/assets/04c7e8e6-67c4-448f-8138-5b359f685efc)

## Describe your changes
Populate autocomplete options correctly

## Issue ticket link
https://hdruk.atlassian.net/browse/GAT-6688

## Checklist before requesting a review

-   [ ] I have performed a self-review of my code
-   [ ] I have added appropriate unit tests
-   [ ] I have created mocks for unit tests (where appropriate)
-   [ ] The interface is responsive (where appropriate)
-   [ ] The interface is at least AA (where appropriate)
