### PR TITLE
feat(GAT-5790): Add Cohort Discovery button to Datasets list and table views

### DIFF
--- a/src/app/[locale]/(logged-out)/about/cohort-discovery/components/CohortDiscoveryButton/CohortDiscoveryButton.tsx
+++ b/src/app/[locale]/(logged-out)/about/cohort-discovery/components/CohortDiscoveryButton/CohortDiscoveryButton.tsx
@@ -1,0 +1,87 @@
+import { useEffect, useState } from "react";
+import { useTranslations } from "next-intl";
+import { useRouter } from "next/navigation";
+import { CtaLink } from "@/interfaces/Cms";
+import { CohortRequest } from "@/interfaces/CohortRequest";
+import Button from "@/components/Button";
+import Tooltip from "@/components/Tooltip";
+import ProvidersDialog from "@/modules/ProvidersDialog";
+import useAuth from "@/hooks/useAuth";
+import useDialog from "@/hooks/useDialog";
+import useGet from "@/hooks/useGet";
+import apis from "@/config/apis";
+
+interface accessRequestType {
+    redirect_url: string;
+}
+
+interface CohortDiscoveryButtonProps {
+    ctaLink: CtaLink;
+    color?: string | null;
+}
+
+export const DATA_TEST_ID = "cohort-discovery-button";
+
+const TRANSLATION_PATH_CTAOVERRIDE = "components.CohortDiscoveryButton";
+
+const CohortDiscoveryButton = ({
+    ctaLink,
+    color = undefined,
+    ...restProps
+}: CohortDiscoveryButtonProps) => {
+    const { showDialog } = useDialog();
+    const { push } = useRouter();
+    const { isLoggedIn, user } = useAuth();
+    const [isClicked, setIsClicked] = useState(false);
+    const t = useTranslations(TRANSLATION_PATH_CTAOVERRIDE);
+
+    const { data: userData } = useGet<CohortRequest>(
+        `${apis.cohortRequestsV1Url}/user/${user?.id}`,
+        {
+            shouldFetch: !!user?.id,
+        }
+    );
+
+    const { data: accessData } = useGet<accessRequestType>(
+        `${apis.cohortRequestsV1Url}/access`,
+        {
+            shouldFetch: isClicked && userData?.request_status === "APPROVED",
+        }
+    );
+
+    useEffect(() => {
+        if (isClicked) {
+            if (accessData?.redirect_url) {
+                push(accessData?.redirect_url);
+            } else if (isLoggedIn) {
+                push(ctaLink.url);
+            } else {
+                showDialog(ProvidersDialog, { isProvidersDialog: true });
+            }
+        }
+    }, [accessData, isClicked, isLoggedIn]);
+
+    const isDisabled =
+        isLoggedIn && userData
+            ? !["APPROVED", "REJECTED", "EXPIRED"].includes(
+                  userData.request_status
+              )
+            : false;
+
+    return (
+        <Tooltip title={isDisabled ? t(`notApproved`) : ""}>
+            <span>
+                <Button
+                    onClick={() => setIsClicked(true)}
+                    data-testid={DATA_TEST_ID}
+                    color={color}
+                    disabled={isDisabled}
+                    {...restProps}>
+                    {ctaLink?.title}
+                </Button>
+            </span>
+        </Tooltip>
+    );
+};
+
+export default CohortDiscoveryButton;

--- a/src/app/[locale]/(logged-out)/about/cohort-discovery/components/CohortDiscoveryButton/CohortDiscoveryButton.tsx
+++ b/src/app/[locale]/(logged-out)/about/cohort-discovery/components/CohortDiscoveryButton/CohortDiscoveryButton.tsx
@@ -1,7 +1,7 @@
 import { useEffect, useState } from "react";
+import { Tooltip } from "@mui/material";
 import { useTranslations } from "next-intl";
 import { useRouter } from "next/navigation";
-import { Tooltip } from "@mui/material";
 import { CtaLink } from "@/interfaces/Cms";
 import { CohortRequest } from "@/interfaces/CohortRequest";
 import Button from "@/components/Button";

--- a/src/app/[locale]/(logged-out)/about/cohort-discovery/components/CohortDiscoveryButton/CohortDiscoveryButton.tsx
+++ b/src/app/[locale]/(logged-out)/about/cohort-discovery/components/CohortDiscoveryButton/CohortDiscoveryButton.tsx
@@ -1,10 +1,10 @@
 import { useEffect, useState } from "react";
 import { useTranslations } from "next-intl";
 import { useRouter } from "next/navigation";
