### PR TITLE
feat(GAT-6843): focus styles for tabs

### DIFF
--- a/src/components/Tabs/Tabs.styles.ts
+++ b/src/components/Tabs/Tabs.styles.ts
@@ -26,6 +26,7 @@ export const tabsStyle = {
             "&.MuiTab-root": {
                 flex: 1,
                 borderRadius: "20px 20px 0px 0px",
+                borderBottom: `3px solid transparent`,
                 fontSize: "20px",
                 marginTop: "2px",
                 boxShadow: "1px -1px 3px 0px #2626261A",
@@ -35,7 +36,8 @@ export const tabsStyle = {
                 padding: "6px",
 
                 "&:focus,&:hover, &:active": {
-                    border: `3px solid ${colors.green400}`,
+                    background: colors.green100,
+                    borderBottom: `3px solid ${colors.green400}`,
                 },
 
                 "&t:active:not(.Mui-selected)": {
@@ -57,7 +59,8 @@ export const tabsStyle = {
                 },
 
                 "&:focus, &:hover, &:active": {
-                    border: `3px solid ${colors.green400}`,
+                    background: colors.green100,
+                    borderBottom: `3px solid ${colors.green400}`,
                 },
 
                 "&t:active:not(.Mui-selected)": {

--- a/src/components/Tabs/Tabs.styles.ts
+++ b/src/components/Tabs/Tabs.styles.ts
@@ -36,7 +36,7 @@ export const tabsStyle = {
                 padding: "6px",
 
                 "&:focus,&:hover, &:active": {
-                    background: colors.green100,
+                    background: colors.white,
                     borderBottom: `3px solid ${colors.green400}`,
                 },
 
@@ -45,6 +45,7 @@ export const tabsStyle = {
                 },
                 "&:focus:not(.Mui-selected), &:hover:not(.Mui-selected), &.Mui-focusVisible:not(.Mui-selected)":
                     {
+                        background: colors.green100,
                         color: "inherit",
                     },
             },

--- a/src/components/Tabs/Tabs.styles.ts
+++ b/src/components/Tabs/Tabs.styles.ts
@@ -13,9 +13,11 @@ export const tabsStyle = {
             minHeight: "40px",
         },
     }),
+
     tab: () =>
         css({
             "&.MuiTab-root.Mui-selected": {
+                borderBottom: `3px solid ${colors.green400}`,
                 background: colors.green400,
                 color: colors.white,
                 boxShadow: "inherit",
@@ -24,6 +26,7 @@ export const tabsStyle = {
             "&.MuiTab-root": {
                 flex: 1,
                 borderRadius: "20px 20px 0px 0px",
+                borderBottom: `3px solid transparent`,
                 fontSize: "20px",
                 marginTop: "2px",
                 boxShadow: "1px -1px 3px 0px #2626261A",
@@ -32,11 +35,38 @@ export const tabsStyle = {
                 minHeight: "40px",
                 padding: "6px",
 
+                "&:focus,&:hover, &:active": {
+                    background: colors.green100,
+                    borderBottom: `3px solid ${colors.green400}`,
+                },
+
+                "&t:active:not(.Mui-selected)": {
+                    borderBottom: `3px solid ${colors.green400}`,
+                },
                 "&:focus:not(.Mui-selected), &:hover:not(.Mui-selected), &.Mui-focusVisible:not(.Mui-selected)":
                     {
-                        background: colors.green100,
                         color: "inherit",
                     },
+            },
+        }),
+
+    normal: () =>
+        css({
+            "&.MuiTab-root": {
+                borderBottom: `3px solid transparent`,
+                "&.Mui-selected": {
+                    borderBottom: `3px solid ${colors.green400}`,
+                    boxShadow: "inherit",
+                },
+
+                "&:focus, &:hover, &:active": {
+                    background: colors.green100,
+                    borderBottom: `3px solid ${colors.green400}`,
+                },
+
+                "&t:active:not(.Mui-selected)": {
+                    borderBottom: `3px solid ${colors.green400}`,
+                },
             },
         }),
 };

--- a/src/components/Tabs/Tabs.styles.ts
+++ b/src/components/Tabs/Tabs.styles.ts
@@ -26,7 +26,6 @@ export const tabsStyle = {
             "&.MuiTab-root": {
                 flex: 1,
                 borderRadius: "20px 20px 0px 0px",
-                borderBottom: `3px solid transparent`,
                 fontSize: "20px",
                 marginTop: "2px",
                 boxShadow: "1px -1px 3px 0px #2626261A",
@@ -36,8 +35,7 @@ export const tabsStyle = {
                 padding: "6px",
 
                 "&:focus,&:hover, &:active": {
-                    background: colors.green100,
-                    borderBottom: `3px solid ${colors.green400}`,
+                    border: `3px solid ${colors.green400}`,
                 },
 
                 "&t:active:not(.Mui-selected)": {
@@ -53,15 +51,13 @@ export const tabsStyle = {
     normal: () =>
         css({
             "&.MuiTab-root": {
-                borderBottom: `3px solid transparent`,
                 "&.Mui-selected": {
                     borderBottom: `3px solid ${colors.green400}`,
                     boxShadow: "inherit",
                 },
 
                 "&:focus, &:hover, &:active": {
-                    background: colors.green100,
-                    borderBottom: `3px solid ${colors.green400}`,
+                    border: `3px solid ${colors.green400}`,
                 },
 
                 "&t:active:not(.Mui-selected)": {

--- a/src/components/Tabs/Tabs.tsx
+++ b/src/components/Tabs/Tabs.tsx
@@ -25,6 +25,7 @@ export enum TabVariant {
 }
 
 export interface TabProps {
+    ariaLabel?: string;
     tabs: Tab[];
     introContent?: ReactNode;
     centered?: boolean;
@@ -84,11 +85,11 @@ const Tabs = ({
     persistParams = true,
     defaultSelectedTab,
     tabVariant = "",
+    ariaLabel,
     handleChange,
 }: TabProps) => {
     const searchParams = useSearchParams();
     const currentTab = searchParams?.get(paramName);
-
     const selectedTab = currentTab || defaultSelectedTab || tabs[0].value;
 
     return (
@@ -102,13 +103,20 @@ const Tabs = ({
                         ...tabBoxSx,
                     }}>
                     <MuiTabList
+                        aria-label={ariaLabel ?? "tab navigation"}
                         variant={tabVariant}
                         scrollButtons="auto"
-                        sx={{ mb: variant === TabVariant.STANDARD ? 1 : 0 }}
+                        sx={{
+                            mb: variant === TabVariant.STANDARD ? 1 : 0,
+                            ".MuiTabs-indicator": {
+                                display: "none",
+                            },
+                        }}
                         centered={centered}
                         onChange={handleChange}>
                         {tabs.map(tab => (
                             <MuiTab<ElementType>
+                                id={`tab-${tab.value}`}
                                 component={CustomLink}
                                 disableRipple
                                 color="secondary"
@@ -117,8 +125,9 @@ const Tabs = ({
                                 value={tab.value}
                                 label={tab.label}
                                 css={
-                                    variant === TabVariant.LARGE &&
-                                    tabsStyle.tab
+                                    variant === TabVariant.LARGE
+                                        ? tabsStyle.tab
+                                        : tabsStyle.normal
                                 }
                                 param={paramName}
                                 persist={persistParams}
@@ -130,6 +139,7 @@ const Tabs = ({
                 {renderTabContent &&
                     tabs.map(tab => (
                         <MuiTabPanel
+                            aria-labelledby={`tab-${tab.value}`}
                             sx={{ padding: 0 }}
                             key={tab.value}
                             value={tab.value}>


### PR DESCRIPTION
## Screenshots (if relevant)

https://github.com/user-attachments/assets/ee8de04c-40af-4ca3-9fd2-454e4a816efa


## Describe your changes
remove the indicator and user border of the same size. Added in border transparent to avoid content shift.
## Issue ticket link

## Checklist before requesting a review

-   [x] I have performed a self-review of my code
-   [ ] I have added appropriate unit tests
-   [ ] I have created mocks for unit tests (where appropriate)
-   [ ] The interface is responsive (where appropriate)
-   [x] The interface is at least AA (where appropriate)
