### PR TITLE
feat(GAT-4070): Add Data Custodian filter to Tools search

### DIFF
--- a/src/app/[locale]/(logged-out)/search/components/FilterPanel/FilterPanel.tsx
+++ b/src/app/[locale]/(logged-out)/search/components/FilterPanel/FilterPanel.tsx
@@ -40,6 +40,7 @@ import {
     FILTER_DATA_CUSTODIAN_NETWORK,
     FILTER_FORMAT_STANDARDS,
     FILTER_COHORT_DISCOVERY,
+    FILTER_DATA_PROVIDER,
 } from "@/config/forms/filters";
 import { SOURCE_GAT } from "@/config/forms/search";
 import { INCLUDE_UNREPORTED } from "@/consts/filters";
@@ -107,6 +108,7 @@ const FILTER_ORDERING: { [key: string]: Array<string> } = {
     ],
     tool: [
         FILTER_TYPE_CATEGORY,
+        FILTER_DATA_PROVIDER,
         FILTER_DATA_SET_TITLES,
         FILTER_PROGRAMMING_LANGUAGE,
         FILTER_LICENSE,

--- a/src/config/forms/team.tsx
+++ b/src/config/forms/team.tsx
@@ -58,7 +58,7 @@ const formFields = [
     {
         label: "Organisation name",
         name: "name",
-        info: "Please ensure the name matches the standard format for organsitation names",
+        info: "Please ensure the name matches the standard format for organisation names",
         component: inputComponents.TextArea,
         required: true,
     },

--- a/src/config/messages/en.json
+++ b/src/config/messages/en.json
@@ -1030,6 +1030,8 @@
                             "programmingLanguagesTooltip": "Programming language used in developing an analysis script or software",
                             "typeCategory": "Tool type",
                             "typeCategoryTooltip": "Categorisation based on where in the research journey an Analysis Script & Software is used",
+                            "dataProvider": "Data Custodian",
+                            "dataProviderTooltip": "Individual or organisation providing metadata on the Gateway",
                             "datasetTitles": "Dataset",
                             "datasetTitlesTooltip": "The name of the dataset(s) being accessed"
                         }


### PR DESCRIPTION
## Screenshots (if relevant)
![image](https://github.com/user-attachments/assets/b29b7fe0-6efb-4ee5-bea3-f39e6732932c)


## Describe your changes
Add Data Provider filter to Tools search

## Issue ticket link
https://hdruk.atlassian.net/browse/GAT-4070

## Checklist before requesting a review

-   [ ] I have performed a self-review of my code
-   [ ] I have added appropriate unit tests
-   [ ] I have created mocks for unit tests (where appropriate)
-   [ ] The interface is responsive (where appropriate)
-   [ ] The interface is at least AA (where appropriate)
