### PR TITLE
feat(GAT-4346): Dataset metadata keywords render as actionable buttons

### DIFF
--- a/src/app/[locale]/(logged-out)/dataset/[datasetId]/components/DatasetContent/DatasetContent.styles.ts
+++ b/src/app/[locale]/(logged-out)/dataset/[datasetId]/components/DatasetContent/DatasetContent.styles.ts
@@ -1,5 +1,6 @@
 import { styled } from "@mui/material";
 import Box from "@/components/Box";
+import Button from "@/components/Button";
 import Chip from "@/components/Chip";
 
 export const ObservationTableWrapper = styled(Box)(({ theme }) => ({
@@ -16,6 +17,14 @@ export const DatasetFieldWrapper = styled(Box)(() => ({
 }));
 
 export const DatasetFieldItem = styled(Chip)(() => ({
+    textOverflow: "ellipsis",
+    maxWidth: 200,
+    overflow: "hidden",
+    whiteSpace: "nowrap",
+    marginBottom: "4px",
+}));
+
+export const DatasetButtonItem = styled(Button)(() => ({
     textOverflow: "ellipsis",
     maxWidth: 200,
     overflow: "hidden",

--- a/src/app/[locale]/(logged-out)/dataset/[datasetId]/components/DatasetContent/DatasetContent.tsx
+++ b/src/app/[locale]/(logged-out)/dataset/[datasetId]/components/DatasetContent/DatasetContent.tsx
@@ -28,6 +28,7 @@ import {
     observationTableColumns,
 } from "../../config";
 import {
+    DatasetButtonItem,
     DatasetFieldItem,
     DatasetFieldWrapper,
     ListContainer,
@@ -96,25 +97,24 @@ const DatasetContent = ({
                     <Typography>{formatDate(value, DATE_FORMAT)}</Typography>
                 );
             }
-            case FieldType.TAG: {
-                const tagList = splitStringList(value);
+            case FieldType.TAG_LIST: {
+                const tagList = value;
 
                 return (
                     <DatasetFieldWrapper>
                         {tagList.map(tag => (
-                            <DatasetFieldItem
+                            <DatasetButtonItem
                                 color="success"
                                 size="small"
-                                label={tag}
                                 onClick={() =>
                                     router.push(
                                         `/${RouteName.SEARCH}?type=${
                                             SearchCategory.DATASETS
                                         }&query=${encodeURIComponent(tag)}`
                                     )
-                                }
-                                key={tag}
-                            />
+                                }>
+                                {tag}
+                            </DatasetButtonItem>
                         ))}
                     </DatasetFieldWrapper>
                 );

--- a/src/app/[locale]/(logged-out)/dataset/[datasetId]/components/DatasetContent/DatasetContent.tsx
+++ b/src/app/[locale]/(logged-out)/dataset/[datasetId]/components/DatasetContent/DatasetContent.tsx
@@ -29,7 +29,6 @@ import {
 } from "../../config";
 import {
     DatasetButtonItem,
-    DatasetFieldItem,
     DatasetFieldWrapper,
     ListContainer,
     ObservationTableWrapper,

--- a/src/app/[locale]/(logged-out)/dataset/[datasetId]/config.tsx
+++ b/src/app/[locale]/(logged-out)/dataset/[datasetId]/config.tsx
@@ -2,7 +2,7 @@ export enum FieldType {
     TEXT = "text",
     LIST = "list",
     DATE = "date",
-    TAG = "tag",
+    TAG_LIST = "tag-list",
     LINK_LIST = "link-list",
 }
 interface DatasetField {
@@ -83,7 +83,7 @@ const datasetFields: DatasetSection[] = [
         fields: [
             {
                 path: "metadata.metadata.summary.keywords",
-                type: FieldType.LIST,
+                type: FieldType.TAG_LIST,
             },
         ],
     },
@@ -146,7 +146,7 @@ const datasetFields: DatasetSection[] = [
         fields: [
             {
                 path: "metadata.metadata.structuralMetadata.tables",
-                type: FieldType.TAG,
+                type: FieldType.TAG_LIST,
             },
         ],
     },


### PR DESCRIPTION
## Screenshots (if relevant)
<img width="645" alt="image" src="https://github.com/user-attachments/assets/e5793d39-ff55-4cf5-b2e3-437f2057ba61" />

## Describe your changes
replace TAG with TAG_LIST, and create DatasetButtonItem for the keyword button.

## Issue ticket link
https://hdruk.atlassian.net/browse/GAT-4346

## Checklist before requesting a review

-   [ ] I have performed a self-review of my code
-   [ ] I have added appropriate unit tests
-   [ ] I have created mocks for unit tests (where appropriate)
-   [ ] The interface is responsive (where appropriate)
-   [ ] The interface is at least AA (where appropriate)
