### PR TITLE
feat(GAT-7195): feature flagging for FE

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "gateway-web-2",
-  "version": "2.8.1",
+  "version": "2.9.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "gateway-web-2",
-      "version": "2.8.1",
+      "version": "2.9.0",
       "dependencies": {
         "@dnd-kit/core": "^6.1.0",
         "@dnd-kit/sortable": "^8.0.0",
@@ -43,6 +43,7 @@
         "@types/node": "18.14.4",
         "@types/react": "18.0.28",
         "@types/react-dom": "18.0.11",
+        "@vercel/flags": "3.1.1",
         "@visx/group": "^3.3.0",
         "@visx/responsive": "^3.3.0",
         "@visx/scale": "^3.5.0",
@@ -2466,6 +2467,15 @@
       },
       "peerDependencies": {
         "react": ">=16.8.0"
+      }
+    },
+    "node_modules/@edge-runtime/cookies": {
+      "version": "5.0.2",
+      "resolved": "https://registry.npmjs.org/@edge-runtime/cookies/-/cookies-5.0.2.tgz",
+      "integrity": "sha512-Sd8LcWpZk/SWEeKGE8LT6gMm5MGfX/wm+GPnh1eBEtCpya3vYqn37wYknwAHw92ONoyyREl1hJwxV/Qx2DWNOg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=16"
       }
     },
     "node_modules/@emotion/babel-plugin": {
@@ -9958,6 +9968,41 @@
       "funding": {
         "type": "opencollective",
         "url": "https://opencollective.com/typescript-eslint"
+      }
+    },
+    "node_modules/@vercel/flags": {
+      "version": "3.1.1",
+      "resolved": "https://registry.npmjs.org/@vercel/flags/-/flags-3.1.1.tgz",
+      "integrity": "sha512-JM0xXRCHvN5wiSr9C2u6PSbXMnqN/0IXyNEOob6UYWB70vBWVLUKM96wgSuj6orRzRTowItmja2RTYyRvVhuQg==",
+      "deprecated": "This package has been renamed to flags. It offers the same functionality under a new name. Please follow the upgrade guide https://github.com/vercel/flags/blob/main/packages/flags/guides/upgrade-to-v4.md",
+      "license": "MIT",
+      "dependencies": {
+        "@edge-runtime/cookies": "^5.0.2",
+        "jose": "^5.2.1"
+      },
+      "peerDependencies": {
+        "@opentelemetry/api": "^1.7.0",
+        "@sveltejs/kit": "*",
+        "next": "*",
+        "react": "*",
+        "react-dom": "*"
+      },
+      "peerDependenciesMeta": {
+        "@opentelemetry/api": {
+          "optional": true
+        },
+        "@sveltejs/kit": {
+          "optional": true
+        },
+        "next": {
+          "optional": true
+        },
+        "react": {
+          "optional": true
+        },
+        "react-dom": {
+          "optional": true
+        }
       }
     },
     "node_modules/@visx/curve": {
@@ -18972,6 +19017,15 @@
       },
       "funding": {
         "url": "https://github.com/chalk/supports-color?sponsor=1"
+      }
+    },
+    "node_modules/jose": {
+      "version": "5.10.0",
+      "resolved": "https://registry.npmjs.org/jose/-/jose-5.10.0.tgz",
+      "integrity": "sha512-s+3Al/p9g32Iq+oqXxkW//7jk2Vig6FF1CFqzVXoTUXt2qz89YWbL+OwS17NFYEvxC35n0FKeGO2LGYSxeM2Gg==",
+      "license": "MIT",
+      "funding": {
+        "url": "https://github.com/sponsors/panva"
       }
     },
     "node_modules/js-cookie": {

--- a/package.json
+++ b/package.json
@@ -22,6 +22,7 @@
     "semi": "npx semantic-release"
   },
   "dependencies": {
+     "@vercel/flags": "3.1.1",
     "@dnd-kit/core": "^6.1.0",
     "@dnd-kit/sortable": "^8.0.0",
     "@dnd-kit/utilities": "^3.2.2",

--- a/src/app/[locale]/layout.tsx
+++ b/src/app/[locale]/layout.tsx
@@ -1,6 +1,6 @@
 import { ReactNode, Suspense } from "react";
 import { GoogleTagManager } from "@next/third-parties/google";
-import { NextIntlClientProvider, useMessages } from "next-intl";
+import { AbstractIntlMessages, NextIntlClientProvider } from "next-intl";
 import { notFound } from "next/navigation";
 import CustomerSurvey from "@/components/CustomerSurvey";
 import Footer from "@/components/Footer";
@@ -11,8 +11,10 @@ import SupportPopOut from "@/components/SupportPopOut";
 import ThemeRegistry from "@/components/ThemeRegistry/ThemeRegistry";
 import ProvidersDialog from "@/modules/ProvidersDialog";
 import metaData from "@/utils/metadata";
+import { isAliasesEnabled, isSDEConciergeServiceEnquiryEnabled } from "@/flags";
 import ActionBarProvider from "@/providers/ActionBarProvider";
 import DialogProvider from "@/providers/DialogProvider";
+import { FeatureProvider } from "@/providers/FeatureProvider";
 import SWRProvider from "@/providers/SWRProvider";
 import SnackbarProvider from "@/providers/SnackbarProvider";
 import CMSBanners from "./components/CMSBanners";
@@ -26,19 +28,27 @@ export const metadata = metaData({
         "The Health Data Research Gateway is a portal enabling researchers and innovators in academia, industry and the NHS to search for and request access to UK health research data.",
 });
 
-const locales = ["en"];
-
-export default function RootLayout({
+export default async function RootLayout({
     children,
     params: { locale },
 }: {
     params: { locale: string };
     children: ReactNode;
 }) {
-    if (!locales.includes(locale)) notFound();
-
-    const messages = useMessages();
+    let messages;
+    try {
+        messages = (await import(`@/config/messages/${locale}.json`))
+            .default as AbstractIntlMessages;
+    } catch {
+        notFound();
+    }
     const gtmId = process.env.NEXT_PUBLIC_GTM_ID;
+
+    const features = {
+        isSDEConciergeServiceEnquiryEnabled:
+            (await isSDEConciergeServiceEnquiryEnabled()) as boolean,
+        isAliasesEnabled: (await isAliasesEnabled()) as boolean,
+    };
 
     return (
         <html lang={locale}>
@@ -48,25 +58,26 @@ export default function RootLayout({
                 <NextIntlClientProvider locale={locale} messages={messages}>
                     <SWRProvider>
                         <ThemeRegistry>
-                            <DialogProvider>
-                                <ActionBarProvider>
-                                    <SupportPopOut />
-                                    <LightBox />
-                                    <CMSBanners />
-                                    <SnackbarProvider />
-                                    <Header />
-
-                                    {children}
-                                    <Footer />
-                                    <CustomerSurvey />
-                                    <Suspense fallback={null}>
-                                        <NavigationEvents />
-                                        <PageTracker />
-                                    </Suspense>
-                                </ActionBarProvider>
-                                {/* ProvidersDialog has to remain in DOM */}
-                                <ProvidersDialog />
-                            </DialogProvider>
+                            <FeatureProvider feature={features}>
+                                <DialogProvider>
+                                    <ActionBarProvider>
+                                        <SupportPopOut />
+                                        <LightBox />
+                                        <CMSBanners />
+                                        <SnackbarProvider />
+                                        <Header />
+                                        {children}
+                                        <Footer />
+                                        <CustomerSurvey />
+                                        <Suspense fallback={null}>
+                                            <NavigationEvents />
+                                            <PageTracker />
+                                        </Suspense>
+                                    </ActionBarProvider>
+                                    {/* ProvidersDialog has to remain in DOM */}
+                                    <ProvidersDialog />
+                                </DialogProvider>
+                            </FeatureProvider>
                         </ThemeRegistry>
                     </SWRProvider>
                 </NextIntlClientProvider>

--- a/src/config/apis.ts
+++ b/src/config/apis.ts
@@ -13,6 +13,7 @@ const apiV2IPUrl =
 const apis = {
     apiV1Url,
     apiV1IPUrl,
+    enablebFeatures: `${apiV1IPUrl}/feature-flags/enabled`,
     logoutInternalUrl: "/api/logout",
     signInInternalUrl: "/api/signIn",
     authInternalUrl: "/api/auth",

--- a/src/config/apis.ts
+++ b/src/config/apis.ts
@@ -13,7 +13,7 @@ const apiV2IPUrl =
 const apis = {
     apiV1Url,
     apiV1IPUrl,
-    enablebFeatures: `${apiV1IPUrl}/feature-flags/enabled`,
+    enabledFeatures: `${apiV1IPUrl}/feature-flags/enabled`,
     logoutInternalUrl: "/api/logout",
     signInInternalUrl: "/api/signIn",
     authInternalUrl: "/api/auth",

--- a/src/flags.ts
+++ b/src/flags.ts
@@ -1,0 +1,14 @@
+import { flag } from "@vercel/flags/next";
+import { createGatewayFlagAdapter } from "./utils/gatewayFlagAdapter";
+
+const gatewayAdapter = createGatewayFlagAdapter();
+
+export const isSDEConciergeServiceEnquiryEnabled = flag({
+    key: "SDEConciergeServiceEnquiry",
+    adapter: await gatewayAdapter(),
+});
+
+export const isAliasesEnabled = flag({
+    key: "Aliases",
+    adapter: await gatewayAdapter(),
+});

--- a/src/providers/FeatureProvider.tsx
+++ b/src/providers/FeatureProvider.tsx
@@ -1,0 +1,28 @@
+"use client";
+
+import { useContext, createContext, ReactNode, useMemo } from "react";
+
+const FeatureContext = createContext("features");
+
+export interface FeatureType {
+    [key: string]: boolean;
+}
+
+interface ProviderProps {
+    children: ReactNode;
+    feature: FeatureType;
+}
+function FeatureProvider({ children, feature }: Readonly<ProviderProps>) {
+    const value = useMemo(() => feature, [feature]);
+    return (
+        <FeatureContext.Provider value={value as any}>
+            {children}
+        </FeatureContext.Provider>
+    );
+}
+
+function useFeatures(): FeatureType {
+    return useContext(FeatureContext) as unknown as FeatureType;
+}
+
+export { FeatureProvider, useFeatures };

--- a/src/providers/FeatureProvider.tsx
+++ b/src/providers/FeatureProvider.tsx
@@ -15,7 +15,7 @@ interface ProviderProps {
 function FeatureProvider({ children, feature }: Readonly<ProviderProps>) {
     const value = useMemo(() => feature, [feature]);
     return (
-        <FeatureContext.Provider value={value as any}>
+        <FeatureContext.Provider value={value as unknown as string}>
             {children}
         </FeatureContext.Provider>
     );

--- a/src/utils/gatewayFlagAdapter.test.ts
+++ b/src/utils/gatewayFlagAdapter.test.ts
@@ -3,7 +3,7 @@ import { createGatewayFlagAdapter } from "./gatewayFlagAdapter";
 jest.mock("@/config/apis", () => ({
     __esModule: true,
     default: {
-        enablebFeatures: "http://localhost/mock-api",
+        enabledFeatures: "http://localhost/mock-api",
     },
 }));
 

--- a/src/utils/gatewayFlagAdapter.test.ts
+++ b/src/utils/gatewayFlagAdapter.test.ts
@@ -1,0 +1,71 @@
+import { createGatewayFlagAdapter } from "./gatewayFlagAdapter";
+
+jest.mock("@/config/apis", () => ({
+    __esModule: true,
+    default: {
+        enablebFeatures: "http://localhost/mock-api",
+    },
+}));
+
+describe("createGatewayFlagAdapter", () => {
+    const mockResponse = {
+        SDEConciergeServiceEnquiry: { enabled: true },
+        Aliases: { enabled: false },
+    };
+
+    let adapter: ReturnType<ReturnType<typeof createGatewayFlagAdapter>>;
+
+    beforeEach(() => {
+        global.fetch = jest.fn().mockResolvedValue({
+            ok: true,
+            json: async () => mockResponse,
+        }) as jest.Mock;
+
+        jest.useFakeTimers();
+        adapter = createGatewayFlagAdapter()();
+    });
+
+    afterEach(() => {
+        jest.clearAllMocks();
+        jest.useRealTimers();
+    });
+
+    it("refetches after TTL expiry", async () => {
+        await adapter.decide({ key: "SDEConciergeServiceEnquiry" });
+
+        jest.advanceTimersByTime(5 * 60 * 1000 + 1);
+
+        await adapter.decide({ key: "Aliases" });
+
+        expect(fetch).toHaveBeenCalledTimes(2);
+    });
+
+    it("fetches and caches feature flags", async () => {
+        const result = await adapter.decide({
+            key: "SDEConciergeServiceEnquiry",
+        });
+        expect(result).toBe(true);
+
+        const result2 = await adapter.decide({ key: "Aliases" });
+        expect(result2).toBe(false);
+
+        expect(fetch).toHaveBeenCalledTimes(0); // cached
+    });
+
+    it("handles API failure gracefully", async () => {
+        (fetch as jest.Mock).mockResolvedValueOnce({
+            ok: false,
+            statusText: "Service Unavailable",
+        });
+
+        const result = await adapter.decide({ key: "NonExistent" });
+        expect(result).toBe(undefined);
+    });
+
+    it("handles network error gracefully", async () => {
+        (fetch as jest.Mock).mockRejectedValueOnce(new Error("Network Error"));
+
+        const result = await adapter.decide({ key: "NonExistent" });
+        expect(result).toBe(undefined);
+    });
+});

--- a/src/utils/gatewayFlagAdapter.ts
+++ b/src/utils/gatewayFlagAdapter.ts
@@ -31,7 +31,7 @@ const flattenFlags = (
 
 const setCache = async (): Promise<Record<string, boolean>> => {
     try {
-        const res = await fetch(apis.enablebFeatures);
+        const res = await fetch(apis.enabledFeatures);
         if (!res.ok) {
             console.error(`Failed to fetch feature flags: ${res.statusText}`);
             return {};

--- a/src/utils/gatewayFlagAdapter.ts
+++ b/src/utils/gatewayFlagAdapter.ts
@@ -1,0 +1,52 @@
+import type { Adapter } from "@vercel/flags";
+import apis from "@/config/apis";
+
+let cache: Record<string, boolean> | null = null;
+let cacheTimestamp: number | null = null;
+const CACHE_TTL_MS = 5 * 60 * 1000; // 5 minutes
+
+const setCache = async (): Promise<Record<string, boolean>> => {
+    try {
+        const res = await fetch(apis.enablebFeatures);
+        console.log("here");
+        if (!res.ok) {
+            console.error(`Failed to fetch feature flags: ${res.statusText}`);
+            return {};
+        }
+
+        const json = await res.json();
+
+        cacheTimestamp = Date.now();
+        return Object.entries(json).reduce(
+            (acc: Record<string, boolean>, [key, value]: [string, any]) => {
+                acc[key] = !!value?.enabled;
+                return acc;
+            },
+            {}
+        );
+    } catch (err) {
+        console.error("Error fetching feature flags:", err);
+        return {};
+    }
+};
+
+const isCacheStale = () => {
+    if (!cacheTimestamp) return true;
+    return Date.now() - cacheTimestamp > CACHE_TTL_MS;
+};
+
+export function createGatewayFlagAdapter() {
+    return function gatewayFlagAdapter<ValueType, EntitiesType>(): Adapter<
+        ValueType,
+        EntitiesType
+    > {
+        return {
+            async decide({ key }): Promise<ValueType> {
+                if (!cache || isCacheStale()) {
+                    cache = await setCache();
+                }
+                return cache[key] as ValueType;
+            },
+        };
+    };
+}

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -1,6 +1,6 @@
 {
     "compilerOptions": {
-        "target": "es5",
+        "target": "ES2017",
         "lib": ["dom", "dom.iterable", "esnext"],
         "allowJs": true,
         "skipLibCheck": true,


### PR DESCRIPTION
## Screenshots (if relevant)

## Describe your changes
tsconfig changes need to use async outside of next had to change the target to something a lil more modern..

userMessages() - by default app directory layout is serverside, this is client side... you cant have use... and async together so it blew up.. how this ever actually worked is beyond me... it must have forced it to be serverside, all it does it grab the locale and check if the file exists in the specified locales path. So mimick that behaviour, with that we no longer need the supported list of locales check.

Added in vercel flags and gateway adapter to grab and cache flags with a ttl of 5 minutes.
Added in a context provider so we can use flags in the client side,

vercel flags is a lil more basic than pennant we cant have dynamic keys we have to hard code them for now.

To use server functions/components copy same way thats done in layout.tsx to pass to the provider

for client side: 
`    const { isSDEConciergeServiceEnquiryEnabled } = useFeatures();`


## Issue ticket link

## Checklist before requesting a review

-   [ ] I have performed a self-review of my code
-   [ ] I have added appropriate unit tests
-   [ ] I have created mocks for unit tests (where appropriate)
-   [ ] The interface is responsive (where appropriate)
-   [ ] The interface is at least AA (where appropriate)
