### PR TITLE
fix(GAT-7112): Allow user through to Cohort Discovery T & Cs when previous request has expired

### DIFF
--- a/src/app/[locale]/(logged-out)/about/cohort-discovery/components/CtaOverride/CtaOverride.tsx
+++ b/src/app/[locale]/(logged-out)/about/cohort-discovery/components/CtaOverride/CtaOverride.tsx
@@ -57,7 +57,9 @@ const CtaOverride = ({ ctaLink }: { ctaLink: CtaLink }) => {
 
     const isDisabled =
         isLoggedIn && userData
-            ? !["APPROVED", "REJECTED", "EXPIRED"].includes(userData.request_status)
+            ? !["APPROVED", "REJECTED", "EXPIRED"].includes(
+                  userData.request_status
+              )
             : false;
 
     return (

--- a/src/app/[locale]/(logged-out)/about/cohort-discovery/components/CtaOverride/CtaOverride.tsx
+++ b/src/app/[locale]/(logged-out)/about/cohort-discovery/components/CtaOverride/CtaOverride.tsx
@@ -57,7 +57,7 @@ const CtaOverride = ({ ctaLink }: { ctaLink: CtaLink }) => {
 
     const isDisabled =
         isLoggedIn && userData
-            ? !["APPROVED", "REJECTED"].includes(userData.request_status)
+            ? !["APPROVED", "REJECTED", "EXPIRED"].includes(userData.request_status)
             : false;
 
     return (


### PR DESCRIPTION
## Screenshots (if relevant)
Request a Cohort Discovery access for a user

https://github.com/user-attachments/assets/2930d5e1-7b8e-417e-a983-39da5d708669

Admin grants approval and user can access Rquest (which is not set up locally, hence the broken link)

https://github.com/user-attachments/assets/b81f6468-f6d1-4acd-94c2-46d5a108ec00

I then expire the user's access through the expiry command that runs nightly (not shown).

Expired user can now access T&Cs page, request access again, and be approved by admin

https://github.com/user-attachments/assets/d8a1f6f5-e330-4ac6-9ba1-90bf0c1da46a


## Describe your changes
Paired with https://github.com/HDRUK/gateway-api/pull/1227, this allows previously expired cohort discovery users to go through the process of requesting a renewal.

## Issue ticket link
https://hdruk.atlassian.net/browse/GAT-7112

## Checklist before requesting a review

-   [ ] I have performed a self-review of my code
-   [ ] I have added appropriate unit tests
-   [ ] I have created mocks for unit tests (where appropriate)
-   [ ] The interface is responsive (where appropriate)
-   [ ] The interface is at least AA (where appropriate)