+import { Tooltip } from "@mui/material";
 import { CtaLink } from "@/interfaces/Cms";
 import { CohortRequest } from "@/interfaces/CohortRequest";
 import Button from "@/components/Button";
-import Tooltip from "@/components/Tooltip";
 import ProvidersDialog from "@/modules/ProvidersDialog";
 import useAuth from "@/hooks/useAuth";
 import useDialog from "@/hooks/useDialog";

--- a/src/app/[locale]/(logged-out)/about/cohort-discovery/components/CohortDiscoveryButton/index.tsx
+++ b/src/app/[locale]/(logged-out)/about/cohort-discovery/components/CohortDiscoveryButton/index.tsx
@@ -1,0 +1,3 @@
+import CohortDiscoveryButton from "./CohortDiscoveryButton";
+
+export default CohortDiscoveryButton;

--- a/src/app/[locale]/(logged-out)/about/cohort-discovery/components/CtaOverride/CtaOverride.test.tsx
+++ b/src/app/[locale]/(logged-out)/about/cohort-discovery/components/CtaOverride/CtaOverride.test.tsx
@@ -1,5 +1,5 @@
 import { render, screen } from "@/utils/testUtils";
-import CtaOverride, { DATA_TEST_ID } from "./CtaOverride";
+import CtaOverride from "./CtaOverride";
 
 const MOCK_CTA_LINK = {
     target: "_blank",
@@ -15,7 +15,7 @@ jest.mock("@/hooks/useAuth", () => ({
 describe("CtaOverride", () => {
     it("should display cta link title text", () => {
         render(<CtaOverride ctaLink={MOCK_CTA_LINK} />);
-        expect(screen.getByTestId(DATA_TEST_ID)).toBeInTheDocument();
+        expect(screen.getByTestId("cohort-discovery-button")).toBeInTheDocument();
     });
 
     // it("should navigate to cta url if logged in", async () => {

--- a/src/app/[locale]/(logged-out)/about/cohort-discovery/components/CtaOverride/CtaOverride.test.tsx
+++ b/src/app/[locale]/(logged-out)/about/cohort-discovery/components/CtaOverride/CtaOverride.test.tsx
@@ -15,7 +15,9 @@ jest.mock("@/hooks/useAuth", () => ({
 describe("CtaOverride", () => {
     it("should display cta link title text", () => {
         render(<CtaOverride ctaLink={MOCK_CTA_LINK} />);
-        expect(screen.getByTestId("cohort-discovery-button")).toBeInTheDocument();
+        expect(
+            screen.getByTestId("cohort-discovery-button")
+        ).toBeInTheDocument();
     });
 
     // it("should navigate to cta url if logged in", async () => {

--- a/src/app/[locale]/(logged-out)/about/cohort-discovery/components/CtaOverride/CtaOverride.tsx
+++ b/src/app/[locale]/(logged-out)/about/cohort-discovery/components/CtaOverride/CtaOverride.tsx
@@ -1,80 +1,17 @@
 "use client";
 
-import { useEffect, useState } from "react";
-import { Box, Tooltip } from "@mui/material";
-import { useTranslations } from "next-intl";
-import { useRouter } from "next/navigation";
+import { Box } from "@mui/material";
 import { CtaLink } from "@/interfaces/Cms";
-import { CohortRequest } from "@/interfaces/CohortRequest";
-import Button from "@/components/Button";
-import ProvidersDialog from "@/modules/ProvidersDialog";
-import useAuth from "@/hooks/useAuth";
-import useDialog from "@/hooks/useDialog";
-import useGet from "@/hooks/useGet";
-import apis from "@/config/apis";
-
-export const DATA_TEST_ID = "cta-override-button";
-
-interface accessRequestType {
-    redirect_url: string;
-}
-
-const TRANSLATION_PATH_CTAOVERRIDE = "components.CtaOverride";
+import CohortDiscoveryButton from "../CohortDiscoveryButton";
 
 const CtaOverride = ({ ctaLink }: { ctaLink: CtaLink }) => {
-    const { showDialog } = useDialog();
-    const { push } = useRouter();
-    const { isLoggedIn, user } = useAuth();
-    const [isClicked, setIsClicked] = useState(false);
-    const t = useTranslations(TRANSLATION_PATH_CTAOVERRIDE);
-
-    const { data: userData } = useGet<CohortRequest>(
-        `${apis.cohortRequestsV1Url}/user/${user?.id}`,
-        {
-            shouldFetch: !!user?.id,
-        }
-    );
-
-    const { data: accessData } = useGet<accessRequestType>(
-        `${apis.cohortRequestsV1Url}/access`,
-        {
-            shouldFetch: isClicked && userData?.request_status === "APPROVED",
-        }
-    );
-
-    useEffect(() => {
-        if (isClicked) {
-            if (accessData?.redirect_url) {
-                push(accessData?.redirect_url);
-            } else if (isLoggedIn) {
-                push(ctaLink.url);
-            } else {
-                showDialog(ProvidersDialog, { isProvidersDialog: true });
-            }
-        }
-    }, [accessData, isClicked, isLoggedIn]);
-
-    const isDisabled =
-        isLoggedIn && userData
-            ? !["APPROVED", "REJECTED", "EXPIRED"].includes(
-                  userData.request_status
-              )
-            : false;
-
     return (
         <Box sx={{ display: "flex" }}>
-            <Tooltip title={isDisabled ? t(`notApproved`) : ""}>
-                <span>
-                    <Button
-                        sx={{ mt: 3 }}
-                        onClick={() => setIsClicked(true)}
-                        data-testid={DATA_TEST_ID}
-                        color="greyCustom"
-                        disabled={isDisabled}>
-                        {ctaLink?.title}
-                    </Button>
-                </span>
-            </Tooltip>
+            <CohortDiscoveryButton
+                ctaLink={ctaLink}
+                color="greyCustom"
+                sx={{ mt: 3 }}
+            />
         </Box>
     );
 };

--- a/src/app/[locale]/(logged-out)/about/cohort-discovery/page.tsx
+++ b/src/app/[locale]/(logged-out)/about/cohort-discovery/page.tsx
@@ -9,7 +9,7 @@ export const metadata = metaData({
     description: "",
 });
 
-export default async function CohortDiscoryPage() {
+export default async function CohortDiscoveryPage() {
     const cohortDiscovery = await getCohortDiscovery();
 
     return (

--- a/src/app/[locale]/(logged-out)/search/components/ActionDropdown/ActionDropdown.tsx
+++ b/src/app/[locale]/(logged-out)/search/components/ActionDropdown/ActionDropdown.tsx
@@ -6,6 +6,7 @@ import { get } from "lodash";
 import { useTranslations } from "next-intl";
 import { usePathname, useSearchParams } from "next/navigation";
 import { KeyedMutator } from "swr";
+import { PageTemplatePromo } from "@/interfaces/Cms";
 import { Library } from "@/interfaces/Library";
 import { SearchResultDataset } from "@/interfaces/Search";
 import MenuDropdown from "@/components/MenuDropdown";
@@ -19,25 +20,31 @@ import useGeneralEnquiry from "@/hooks/useGeneralEnquiry";
 import usePostLoginActionCookie from "@/hooks/usePostLoginAction";
 import apis from "@/config/apis";
 import { colors } from "@/config/theme";
-import { SpeechBubbleIcon } from "@/consts/customIcons";
+import { CohortIcon, SpeechBubbleIcon } from "@/consts/customIcons";
 import { PostLoginActions } from "@/consts/postLoginActions";
 import { RouteName } from "@/consts/routeName";
 import { COMPONENTS, PAGES, SEARCH } from "@/consts/translation";
+import CohortDiscoveryButton from "../../../about/cohort-discovery/components/CohortDiscoveryButton";
 
 interface ResultRowProps {
     result: SearchResultDataset;
-    libraryData: Library[];
+    libraryData?: Library[];
     showLibraryModal: (props: { datasetId: number }) => void;
     mutateLibraries: KeyedMutator<Library[]>;
+    isCohortDiscoveryDisabled: boolean;
+    cohortDiscovery: PageTemplatePromo;
 }
 
 const TRANSLATION_PATH = `${PAGES}.${SEARCH}.${COMPONENTS}.ResultCard`;
+const COHORT_DISCOVERY_PATH = "isCohortDiscovery";
 
 const ActionDropdown = ({
     result,
     libraryData,
     showLibraryModal,
     mutateLibraries,
+    isCohortDiscoveryDisabled,
+    cohortDiscovery,
 }: ResultRowProps) => {
     const title = get(result, "metadata.summary.title");
     const t = useTranslations(TRANSLATION_PATH);
@@ -104,6 +111,8 @@ const ActionDropdown = ({
         });
     };
 
+    const isCohortDiscovery = get(result, COHORT_DISCOVERY_PATH);
+
     const menuItems = [
         {
             label: "General enquiry",
@@ -120,6 +129,31 @@ const ActionDropdown = ({
             action: handleStartDarRequest,
             icon: <SpeechBubbleIcon color="primary" sx={{ mr: 1 }} />,
         },
+        ...(isCohortDiscovery
+            ? [
+                  {
+                      label: "Start a Cohort Discovery query",
+                      button: (
+                          <CohortDiscoveryButton
+                              ctaLink={
+                                  cohortDiscovery.template.promofields.ctaLink
+                              }
+                              variant="link"
+                          />
+                      ),
+                      icon: (
+                          <CohortIcon
+                              color={
+                                  !isCohortDiscoveryDisabled
+                                      ? "primary"
+                                      : "greyCustom"
+                              }
+                              sx={{ mr: 1 }}
+                          />
+                      ),
+                  },
+              ]
+            : []),
     ];
 
     const [isLibraryToggled, setLibraryToggle] = useState(false);

--- a/src/app/[locale]/(logged-out)/search/components/ResultCard/ResultCard.tsx
+++ b/src/app/[locale]/(logged-out)/search/components/ResultCard/ResultCard.tsx
@@ -6,6 +6,7 @@ import uniqueId from "lodash/uniqueId";
 import { useTranslations } from "next-intl";
 import { usePathname, useSearchParams } from "next/navigation";
 import { KeyedMutator } from "swr";
+import { PageTemplatePromo } from "@/interfaces/Cms";
 import { Library, NewLibrary } from "@/interfaces/Library";
 import { SearchResultDataset } from "@/interfaces/Search";
 import Box from "@/components/Box";
@@ -23,24 +24,30 @@ import useFeasibilityEnquiry from "@/hooks/useFeasibilityEnquiry";
 import useGeneralEnquiry from "@/hooks/useGeneralEnquiry";
 import usePost from "@/hooks/usePost";
 import apis from "@/config/apis";
-import { SpeechBubbleIcon } from "@/consts/customIcons";
+import { CohortIcon, SpeechBubbleIcon } from "@/consts/customIcons";
 import { ChevronThinIcon } from "@/consts/icons";
 import { RouteName } from "@/consts/routeName";
 import { getDateRange, getPopulationSize } from "@/utils/search";
+import CohortDiscoveryButton from "../../../about/cohort-discovery/components/CohortDiscoveryButton";
 import { Highlight, ResultTitle } from "./ResultCard.styles";
 
 interface ResultCardProps {
     result: SearchResultDataset;
     libraryData: Library[];
     mutateLibraries: KeyedMutator<Library[]>;
+    isCohortDiscoveryDisabled: boolean;
+    cohortDiscovery: PageTemplatePromo;
 }
 
 const TRANSLATION_PATH = "pages.search.components.ResultCard";
+const COHORT_DISCOVERY_PATH = "isCohortDiscovery";
 
 const ResultCard = ({
     result,
     libraryData,
     mutateLibraries,
+    isCohortDiscoveryDisabled,
+    cohortDiscovery,
 }: ResultCardProps) => {
     const t = useTranslations(TRANSLATION_PATH);
     const { current: resultId } = useRef(uniqueId("result-title-"));
@@ -130,6 +137,8 @@ const ResultCard = ({
         });
     };
 
+    const isCohortDiscovery = get(result, COHORT_DISCOVERY_PATH);
+
     const menuItems = [
         {
             label: "General enquiry",
@@ -143,6 +152,31 @@ const ResultCard = ({
             label: "Start a Data Access Request",
             action: handleStartDarRequest,
         },
+        ...(isCohortDiscovery
+            ? [
+                  {
+                      label: "Start a Cohort Discovery query",
+                      button: (
+                          <CohortDiscoveryButton
+                              ctaLink={
+                                  cohortDiscovery.template.promofields.ctaLink
+                              }
+                              variant="link"
+                          />
+                      ),
+                      icon: (
+                          <CohortIcon
+                              color={
+                                  !isCohortDiscoveryDisabled
+                                      ? "primary"
+                                      : "greyCustom"
+                              }
+                              sx={{ mr: 1 }}
+                          />
+                      ),
+                  },
+              ]
+            : []),
     ];
 
     const handleToggleLibraryItem = async (

--- a/src/app/[locale]/(logged-out)/search/components/ResultsTable/ResultsTable.tsx
+++ b/src/app/[locale]/(logged-out)/search/components/ResultsTable/ResultsTable.tsx
@@ -2,6 +2,8 @@ import { createColumnHelper } from "@tanstack/react-table";
 import { get } from "lodash";
 import { useTranslations } from "next-intl";
 import { KeyedMutator } from "swr";
+import { PageTemplatePromo } from "@/interfaces/Cms";
+import { CohortRequest } from "@/interfaces/CohortRequest";
 import { Library } from "@/interfaces/Library";
 import { SearchResultDataset } from "@/interfaces/Search";
 import EllipsisLineLimit from "@/components/EllipsisLineLimit";
@@ -21,6 +23,7 @@ import ActionDropdown from "../ActionDropdown";
 interface ResultTableProps {
     results: SearchResultDataset[];
     showLibraryModal: (props: { datasetId: number }) => void;
+    cohortDiscovery: PageTemplatePromo;
 }
 
 const CONFORMS_TO_PATH = "metadata.accessibility.formatAndStandards.conformsTo";
@@ -39,11 +42,15 @@ const getColumns = ({
     libraryData,
     showLibraryModal,
     mutateLibraries,
+    isCohortDiscoveryDisabled,
+    cohortDiscovery,
 }: {
     translations: { [id: string]: string };
-    libraryData: Library[];
+    libraryData?: Library[];
     showLibraryModal: (props: { datasetId: number }) => void;
     mutateLibraries: KeyedMutator<Library[]>;
+    isCohortDiscoveryDisabled: boolean;
+    cohortDiscovery: PageTemplatePromo;
 }) => [
     columnHelper.display({
         id: "actions",
@@ -56,6 +63,8 @@ const getColumns = ({
                         libraryData={libraryData}
                         showLibraryModal={showLibraryModal}
                         mutateLibraries={mutateLibraries}
+                        isCohortDiscoveryDisabled={isCohortDiscoveryDisabled}
+                        cohortDiscovery={cohortDiscovery}
                     />
                 </div>
             );
@@ -262,14 +271,32 @@ const getColumns = ({
 ];
 
 const RESULTS_TABLE_TRANSLATION_PATH = "pages.search.components.ResultsTable";
-const ResultTable = ({ results, showLibraryModal }: ResultTableProps) => {
+const ResultTable = ({
+    results,
+    showLibraryModal,
+    cohortDiscovery,
+}: ResultTableProps) => {
     const t = useTranslations(RESULTS_TABLE_TRANSLATION_PATH);
-    const { isLoggedIn } = useAuth();
+    const { isLoggedIn, user } = useAuth();
 
     const { data: libraryData, mutate: mutateLibraries } = useGet<Library[]>(
         `${apis.librariesV1Url}?perPage=-1`,
         { shouldFetch: isLoggedIn }
     );
+
+    const { data: userData } = useGet<CohortRequest>(
+        `${apis.cohortRequestsV1Url}/user/${user?.id}`,
+        {
+            shouldFetch: !!user?.id,
+        }
+    );
+
+    const isCohortDiscoveryDisabled =
+        isLoggedIn && userData
+            ? !["APPROVED", "REJECTED", "EXPIRED"].includes(
+                  userData.request_status
+              )
+            : false;
 
     const translations = {
         actionLabel: t("action.label"),
@@ -309,6 +336,8 @@ const ResultTable = ({ results, showLibraryModal }: ResultTableProps) => {
                     libraryData,
                     showLibraryModal,
                     mutateLibraries,
+                    isCohortDiscoveryDisabled,
+                    cohortDiscovery,
                 })}
                 rows={results}
             />

--- a/src/app/[locale]/(logged-out)/search/components/Search/Search.tsx
+++ b/src/app/[locale]/(logged-out)/search/components/Search/Search.tsx
@@ -119,6 +119,7 @@ import ResultsTable from "../ResultsTable";
 import Sort from "../Sort";
 import TabTooltip from "../TabTooltip";
 import { ActionBar, ResultLimitText } from "./Search.styles";
+import { PageTemplatePromo } from "@/interfaces/Cms";
 
 const TRANSLATION_PATH = "pages.search";
 const STATIC_FILTER_SOURCE = "source";
@@ -127,9 +128,10 @@ const EUROPE_PMC_SOURCE_FIELD = "FED";
 
 interface SearchProps {
     filters: Filter[];
+    cohortDiscovery: PageTemplatePromo;
 }
 
-const Search = ({ filters }: SearchProps) => {
+const Search = ({ filters, cohortDiscovery }: SearchProps) => {
     const { showDialog, hideDialog } = useDialog();
     const [isDownloading, setIsDownloading] = useState(false);
     const router = useRouter();
@@ -569,6 +571,7 @@ const Search = ({ filters }: SearchProps) => {
                 <ResultsTable
                     results={data?.list as SearchResultDataset[]}
                     showLibraryModal={showLibraryModal}
+                    cohortDiscovery={cohortDiscovery}
                 />
             );
         }

--- a/src/app/[locale]/(logged-out)/search/page.tsx
+++ b/src/app/[locale]/(logged-out)/search/page.tsx
@@ -1,6 +1,7 @@
 import { cookies } from "next/headers";
 import { Filter } from "@/interfaces/Filter";
 import { getFilters } from "@/utils/api";
+import { getCohortDiscovery } from "@/utils/cms";
 import metaData, { noFollowRobots } from "@/utils/metadata";
 import Search from "./components/Search";
 
@@ -15,7 +16,9 @@ export const metadata = metaData(
 const SearchPage = async () => {
     const cookieStore = cookies();
     const filters: Filter[] = await getFilters(cookieStore);
-    return <Search filters={filters} />;
+    const cohortDiscovery = await getCohortDiscovery();
+
+    return <Search filters={filters} cohortDiscovery={cohortDiscovery} />;
 };
 
 export default SearchPage;

--- a/src/config/messages/en.json
+++ b/src/config/messages/en.json
@@ -1429,7 +1429,7 @@
             "tooltip-3": "Satisfied",
             "tooltip-4": "Very Satisfied"
         },
-        "CtaOverride": {
+        "CohortDiscoveryButton": {
             "notApproved": "Your request to access Cohort Discovery is still pending, keep an eye out for an email with next steps, or contact support via the ‘Need Support’ button on the bottom right of this screen."
         },
         "CMSBanner": {


### PR DESCRIPTION
## Screenshots (if relevant)
Non-logged in user is asked to log in when clicking button. Button only shows if Coho is supported on that dataset.

https://github.com/user-attachments/assets/6519ba1d-c8d9-44f8-86b8-65752454b727

Logged-in user that is pending: button shows when appropriate but disabled with explanatory tooltip.

https://github.com/user-attachments/assets/5e802eed-b715-4aeb-abfc-0e6bb334b169

Logged-in user that is rejected (or has not made a request): button shows when appropriate and send suser to sign up to T&Cs.

https://github.com/user-attachments/assets/a15817b4-19ec-4f0b-bc52-3380dbda91b5

Logged-in user that is approved: button shows when appropriate, and sends user to Rquest (doesn't work locally of course, hence the errors)

https://github.com/user-attachments/assets/07f5d45d-e1fb-4290-a6be-359efb15a7ad


## Describe your changes
"Access Cohort Discovery" buttons added to Table and List views of Datasets search.
Buttons only display on datasets supporting Cohort Discovery, and respect the logic based on user status - prompt user login if not logged in, then grey out the button if pending or banned, otherwise send registered users to Rquest, or unregistered users to the Cohort signup page.

## Issue ticket link
https://hdruk.atlassian.net/browse/GAT-5790

## Checklist before requesting a review

-   [ ] I have performed a self-review of my code
-   [ ] I have added appropriate unit tests
-   [ ] I have created mocks for unit tests (where appropriate)
-   [ ] The interface is responsive (where appropriate)
-   [ ] The interface is at least AA (where appropriate)
