### PR TITLE
fix(GAT-7267): Add logic to force an OpenAthens user who hasn't set their secondary email to do so before they can register for Cohort Discovery.

### DIFF
--- a/src/app/[locale]/(logged-out)/about/cohort-discovery/components/CohortDiscoveryButton/CohortDiscoveryButton.tsx
+++ b/src/app/[locale]/(logged-out)/about/cohort-discovery/components/CohortDiscoveryButton/CohortDiscoveryButton.tsx
@@ -66,7 +66,8 @@ const CohortDiscoveryButton = ({
             if (accessData?.redirect_url) {
                 push(accessData?.redirect_url);
             } else if (isLoggedIn) {
-                // check that if the user is using OpenAthens, that they have provided a secondary email, and
+                // check that if the user is using OpenAthens, that they have provided a secondary email,
+                // and send them to set it if not
                 if (openAthensInvalid) {
                     push(`/${RouteName.ACCOUNT}/${RouteName.PROFILE}`);
                 } else {

--- a/src/app/[locale]/(logged-out)/about/cohort-discovery/components/CohortDiscoveryButton/CohortDiscoveryButton.tsx
+++ b/src/app/[locale]/(logged-out)/about/cohort-discovery/components/CohortDiscoveryButton/CohortDiscoveryButton.tsx
@@ -10,6 +10,7 @@ import useAuth from "@/hooks/useAuth";
 import useDialog from "@/hooks/useDialog";
 import useGet from "@/hooks/useGet";
 import apis from "@/config/apis";
+import { RouteName } from "@/consts/routeName";
 
 interface accessRequestType {
     redirect_url: string;
@@ -60,12 +61,17 @@ const CohortDiscoveryButton = ({
             if (accessData?.redirect_url) {
                 push(accessData?.redirect_url);
             } else if (isLoggedIn) {
-                push(ctaLink.url);
+                // check that if the user is using OpenAthens, that they have provided a secondary email, and
+                if (openAthensInvalid) {
+                    push(`/${RouteName.ACCOUNT}/${RouteName.PROFILE}`);
+                } else {
+                    push(ctaLink.url);
+                }
             } else {
                 showDialog(ProvidersDialog, { isProvidersDialog: true });
             }
         }
-    }, [accessData, isClicked, isLoggedIn]);
+    }, [userData, accessData, isClicked, isLoggedIn]);
 
     const isDisabled =
         isLoggedIn && userData
@@ -77,12 +83,19 @@ const CohortDiscoveryButton = ({
     const isApproved =
         isLoggedIn && userData && userData.request_status === "APPROVED";
 
+    const openAthensInvalid =
+        isLoggedIn &&
+        user?.provider === "open-athens" &&
+        !user?.secondary_email;
+
     return (
         <Tooltip
             title={
                 tooltipOverride ||
                 (isDisabled
                     ? t(`notApproved`)
+                    : openAthensInvalid
+                    ? t("setSecondaryEmail")
                     : showDatasetExplanatoryTooltip && isApproved
                     ? t("explanatoryTooltip")
                     : "")

--- a/src/app/[locale]/(logged-out)/about/cohort-discovery/components/CohortDiscoveryButton/CohortDiscoveryButton.tsx
+++ b/src/app/[locale]/(logged-out)/about/cohort-discovery/components/CohortDiscoveryButton/CohortDiscoveryButton.tsx
@@ -56,6 +56,11 @@ const CohortDiscoveryButton = ({
         }
     );
 
+    const openAthensInvalid =
+        isLoggedIn &&
+        user?.provider === "open-athens" &&
+        !user?.secondary_email;
+
     useEffect(() => {
         if (isClicked) {
             if (accessData?.redirect_url) {
@@ -82,11 +87,6 @@ const CohortDiscoveryButton = ({
 
     const isApproved =
         isLoggedIn && userData && userData.request_status === "APPROVED";
-
-    const openAthensInvalid =
-        isLoggedIn &&
-        user?.provider === "open-athens" &&
-        !user?.secondary_email;
 
     return (
         <Tooltip

--- a/src/config/messages/en.json
+++ b/src/config/messages/en.json
@@ -1444,6 +1444,7 @@
         },
         "CohortDiscoveryButton": {
             "notApproved": "Your request to access Cohort Discovery is still pending. Keep an eye out for an email with next steps, or contact support via the ‘Need Support’ button on the bottom right of this screen.",
+            "setSecondaryEmail": "You are logged in via OpenAthens, which generates a primary email address in your profile that cannot be used for Cohort Discovery. This button will now send you to your profile page to please set your secondary email address. This must be an institutional email address. Please return here after setting and saving a secondary email address.",
             "explanatoryTooltip": "You will be taken to the Cohort Discovery tool. You must have access to this dataset in order to run queries."
         },
         "CMSBanner": {


### PR DESCRIPTION
## Screenshots (if relevant)

![image](https://github.com/user-attachments/assets/86b2f2ed-5fb5-4f72-8feb-3748456ac261)

## Describe your changes
If a user is logged in via OpenAthens and their secondary email is not set, the Tooltip explains what they should do, and the button will send them to their profile page to make changes.

## Issue ticket link
https://hdruk.atlassian.net/browse/GAT-7267

## Checklist before requesting a review

-   [ ] I have performed a self-review of my code
-   [ ] I have added appropriate unit tests
-   [ ] I have created mocks for unit tests (where appropriate)
-   [ ] The interface is responsive (where appropriate)
-   [ ] The interface is at least AA (where appropriate)
