### PR TITLE
feat(GAT-6924): Add team alias creation and display

### DIFF
--- a/src/app/[locale]/(logged-out)/data-custodian/[dataCustodianId]/page.tsx
+++ b/src/app/[locale]/(logged-out)/data-custodian/[dataCustodianId]/page.tsx
@@ -1,8 +1,10 @@
+import { Fragment } from "react";
 import { get, isEmpty } from "lodash";
 import { getTranslations } from "next-intl/server";
 import { cookies } from "next/headers";
 import { notFound } from "next/navigation";
 import Box from "@/components/Box";
+import Chip from "@/components/Chip";
 import CollectionsContent from "@/components/CollectionsContent";
 import DataUsesContent from "@/components/DataUsesContent";
 import DatasetsContent from "@/components/DatasetsContent";
@@ -86,6 +88,18 @@ export default async function DataCustodianItemPage({
                             data={data}
                             populatedSections={populatedSections}
                         />
+                        <Fragment key="custodian_alias">
+                            <Typography variant="h3">{t("aliases")}</Typography>
+                            <Box sx={{ p: 0, pb: 1 }}>
+                                {data.aliases?.map(alias => (
+                                    <Chip
+                                        label={alias.name}
+                                        key={alias.id}
+                                        color="alias"
+                                    />
+                                ))}
+                            </Box>
+                        </Fragment>
                         <DatasetsContent
                             datasets={data.datasets}
                             anchorIndex={populatedSections.length + 1}

--- a/src/app/[locale]/(logged-out)/data-custodian/[dataCustodianId]/page.tsx
+++ b/src/app/[locale]/(logged-out)/data-custodian/[dataCustodianId]/page.tsx
@@ -90,7 +90,7 @@ export default async function DataCustodianItemPage({
                         />
                         <Fragment key="custodian_alias">
                             <Typography variant="h3">{t("aliases")}</Typography>
-                            <Box sx={{ p: 0, pb: 1 }}>
+                            <Box sx={{ p: 0, pb: 1, display: "flex" }} gap={1}>
                                 {data.aliases?.map(alias => (
                                     <Chip
                                         label={alias.name}

--- a/src/app/[locale]/account/profile/teams/components/CreateTeamForm/CreateTeamForm.tsx
+++ b/src/app/[locale]/account/profile/teams/components/CreateTeamForm/CreateTeamForm.tsx
@@ -213,36 +213,30 @@ const CreateTeamForm = () => {
     });
 
     const saveAliases = async (formData: TeamCreateForm | TeamEditForm) => {
-        try {
-            const newAliasNames = formData.aliases.filter(
-                alias => typeof alias === "string"
-            ) as string[];
+        const newAliasNames = formData.aliases.filter(
+            alias => typeof alias === "string"
+        ) as string[];
 
-            // Create new aliases (POST requests)
-            const result = await Promise.all(
-                newAliasNames.map(name => addAlias({ name }))
-            );
+        // Create new aliases (POST requests)
+        const result = await Promise.all(
+            newAliasNames.map(name => addAlias({ name }))
+        );
 
-            // Throw on failure to save alias
-            if (!result || (isArray(result) && result[0] === null)) {
-                throw new Error(`Failed to create Aliases`);
-            }
-
-            // Refetch alias list
-            const updatedAliases = await mutateAliases();
-
-            // Rebuild formData.aliases as full alias objects
-            return formData.aliases.map(alias => {
-                if (typeof alias === "string") {
-                    return (
-                        updatedAliases?.find(a => a.name === alias)?.id ?? alias
-                    );
-                }
-                return alias;
-            });
-        } catch (error) {
-            throw error;
+        // Throw on failure to save alias
+        if (!result || (isArray(result) && result[0] === null)) {
+            throw new Error(`Failed to create Aliases`);
         }
+
+        // Refetch alias list
+        const updatedAliases = await mutateAliases();
+
+        // Rebuild formData.aliases as full alias objects
+        return formData.aliases.map(alias => {
+            if (typeof alias === "string") {
+                return updatedAliases?.find(a => a.name === alias)?.id ?? alias;
+            }
+            return alias;
+        });
     };
 
     const submitForm = async (formData: TeamCreateForm | TeamEditForm) => {

--- a/src/app/[locale]/account/profile/teams/components/CreateTeamForm/CreateTeamForm.tsx
+++ b/src/app/[locale]/account/profile/teams/components/CreateTeamForm/CreateTeamForm.tsx
@@ -3,11 +3,14 @@
 import { useEffect, useMemo, useState } from "react";
 import { FormProvider, useForm } from "react-hook-form";
 import { yupResolver } from "@hookform/resolvers/yup";
+import { isArray } from "lodash";
 import { useTranslations } from "next-intl";
 import { useParams, useRouter } from "next/navigation";
+import { Alias } from "@/interfaces/Alias";
 import { Option } from "@/interfaces/Option";
 import { Team, TeamEditForm, TeamCreateForm } from "@/interfaces/Team";
 import { User } from "@/interfaces/User";
+import { OptionsType } from "@/components/Autocomplete/Autocomplete";
 import Box from "@/components/Box";
 import Button from "@/components/Button";
 import Form from "@/components/Form";
@@ -22,6 +25,7 @@ import useGet from "@/hooks/useGet";
 import usePatch from "@/hooks/usePatch";
 import usePost from "@/hooks/usePost";
 import { useUnsavedChanges } from "@/hooks/useUnsavedChanges";
+import notificationService from "@/services/notification";
 import apis from "@/config/apis";
 import {
     questionBankField,
@@ -85,6 +89,17 @@ const CreateTeamForm = () => {
             shouldFetch: !!searchNameDebounced,
         }
     );
+
+    const {
+        data: aliasesData = [],
+        isLoading: isLoadingAliases,
+        mutate: mutateAliases,
+    } = useGet<Alias[]>(`${apis.aliasesV1Url}?perPage=-1`);
+
+    const addAlias = usePost<Alias>(apis.aliasesV1Url, {
+        successNotificationsOn: false,
+        errorNotificationsOn: false,
+    });
 
     const methods = useForm<TeamEditForm | TeamCreateForm>({
         mode: "onTouched",
@@ -161,6 +176,7 @@ const CreateTeamForm = () => {
             dar_modal_content,
             url,
             service,
+            aliases,
         } = existingTeamData;
 
         const teamData = {
@@ -173,6 +189,7 @@ const CreateTeamForm = () => {
             dar_modal_content,
             url,
             service,
+            aliases: aliases?.map(alias => alias.id),
         };
 
         if (team_logo) {
@@ -191,7 +208,42 @@ const CreateTeamForm = () => {
         successNotificationsOn: !file,
     });
 
-    const editTeam = usePatch<Partial<TeamEditForm>>(apis.teamsV1Url);
+    const editTeam = usePatch<Partial<TeamEditForm>>(apis.teamsV1Url, {
+        itemName: "Team",
+    });
+
+    const saveAliases = async (formData: TeamCreateForm | TeamEditForm) => {
+        try {
+            const newAliasNames = formData.aliases.filter(
+                alias => typeof alias === "string"
+            ) as string[];
+
+            // Create new aliases (POST requests)
+            const result = await Promise.all(
+                newAliasNames.map(name => addAlias({ name }))
+            );
+
+            // Throw on failure to save alias
+            if (!result || (isArray(result) && result[0] === null)) {
+                throw new Error(`Failed to create Aliases`);
+            }
+
+            // Refetch alias list
+            const updatedAliases = await mutateAliases();
+
+            // Rebuild formData.aliases as full alias objects
+            return formData.aliases.map(alias => {
+                if (typeof alias === "string") {
+                    return (
+                        updatedAliases?.find(a => a.name === alias)?.id ?? alias
+                    );
+                }
+                return alias;
+            });
+        } catch (error) {
+            throw error;
+        }
+    };
 
     const submitForm = async (formData: TeamCreateForm | TeamEditForm) => {
         if (isSaving) {
@@ -200,25 +252,46 @@ const CreateTeamForm = () => {
 
         setIsSaving(true);
 
-        const isCreatingTeam = !params?.teamId;
+        try {
+            const updatedAliases = await saveAliases(formData);
 
-        if (isCreatingTeam) {
-            const result = await createTeam({
-                ...teamCreateDefaultValues,
+            const formattedFormData = {
                 ...formData,
-            });
+                aliases: updatedAliases,
+            };
 
-            if (typeof result === "number" && file) {
-                setCreatedTeamId(result as string);
+            const isCreatingTeam = !params?.teamId;
+            let result;
+
+            if (isCreatingTeam) {
+                result = await createTeam({
+                    ...teamCreateDefaultValues,
+                    ...formattedFormData,
+                });
+
+                if (result) {
+                    if (typeof result === "number" && file) {
+                        setCreatedTeamId(result as string);
+                        setFileToBeUploaded(true);
+                    } else {
+                        push(Routes.ACCOUNT_TEAMS);
+                    }
+                } else {
+                    setIsSaving(false);
+                }
+            } else if (file) {
                 setFileToBeUploaded(true);
             } else {
-                push(Routes.ACCOUNT_TEAMS);
+                result = await editTeam(params.teamId, formattedFormData);
+                if (result) {
+                    push(Routes.ACCOUNT_TEAMS);
+                } else {
+                    setIsSaving(false);
+                }
             }
-        } else if (file) {
-            setFileToBeUploaded(true);
-        } else {
-            await editTeam(params.teamId, formData);
-            push(Routes.ACCOUNT_TEAMS);
+        } catch (error) {
+            notificationService.apiError("Failed to save team");
+            setIsSaving(false);
         }
     };
 
@@ -244,6 +317,24 @@ const CreateTeamForm = () => {
         setSearchName(value);
     };
 
+    const aliasOptions = useMemo(() => {
+        if (!aliasesData) return [];
+
+        return aliasesData.map(data => {
+            return {
+                label: data.name,
+                value: data.id,
+            };
+        }) as OptionsType[];
+    }, [aliasesData]);
+
+    const getOptions = (field: string) => {
+        if (field === "aliases") {
+            return aliasOptions;
+        }
+        return userOptions;
+    };
+
     const hydratedFormFields = useMemo(
         () =>
             teamFormFields.map(field => {
@@ -255,9 +346,18 @@ const CreateTeamForm = () => {
                         options: userOptions,
                     };
                 }
+                if (field.name === "aliases") {
+                    return {
+                        ...field,
+                        options: getOptions("aliases"),
+                        isLoadingOptions: isLoadingAliases,
+                        chipColor: "alias",
+                    };
+                }
+
                 return field;
             }),
-        [userOptions, isLoadingUsers]
+        [isLoadingUsers, userOptions, getOptions, isLoadingAliases]
     );
 
     if (isLoading) {

--- a/src/app/[locale]/account/profile/teams/components/CreateTeamForm/CreateTeamForm.tsx
+++ b/src/app/[locale]/account/profile/teams/components/CreateTeamForm/CreateTeamForm.tsx
@@ -3,7 +3,6 @@
 import { useEffect, useMemo, useState } from "react";
 import { FormProvider, useForm } from "react-hook-form";
 import { yupResolver } from "@hookform/resolvers/yup";
-import { isArray } from "lodash";
 import { useTranslations } from "next-intl";
 import { useParams, useRouter } from "next/navigation";
 import { Alias } from "@/interfaces/Alias";
@@ -223,7 +222,7 @@ const CreateTeamForm = () => {
         );
 
         // Throw on failure to save alias
-        if (!result || (isArray(result) && result[0] === null)) {
+        if (!result || (Array.isArray(result) && result[0] === null)) {
             throw new Error(`Failed to create Aliases`);
         }
 

--- a/src/components/Autocomplete/Autocomplete.tsx
+++ b/src/components/Autocomplete/Autocomplete.tsx
@@ -6,6 +6,7 @@ import {
     InputAdornment,
     ListItemText,
     Chip,
+    ChipPropsColorOverrides,
 } from "@mui/material";
 import MuiAutocomplete, {
     createFilterOptions,
@@ -48,6 +49,7 @@ export interface AutocompleteProps<T extends FieldValues> {
     isLoadingOptions?: boolean;
     noOptionsText?: string;
     clearIcon?: boolean;
+    chipColor?: keyof ChipPropsColorOverrides;
 }
 
 interface SearchOptions {
@@ -77,6 +79,7 @@ const Autocomplete = <T extends FieldValues>(props: AutocompleteProps<T>) => {
         noOptionsText = "No options",
         id,
         clearIcon = false,
+        chipColor,
         ...restProps
     } = props;
 
@@ -150,6 +153,7 @@ const Autocomplete = <T extends FieldValues>(props: AutocompleteProps<T>) => {
                             <Chip
                                 label={chipLabel || ""}
                                 size="small"
+                                {...(chipColor ? { color: chipColor } : {})}
                                 {...getTagProps({ index })}
                             />
                         );

--- a/src/config/apis.ts
+++ b/src/config/apis.ts
@@ -79,6 +79,7 @@ const apis = {
     programmingLanguagesV1Url: `${apiV1Url}/programming_languages`,
     enquiryThreadsV1Url: `${apiV1Url}/enquiry_threads`,
     doiSearchV1Url: `${apiV1Url}/search/doi`,
+    aliasesV1Url: `${apiV1Url}/aliases`,
 };
 
 export default apis;

--- a/src/config/forms/team.tsx
+++ b/src/config/forms/team.tsx
@@ -12,6 +12,7 @@ const defaultValues: TeamEditForm = {
     is_question_bank: false,
     introduction: "",
     dar_modal_content: "",
+    aliases: [],
 };
 
 const createDefaultValues: TeamCreateForm = {
@@ -28,6 +29,7 @@ const createDefaultValues: TeamCreateForm = {
     is_question_bank: false,
     introduction: "",
     dar_modal_content: "",
+    aliases: [],
 };
 
 const validationSchema = yup.object({
@@ -61,6 +63,20 @@ const formFields = [
         info: "Please ensure the name matches the standard format for organisation names",
         component: inputComponents.TextArea,
         required: true,
+    },
+    {
+        label: "Organisation aliases",
+        name: "aliases",
+        info: "Input alternative names the organisation is known by - these help users find the Team when searching the Gateway",
+        component: inputComponents.Autocomplete,
+        options: [],
+        canCreate: true,
+        multiple: true,
+        isOptionEqualToValue: (
+            option: { value: string | number; label: string },
+            value: string | number
+        ) => option.value === value,
+        getChipLabel,
     },
     {
         label: "Member of",

--- a/src/config/messages/en.json
+++ b/src/config/messages/en.json
@@ -1182,6 +1182,7 @@
             "publications": "Publications",
             "tools": "Tools",
             "serviceOfferings": "Service offerings",
+            "aliases": "Aliases",
             "components": {
                 "DataCustodianLinks": {
                     "usefulLinks": "Useful links:"

--- a/src/config/theme.ts
+++ b/src/config/theme.ts
@@ -77,6 +77,7 @@ declare module "@mui/material/Switch" {
 declare module "@mui/material/Chip" {
     interface ChipPropsColorOverrides {
         warningCustom: true;
+        alias: true;
     }
 }
 
@@ -174,6 +175,10 @@ const palette = {
         light: "#E9DB5D",
         dark: "#A29415",
         contrastText: colors.black,
+    },
+    alias: {
+        backgroundColor: colors.grey700,
+        contrastText: colors.white,
     },
 };
 
@@ -720,6 +725,13 @@ const theme = createTheme({
                     props: { color: "warningCustom" },
                     style: {
                         background: colors.orange300,
+                    },
+                },
+                {
+                    props: { color: "alias" },
+                    style: {
+                        backgroundColor: palette.alias.backgroundColor,
+                        color: palette.alias.contrastText,
                     },
                 },
             ],

--- a/src/interfaces/Alias.ts
+++ b/src/interfaces/Alias.ts
@@ -1,0 +1,4 @@
+export interface Alias {
+    id?: number;
+    name: string;
+}

--- a/src/interfaces/Team.ts
+++ b/src/interfaces/Team.ts
@@ -1,5 +1,6 @@
 import { Notification } from "@/interfaces/Notification";
 import { User } from "@/interfaces/User";
+import { Alias } from "./Alias";
 
 interface Team {
     id: number;
@@ -28,6 +29,7 @@ interface Team {
     introduction: string;
     url?: string;
     service?: string;
+    aliases?: Alias[];
 }
 
 interface TeamEditForm
@@ -42,6 +44,7 @@ interface TeamEditForm
         | "dar_modal_content"
     > {
     users: number[];
+    aliases: number[];
 }
 
 interface TeamCreateForm
@@ -62,6 +65,7 @@ interface TeamCreateForm
         | "dar_modal_content"
     > {
     users: number[];
+    aliases: number[];
 }
 
 export type { Team, TeamEditForm, TeamCreateForm };

--- a/src/interfaces/TeamSummary.ts
+++ b/src/interfaces/TeamSummary.ts
@@ -1,3 +1,4 @@
+import { Alias } from "@/interfaces/Alias";
 import { Collection } from "@/interfaces/Collection";
 import { DataUse } from "@/interfaces/DataUse";
 import { DataCustodianDataset } from "@/interfaces/Dataset";
@@ -18,6 +19,7 @@ interface TeamSummary {
     collections: Collection[];
     url: string | null;
     service: string[] | null;
+    aliases?: Alias[];
 }
 
 export type { TeamSummary };


### PR DESCRIPTION
## Screenshots (if relevant)
![image](https://github.com/user-attachments/assets/c12506f0-3582-4b14-ac02-68bb1a90c085)
![image](https://github.com/user-attachments/assets/7731f5d3-c3d9-4873-b61c-09cc06e617c2)
![image](https://github.com/user-attachments/assets/f5a7b209-62f3-4abd-b3e5-26a81e08036c)

## Describe your changes
- Add team alias autocomplete to team creation page
- Display aliases on data custodian page

## Issue ticket link
https://hdruk.atlassian.net/browse/GAT-6924

## Checklist before requesting a review

-   [ ] I have performed a self-review of my code
-   [ ] I have added appropriate unit tests
-   [ ] I have created mocks for unit tests (where appropriate)
-   [ ] The interface is responsive (where appropriate)
-   [ ] The interface is at least AA (where appropriate)
