### PR TITLE
feat(GAT-5791): Add Access Cohort Discovery to Library

### DIFF
--- a/src/app/[locale]/(logged-out)/about/cohort-discovery/components/CohortDiscoveryButton/CohortDiscoveryButton.tsx
+++ b/src/app/[locale]/(logged-out)/about/cohort-discovery/components/CohortDiscoveryButton/CohortDiscoveryButton.tsx
@@ -80,13 +80,12 @@ const CohortDiscoveryButton = ({
     return (
         <Tooltip
             title={
-                tooltipOverride
-                    ? tooltipOverride
-                    : isDisabled
+                tooltipOverride ||
+                (isDisabled
                     ? t(`notApproved`)
                     : showDatasetExplanatoryTooltip && isApproved
                     ? t("explanatoryTooltip")
-                    : ""
+                    : "")
             }>
             <span>
                 <Button

--- a/src/app/[locale]/(logged-out)/about/cohort-discovery/components/CohortDiscoveryButton/CohortDiscoveryButton.tsx
+++ b/src/app/[locale]/(logged-out)/about/cohort-discovery/components/CohortDiscoveryButton/CohortDiscoveryButton.tsx
@@ -19,6 +19,8 @@ interface CohortDiscoveryButtonProps {
     ctaLink: CtaLink;
     showDatasetExplanatoryTooltip: boolean | null;
     color?: string | null;
+    tooltipOverride?: string | null;
+    disabledOuter?: boolean;
 }
 
 export const DATA_TEST_ID = "cohort-discovery-button";
@@ -29,6 +31,8 @@ const CohortDiscoveryButton = ({
     ctaLink,
     showDatasetExplanatoryTooltip = false,
     color = undefined,
+    tooltipOverride = "",
+    disabledOuter = false,
     ...restProps
 }: CohortDiscoveryButtonProps) => {
     const { showDialog } = useDialog();
@@ -76,7 +80,9 @@ const CohortDiscoveryButton = ({
     return (
         <Tooltip
             title={
-                isDisabled
+                tooltipOverride
+                    ? tooltipOverride
+                    : isDisabled
                     ? t(`notApproved`)
                     : showDatasetExplanatoryTooltip && isApproved
                     ? t("explanatoryTooltip")
@@ -87,7 +93,7 @@ const CohortDiscoveryButton = ({
                     onClick={() => setIsClicked(true)}
                     data-testid={DATA_TEST_ID}
                     color={color}
-                    disabled={isDisabled}
+                    disabled={disabledOuter || isDisabled}
                     {...restProps}>
                     {ctaLink?.title}
                 </Button>

--- a/src/app/[locale]/account/profile/library/components/LibraryTable.tsx
+++ b/src/app/[locale]/account/profile/library/components/LibraryTable.tsx
@@ -31,6 +31,7 @@ const LibraryTable = ({
         datasetId: item.dataset_id,
         name: item.dataset_name,
         darEnabled: item.data_provider_dar_enabled,
+        cohortEnabled: item.dataset_is_cohort_discovery,
         dataCustodian: item.data_provider_name,
         entityType: "Dataset", // will we update in the future with other entities?
         dataCustodianId: item.data_provider_id,
@@ -42,6 +43,7 @@ const LibraryTable = ({
         darEnabled: t("darEnabled.label"),
         dataCustodian: t("dataCustodian.label"),
         entityType: t("entityType.label"),
+        cohortEnabled: t("cohortEnabled.label"),
     };
 
     return (

--- a/src/app/[locale]/account/profile/library/components/RightPanel.tsx
+++ b/src/app/[locale]/account/profile/library/components/RightPanel.tsx
@@ -6,6 +6,7 @@ import { Divider, Tooltip } from "@mui/material";
 import { uniq } from "lodash";
 import { useTranslations } from "next-intl";
 import { usePathname } from "next/navigation";
+import { PageTemplatePromo } from "@/interfaces/Cms";
 import { SelectedLibrary } from "@/interfaces/Library";
 import Box from "@/components/Box";
 import Button from "@/components/Button";
@@ -17,15 +18,21 @@ import useDataAccessRequest from "@/hooks/useDataAccessRequest";
 import useSidebar from "@/hooks/useSidebar";
 import theme from "@/config/theme";
 import { QuestionAnswerIcon, DeleteForeverIcon } from "@/consts/icons";
+import CohortDiscoveryButton from "@/app/[locale]/(logged-out)/about/cohort-discovery/components/CohortDiscoveryButton";
 
 const TRANSLATION_PATH = "pages.account.profile.library.components.RightPanel";
 
 interface RightPanelProps {
     selected: SelectedLibrary;
     handleRemove: (id: string) => void;
+    cohortDiscovery: PageTemplatePromo;
 }
 
-const RightPanel = ({ selected, handleRemove }: RightPanelProps) => {
+const RightPanel = ({
+    selected,
+    handleRemove,
+    cohortDiscovery,
+}: RightPanelProps) => {
     const t = useTranslations(TRANSLATION_PATH);
     const { showSidebar } = useSidebar();
     const { createDARApplication } = useDataAccessRequest();
@@ -42,6 +49,7 @@ const RightPanel = ({ selected, handleRemove }: RightPanelProps) => {
                     teamName: item.teamName,
                     teamMemberOf: item.teamMemberOf,
                     darEnabled: item.darEnabled,
+                    cohortEnabled: item.cohortEnabled,
                 };
             });
     }, [selected]);
@@ -167,6 +175,37 @@ const RightPanel = ({ selected, handleRemove }: RightPanelProps) => {
                             </Button>
                         </div>
                     </Tooltip>
+                </Box>
+                <Divider sx={{ my: 2 }} />
+                <Box sx={{ p: 0 }}>
+                    <Typography variant="h2">
+                        {t("cohortDiscovery.title")}
+                    </Typography>
+                    <Typography>{t("cohortDiscovery.text")}</Typography>
+                    <div>
+                        <CohortDiscoveryButton
+                            sx={{ mt: 2, width: "100%" }}
+                            disabledOuter={
+                                !(selectedDatasets.length > 0) ||
+                                !selectedDatasets.every(
+                                    dataset => dataset.cohortEnabled
+                                )
+                            }
+                            ctaLink={
+                                cohortDiscovery?.template?.promofields?.ctaLink
+                            }
+                            showDatasetExplanatoryTooltip
+                            tooltipOverride={
+                                !selectedDatasets.every(
+                                    dataset => dataset.cohortEnabled
+                                )
+                                    ? t("cohortDiscovery.buttonTooltipCohort")
+                                    : selectedDatasets.length > 0
+                                    ? ""
+                                    : t("cohortDiscovery.buttonTooltip")
+                            }
+                        />
+                    </div>
                 </Box>
                 {selectedDatasets.length > 1 && (
                     <>

--- a/src/app/[locale]/account/profile/library/components/UserLibrary.tsx
+++ b/src/app/[locale]/account/profile/library/components/UserLibrary.tsx
@@ -1,6 +1,7 @@
 "use client";
 
 import { useState } from "react";
+import { PageTemplatePromo } from "@/interfaces/Cms";
 import { Library, SelectedLibrary } from "@/interfaces/Library";
 import Box from "@/components/Box";
 import Loading from "@/components/Loading";
@@ -20,7 +21,11 @@ export const metadata = metaData(
     noFollowRobots
 );
 
-const UserLibrary = () => {
+interface UserLibraryProps {
+    cohortDiscovery: PageTemplatePromo;
+}
+
+const UserLibrary = ({ cohortDiscovery }: UserLibraryProps) => {
     const { data, isLoading, mutate } = useGet<Library[]>(apis.librariesV1Url);
     const [selected, setSelected] = useState<SelectedLibrary>({});
 
@@ -64,6 +69,7 @@ const UserLibrary = () => {
                     <RightPanel
                         selected={selected}
                         handleRemove={handleRemove}
+                        cohortDiscovery={cohortDiscovery}
                     />
                 </Box>
             </Box>

--- a/src/app/[locale]/account/profile/library/page.tsx
+++ b/src/app/[locale]/account/profile/library/page.tsx
@@ -1,3 +1,4 @@
+import { getCohortDiscovery } from "@/utils/cms";
 import metaData, { noFollowRobots } from "@/utils/metadata";
 import UserLibrary from "./components/UserLibrary";
 
@@ -8,6 +9,8 @@ export const metadata = metaData(
     },
     noFollowRobots
 );
-export default function LibraryPage() {
-    return <UserLibrary />;
+
+export default async function LibraryPage() {
+    const cohortDiscovery = await getCohortDiscovery();
+    return <UserLibrary cohortDiscovery={cohortDiscovery} />;
 }

--- a/src/app/[locale]/account/profile/library/utils/index.tsx
+++ b/src/app/[locale]/account/profile/library/utils/index.tsx
@@ -32,6 +32,7 @@ const getColumns = ({
                 dataCustodian,
                 dataCustodianMemberOf,
                 darEnabled,
+                cohortEnabled,
             } = row.original;
             return (
                 <div style={{ textAlign: "center" }}>
@@ -47,6 +48,7 @@ const getColumns = ({
                                     teamName: dataCustodian,
                                     teamMemberOf: dataCustodianMemberOf,
                                     darEnabled,
+                                    cohortEnabled,
                                 },
                             })
                         }

--- a/src/app/[locale]/account/profile/library/utils/index.tsx
+++ b/src/app/[locale]/account/profile/library/utils/index.tsx
@@ -100,6 +100,21 @@ const getColumns = ({
     }),
 
     columnHelper.display({
+        id: "cohortEnabled",
+        cell: ({
+            row: {
+                original: { cohortEnabled },
+            },
+        }) => (
+            <div style={{ textAlign: "center" }}>
+                {cohortEnabled ? <CheckIcon color="primary" /> : "-"}
+            </div>
+        ),
+        header: () => <span>{translations.cohortEnabled}</span>,
+        size: 100,
+    }),
+
+    columnHelper.display({
         id: "dataCustodian",
         cell: ({
             row: {

--- a/src/config/messages/en.json
+++ b/src/config/messages/en.json
@@ -391,6 +391,9 @@
                     "name": {
                         "label": "Name"
                     },
+                    "cohortEnabled": {
+                        "label": "Cohort Discovery Enabled"
+                    },
                     "darEnabled": {
                         "label": "Data Access Request Enabled"
                     },

--- a/src/config/messages/en.json
+++ b/src/config/messages/en.json
@@ -383,6 +383,13 @@
                                 "buttonTooltip": "Select at least one dataset to enable",
                                 "buttonTooltipDar": "You have selected dataset(s) from Data Custodian(s) that don't have an associated DAR application template"
                             },
+                            "cohortDiscovery": {
+                                "title": "Cohort Discovery",
+                                "text": "Start a Cohort Discovery request. Not all Datasets on the Gateway have this feature enabled. You will also need to have Cohort Discovery access approved for your account.",
+                                "buttonText": "Start a Cohort Discovery request",
+                                "buttonTooltip": "Select at least one dataset to enable.",
+                                "buttonTooltipCohort": "You have selected dataset(s) that do not support Cohort Discovery."
+                            },
                             "multiDelete": {
                                 "label": "Multi delete"
                             }

--- a/src/interfaces/Library.ts
+++ b/src/interfaces/Library.ts
@@ -9,6 +9,7 @@ interface Library {
     data_provider_dar_enabled: boolean;
     data_provider_name: string;
     data_provider_member_of: string;
+    dataset_is_cohort_discovery: boolean;
 }
 
 interface SelectedLibrary {
@@ -28,6 +29,7 @@ interface LibraryListItem {
     datasetId: number;
     name: string;
     darEnabled: boolean;
+    cohortEnabled: boolean;
     dataCustodian: string;
     entityType: string;
     dataCustodianId: number;

--- a/src/interfaces/Library.ts
+++ b/src/interfaces/Library.ts
@@ -21,6 +21,7 @@ interface SelectedLibrary {
         teamName: string;
         teamMemberOf: string;
         darEnabled: boolean;
+        cohortEnabled: boolean;
     };
 }
 


### PR DESCRIPTION
## Screenshots (if relevant)
Showing button states based upon selected datasets. User is PENDING so cannot click button even when correct datasets are selected.

https://github.com/user-attachments/assets/32112f0b-9031-44a0-a016-ec2d7a745363

User is APPROVED - redirected to rquest when correct datasets are selected.

https://github.com/user-attachments/assets/e4e255a5-f61e-4f69-8a69-be4682385016

User does not yet have access, so is directed to T&Cs once they've selected correct datasets.

https://github.com/user-attachments/assets/18e11294-c9bd-4646-a4f9-911b33f77f73

## Describe your changes
Added a Cohort Discovery button from the Library page. Button is only enabled if (1) supported datasets are selected; AND (2) the user is approved for Cohort Discovery. If they've not applied, they are sent to T&Cs page.

Expanded the arguments the CohortDiscoveryButton component takes in order to smoothly handle the multiple possible tooltips and multiple criteria for button disabling.

## Issue ticket link
https://hdruk.atlassian.net/browse/GAT-5791

## Checklist before requesting a review

-   [ ] I have performed a self-review of my code
-   [ ] I have added appropriate unit tests
-   [ ] I have created mocks for unit tests (where appropriate)
-   [ ] The interface is responsive (where appropriate)
-   [ ] The interface is at least AA (where appropriate)
