### PR TITLE
feat(GAT-6786): pagination search shifts focus

### DIFF
--- a/src/app/[locale]/(logged-out)/search/components/Search/Search.tsx
+++ b/src/app/[locale]/(logged-out)/search/components/Search/Search.tsx
@@ -1022,27 +1022,23 @@ const Search = ({ filters, cohortDiscovery }: SearchProps) => {
                                     <div aria-describedby="result-summary">
                                         {renderResults()}
                                     </div>
-
-                                    <Pagination
-                                        isLoading={isSearching}
-                                        page={parseInt(queryParams.page, 10)}
-                                        count={data?.lastPage}
-                                        onChange={(
-                                            e: React.ChangeEvent<unknown>,
-                                            page: number
-                                        ) => {
-                                            setQueryParams({
-                                                ...queryParams,
-                                                page: page.toString(),
-                                            });
-                                            updatePath(
-                                                PAGE_FIELD,
-                                                page.toString()
-                                            );
-                                        }}
-                                    />
                                 </>
                             )}
+                        <Pagination
+                            isLoading={isSearching}
+                            page={parseInt(queryParams.page, 10)}
+                            count={data?.lastPage}
+                            onChange={(
+                                e: React.ChangeEvent<unknown>,
+                                page: number
+                            ) => {
+                                setQueryParams({
+                                    ...queryParams,
+                                    page: page.toString(),
+                                });
+                                updatePath(PAGE_FIELD, page.toString());
+                            }}
+                        />
                     </Box>
                 </Box>
             </BoxContainer>

--- a/src/components/Pagination/Pagination.tsx
+++ b/src/components/Pagination/Pagination.tsx
@@ -10,7 +10,6 @@ interface PaginationProps extends MuiPaginationProps {
 }
 
 const Pagination = ({ isLoading = false, ...rest }: PaginationProps) => {
-    if (isLoading) return null;
     return (
         <Box sx={{ p: 0, display: "flex", justifyContent: "center" }}>
             <MuiPagination
@@ -22,6 +21,7 @@ const Pagination = ({ isLoading = false, ...rest }: PaginationProps) => {
                             next: ArrowRightIcon,
                         }}
                         {...item}
+                        disabled={isLoading}
                     />
                 )}
                 {...rest}

