### PR TITLE
fix(GAT-5970): html entities in collection names

### DIFF
--- a/src/app/[locale]/(logged-out)/collection/[collectionId]/page.test.tsx
+++ b/src/app/[locale]/(logged-out)/collection/[collectionId]/page.test.tsx
@@ -92,7 +92,7 @@ describe("CollectionItemPage", () => {
             await setup({ collectionId: "123" });
 
             expect(
-                await screen.getByText(data.name, { selector: "h1" })
+                await screen.getByText(data.name, { selector: "h1 > div" })
             ).toBeInTheDocument();
             expect(await screen.findByText("Description")).toBeInTheDocument();
         }

--- a/src/app/[locale]/(logged-out)/collection/[collectionId]/page.tsx
+++ b/src/app/[locale]/(logged-out)/collection/[collectionId]/page.tsx
@@ -3,6 +3,7 @@ import { cookies } from "next/headers";
 import { notFound } from "next/navigation";
 import Box from "@/components/Box";
 import DataUsesContent from "@/components/DataUsesContent";
+import HTMLContent from "@/components/HTMLContent";
 import LayoutDataItemPage from "@/components/LayoutDataItemPage";
 import { MarkDownSanitizedWithHtml } from "@/components/MarkDownSanitizedWithHTML";
 import PublicationsContent from "@/components/PublicationsContent";
@@ -69,7 +70,7 @@ export default async function CollectionItemPage({
                             src={image_link || StaticImages.BASE.placeholder}
                         />
                         <Typography variant="h1" sx={{ ml: 2 }}>
-                            {name}
+                            <HTMLContent content={name} />
                         </Typography>
                     </Box>
 

--- a/src/app/[locale]/(logged-out)/search/components/ResultCardCollection/ResultCardCollection.test.tsx
+++ b/src/app/[locale]/(logged-out)/search/components/ResultCardCollection/ResultCardCollection.test.tsx
@@ -8,7 +8,7 @@ describe("ResultCardCollection", () => {
 
         render(<ResultCardCollection result={mockResult} />);
 
-        expect(screen.getByRole("heading", { level: 3 })).toHaveTextContent(
+        expect(screen.getByRole("heading", { level: 3 }).textContent).toEqual(
             mockResult.name
         );
     });

--- a/src/components/CardStacked/CardStacked.tsx
+++ b/src/components/CardStacked/CardStacked.tsx
@@ -4,6 +4,7 @@ import BoxStacked from "@/components/BoxStacked";
 import { BoxStackedProps } from "@/components/BoxStacked/BoxStacked";
 import Chip, { ChipProps } from "@/components/Chip";
 import { colors } from "@/config/theme";
+import HTMLContent from "../HTMLContent";
 
 export interface CardStackedProps {
     href: string;
@@ -43,7 +44,7 @@ export default function CardStacked({
                     role="heading"
                     aria-level={3}
                     size="small"
-                    label={title}
+                    label={<HTMLContent content={title} />}
                     sx={{
                         backgroundColor: colors.grey600,
                         color: colors.white,

--- a/src/components/FilterSection/FilterSection.tsx
+++ b/src/components/FilterSection/FilterSection.tsx
@@ -18,6 +18,7 @@ import TextField from "@/components/TextField";
 import Typography from "@/components/Typography";
 import { SearchIcon } from "@/consts/icons";
 import ClearFilterButton from "@/app/[locale]/(logged-out)/search/components/ClearFilterButton";
+import HTMLContent from "../HTMLContent";
 
 interface FilterSectionProps<TFieldValues extends FieldValues, TName> {
     filterItem: { label: string; value: string; buckets: BucketCheckbox[] };
@@ -92,10 +93,12 @@ const FilterSection = <
         key: string;
         style: CSSProperties;
     }) => {
-        const formattedRow = cloneDeep(checkboxes[index]);
+        const { label, ...formattedRow } = cloneDeep(checkboxes[index]);
+
         return (
             <div key={key} style={style}>
                 <CheckboxControlled
+                    label={<HTMLContent content={label} />}
                     {...formattedRow}
                     formControlSx={{ pl: 1, pr: 1 }}
                     checked={


### PR DESCRIPTION
## Screenshots (if relevant)
<img width="1015" alt="Screenshot 2025-05-02 at 10 45 17" src="https://github.com/user-attachments/assets/2c088142-cf51-4387-b4fe-35c216902d0b" />


## Describe your changes
HTML encoding in collection titles

## Issue ticket link
https://hdruk.atlassian.net/browse/GAT-5970

## Checklist before requesting a review

-   [x] I have performed a self-review of my code
-   [ ] I have added appropriate unit tests
-   [ ] I have created mocks for unit tests (where appropriate)
-   [ ] The interface is responsive (where appropriate)
-   [ ] The interface is at least AA (where appropriate)