--- a/src/components/Pagination/__snapshots__/Pagination.test.tsx.snap
+++ b/src/components/Pagination/__snapshots__/Pagination.test.tsx.snap
@@ -15,10 +15,9 @@ exports[`Pagination renders without crashing 1`] = `
         <li>
           <button
             aria-label="Go to previous page"
-            class="MuiButtonBase-root Mui-disabled MuiPaginationItem-root MuiPaginationItem-sizeMedium MuiPaginationItem-outlined MuiPaginationItem-rounded Mui-disabled MuiPaginationItem-previousNext mui-style-18irgz1-MuiButtonBase-root-MuiPaginationItem-root"
+            class="MuiButtonBase-root MuiPaginationItem-root MuiPaginationItem-sizeMedium MuiPaginationItem-outlined MuiPaginationItem-rounded MuiPaginationItem-previousNext mui-style-18irgz1-MuiButtonBase-root-MuiPaginationItem-root"
             data-testid="pagination-item"
-            disabled=""
-            tabindex="-1"
+            tabindex="0"
             type="button"
           >
             <svg
@@ -135,4 +134,144 @@ exports[`Pagination renders without crashing 1`] = `
 </div>
 `;
 
-exports[`Pagination should return empty div if still loading 1`] = `<div />`;
+exports[`Pagination should return empty div if still loading 1`] = `
+<div>
+  <div
+    class="MuiBox-root mui-style-1r2sw3a"
+  >
+    <nav
+      aria-label="pagination navigation"
+      class="MuiPagination-root MuiPagination-outlined mui-style-1oj2twp-MuiPagination-root"
+    >
+      <ul
+        class="MuiPagination-ul mui-style-wjh20t-MuiPagination-ul"
+      >
+        <li>
+          <button
+            aria-label="Go to previous page"
+            class="MuiButtonBase-root Mui-disabled MuiPaginationItem-root MuiPaginationItem-sizeMedium MuiPaginationItem-outlined MuiPaginationItem-rounded Mui-disabled MuiPaginationItem-previousNext mui-style-18irgz1-MuiButtonBase-root-MuiPaginationItem-root"
+            data-testid="pagination-item"
+            disabled=""
+            tabindex="-1"
+            type="button"
+          >
+            <svg
+              aria-hidden="true"
+              class="MuiSvgIcon-root MuiSvgIcon-fontSizeMedium MuiPaginationItem-icon mui-style-g2z002-MuiSvgIcon-root-MuiPaginationItem-icon"
+              data-testid="ArrowLeftIcon"
+              focusable="false"
+              viewBox="0 0 24 24"
+            >
+              <path
+                d="m14 7-5 5 5 5V7z"
+              />
+            </svg>
+          </button>
+        </li>
+        <li>
+          <button
+            aria-current="true"
+            aria-label="page 1"
+            class="MuiButtonBase-root Mui-disabled MuiPaginationItem-root MuiPaginationItem-sizeMedium MuiPaginationItem-outlined MuiPaginationItem-rounded Mui-disabled Mui-selected MuiPaginationItem-page mui-style-18irgz1-MuiButtonBase-root-MuiPaginationItem-root"
+            data-testid="pagination-item"
+            disabled=""
+            tabindex="-1"
+            type="button"
+          >
+            1
+          </button>
+        </li>
+        <li>
+          <button
+            aria-label="Go to page 2"
+            class="MuiButtonBase-root Mui-disabled MuiPaginationItem-root MuiPaginationItem-sizeMedium MuiPaginationItem-outlined MuiPaginationItem-rounded Mui-disabled MuiPaginationItem-page mui-style-18irgz1-MuiButtonBase-root-MuiPaginationItem-root"
+            data-testid="pagination-item"
+            disabled=""
+            tabindex="-1"
+            type="button"
+          >
+            2
+          </button>
+        </li>
+        <li>
+          <button
+            aria-label="Go to page 3"
+            class="MuiButtonBase-root Mui-disabled MuiPaginationItem-root MuiPaginationItem-sizeMedium MuiPaginationItem-outlined MuiPaginationItem-rounded Mui-disabled MuiPaginationItem-page mui-style-18irgz1-MuiButtonBase-root-MuiPaginationItem-root"
+            data-testid="pagination-item"
+            disabled=""
+            tabindex="-1"
+            type="button"
+          >
+            3
+          </button>
+        </li>
+        <li>
+          <button
+            aria-label="Go to page 4"
+            class="MuiButtonBase-root Mui-disabled MuiPaginationItem-root MuiPaginationItem-sizeMedium MuiPaginationItem-outlined MuiPaginationItem-rounded Mui-disabled MuiPaginationItem-page mui-style-18irgz1-MuiButtonBase-root-MuiPaginationItem-root"
+            data-testid="pagination-item"
+            disabled=""
+            tabindex="-1"
+            type="button"
+          >
+            4
+          </button>
+        </li>
+        <li>
+          <button
+            aria-label="Go to page 5"
+            class="MuiButtonBase-root Mui-disabled MuiPaginationItem-root MuiPaginationItem-sizeMedium MuiPaginationItem-outlined MuiPaginationItem-rounded Mui-disabled MuiPaginationItem-page mui-style-18irgz1-MuiButtonBase-root-MuiPaginationItem-root"
+            data-testid="pagination-item"
+            disabled=""
+            tabindex="-1"
+            type="button"
+          >
+            5
+          </button>
+        </li>
+        <li>
+          <div
+            class="MuiPaginationItem-root MuiPaginationItem-sizeMedium MuiPaginationItem-outlined MuiPaginationItem-rounded Mui-disabled MuiPaginationItem-ellipsis mui-style-11qesrg-MuiPaginationItem-root"
+          >
+            …
+          </div>
+        </li>
+        <li>
+          <button
+            aria-label="Go to page 10"
+            class="MuiButtonBase-root Mui-disabled MuiPaginationItem-root MuiPaginationItem-sizeMedium MuiPaginationItem-outlined MuiPaginationItem-rounded Mui-disabled MuiPaginationItem-page mui-style-18irgz1-MuiButtonBase-root-MuiPaginationItem-root"
+            data-testid="pagination-item"
+            disabled=""
+            tabindex="-1"
+            type="button"
+          >
+            10
+          </button>
+        </li>
+        <li>
+          <button
+            aria-label="Go to next page"
+            class="MuiButtonBase-root Mui-disabled MuiPaginationItem-root MuiPaginationItem-sizeMedium MuiPaginationItem-outlined MuiPaginationItem-rounded Mui-disabled MuiPaginationItem-previousNext mui-style-18irgz1-MuiButtonBase-root-MuiPaginationItem-root"
+            data-testid="pagination-item"
+            disabled=""
+            tabindex="-1"
+            type="button"
+          >
+            <svg
+              aria-hidden="true"
+              class="MuiSvgIcon-root MuiSvgIcon-fontSizeMedium MuiPaginationItem-icon mui-style-g2z002-MuiSvgIcon-root-MuiPaginationItem-icon"
+              data-testid="ArrowRightIcon"
+              focusable="false"
+              viewBox="0 0 24 24"
+            >
+              <path
+                d="m10 17 5-5-5-5v10z"
+              />
+            </svg>
+          </button>
+        </li>
+      </ul>
+    </nav>
+  </div>
+</div>
+`;


### PR DESCRIPTION
## Screenshots (if relevant)

## Describe your changes
Due to the element being removed from the dom the next tab becomes the top of the page
## Issue ticket link

## Checklist before requesting a review

-   [ ] I have performed a self-review of my code
-   [ ] I have added appropriate unit tests
-   [ ] I have created mocks for unit tests (where appropriate)
-   [ ] The interface is responsive (where appropriate)
-   [ ] The interface is at least AA (where appropriate)
