### PR TITLE
fix!(GAT-5468): Search total now hidden if elastic doesn't return 100 results. 

### DIFF
--- a/src/app/[locale]/(logged-out)/search/components/Search/Search.tsx
+++ b/src/app/[locale]/(logged-out)/search/components/Search/Search.tsx
@@ -779,7 +779,7 @@ const Search = ({ filters, cohortDiscovery }: SearchProps) => {
         // Sometimes elastic_total > 100 while total < 100, so we avoid showing the total number
         // to make it seem more consistent
         return data && data.elastic_total > 100 && data.total <= 100 ? (
-            <ShowingXofX to={data?.to} from={data?.from} hideTotal={true} />
+            <ShowingXofX to={data?.to} from={data?.from} hideTotal />
         ) : (
             <ShowingXofX to={data?.to} from={data?.from} total={data?.total} />
         );

--- a/src/app/[locale]/(logged-out)/search/components/Search/Search.tsx
+++ b/src/app/[locale]/(logged-out)/search/components/Search/Search.tsx
@@ -778,17 +778,11 @@ const Search = ({ filters, cohortDiscovery }: SearchProps) => {
     const getXofX = () => {
         // Sometimes elastic_total > 100 while total < 100, so we avoid showing the total number
         // to make it seem more consistent
-        if (data && data.elastic_total > 100 && data.total <= 100) {
-            return <ShowingXofX to={data?.to} from={data?.from} />;
-        } else {
-            return (
-                <ShowingXofX
-                    to={data?.to}
-                    from={data?.from}
-                    total={data?.total}
-                />
-            );
-        }
+        return data && data.elastic_total > 100 && data.total <= 100 ? (
+            <ShowingXofX to={data?.to} from={data?.from} />
+        ) : (
+            <ShowingXofX to={data?.to} from={data?.from} total={data?.total} />
+        );
     };
     return (
         <Box

--- a/src/app/[locale]/(logged-out)/search/components/Search/Search.tsx
+++ b/src/app/[locale]/(logged-out)/search/components/Search/Search.tsx
@@ -779,7 +779,7 @@ const Search = ({ filters, cohortDiscovery }: SearchProps) => {
         // Sometimes elastic_total > 100 while total < 100, so we avoid showing the total number
         // to make it seem more consistent
         return data && data.elastic_total > 100 && data.total <= 100 ? (
-            <ShowingXofX to={data?.to} from={data?.from} />
+            <ShowingXofX to={data?.to} from={data?.from} hideTotal={true} />
         ) : (
             <ShowingXofX to={data?.to} from={data?.from} total={data?.total} />
         );

--- a/src/app/[locale]/(logged-out)/search/components/Search/Search.tsx
+++ b/src/app/[locale]/(logged-out)/search/components/Search/Search.tsx
@@ -774,6 +774,24 @@ const Search = ({ filters, cohortDiscovery }: SearchProps) => {
     const europePmcModalAction = () =>
         showDialog(PublicationSearchDialogMemoised);
 
+    const getXofX = () => {
+        if (data && data.path?.includes(queryParams.type)) {
+            // Sometimes elastic_total > 100 while total < 100, so we avoid showing the total number
+            // to make it seem more consistent
+            if (data.elastic_total > 100 && data.total <= 100) {
+                return <ShowingXofX to={data?.to} from={data?.from} />;
+            } else {
+                return (
+                    <ShowingXofX
+                        to={data?.to}
+                        from={data?.from}
+                        total={data?.total}
+                    />
+                );
+            }
+        }
+        return <></>;
+    };
     return (
         <Box
             display={{
@@ -946,14 +964,7 @@ const Search = ({ filters, cohortDiscovery }: SearchProps) => {
                                     id="result-summary"
                                     role="alert"
                                     aria-live="polite">
-                                    {data?.path?.includes(queryParams.type) &&
-                                        !!data?.elastic_total && (
-                                            <ShowingXofX
-                                                to={data?.to}
-                                                from={data?.from}
-                                                total={data?.total}
-                                            />
-                                        )}
+                                    {getXofX()}
                                     {data && data.elastic_total > 100 && (
                                         <ResultLimitText>
                                             {t("resultLimit")}

--- a/src/app/[locale]/(logged-out)/search/components/Search/Search.tsx
+++ b/src/app/[locale]/(logged-out)/search/components/Search/Search.tsx
@@ -791,7 +791,6 @@ const Search = ({ filters, cohortDiscovery }: SearchProps) => {
                 );
             }
         }
-        return <></>;
     };
     return (
         <Box

--- a/src/app/[locale]/(logged-out)/search/components/Search/Search.tsx
+++ b/src/app/[locale]/(logged-out)/search/components/Search/Search.tsx
@@ -776,20 +776,18 @@ const Search = ({ filters, cohortDiscovery }: SearchProps) => {
         showDialog(PublicationSearchDialogMemoised);
 
     const getXofX = () => {
-        if (data && data.path?.includes(queryParams.type)) {
-            // Sometimes elastic_total > 100 while total < 100, so we avoid showing the total number
-            // to make it seem more consistent
-            if (data.elastic_total > 100 && data.total <= 100) {
-                return <ShowingXofX to={data?.to} from={data?.from} />;
-            } else {
-                return (
-                    <ShowingXofX
-                        to={data?.to}
-                        from={data?.from}
-                        total={data?.total}
-                    />
-                );
-            }
+        // Sometimes elastic_total > 100 while total < 100, so we avoid showing the total number
+        // to make it seem more consistent
+        if (data && data.elastic_total > 100 && data.total <= 100) {
+            return <ShowingXofX to={data?.to} from={data?.from} />;
+        } else {
+            return (
+                <ShowingXofX
+                    to={data?.to}
+                    from={data?.from}
+                    total={data?.total}
+                />
+            );
         }
     };
     return (
@@ -964,7 +962,9 @@ const Search = ({ filters, cohortDiscovery }: SearchProps) => {
                                     id="result-summary"
                                     role="alert"
                                     aria-live="polite">
-                                    {getXofX()}
+                                    {data &&
+                                        data.path?.includes(queryParams.type) &&
+                                        getXofX()}
                                     {data && data.elastic_total > 100 && (
                                         <ResultLimitText>
                                             {t("resultLimit")}

--- a/src/components/ShowingXofX/ShowingXofX.tsx
+++ b/src/components/ShowingXofX/ShowingXofX.tsx
@@ -9,7 +9,8 @@ interface ShowingXofXProps {
 const ShowingXofX = ({ from, to, total }: ShowingXofXProps) => {
     return (
         <Typography sx={{ p: 0, mb: 1 }}>
-            Showing {from || 0}-{to || 0} of {total || 0} results
+            Showing {from || 0}-{to || 0}
+            {total && <> of {total} results</>}
         </Typography>
     );
 };

--- a/src/components/ShowingXofX/ShowingXofX.tsx
+++ b/src/components/ShowingXofX/ShowingXofX.tsx
@@ -4,13 +4,14 @@ interface ShowingXofXProps {
     from?: number;
     to?: number;
     total?: number;
+    hideTotal?: boolean;
 }
 
-const ShowingXofX = ({ from, to, total }: ShowingXofXProps) => {
+const ShowingXofX = ({ from, to, total, hideTotal }: ShowingXofXProps) => {
     return (
         <Typography sx={{ p: 0, mb: 1 }}>
-            Showing {from || 0}-{to || 0}
-            {total && <> of {total} results</>}
+            Showing {from || 0}-{to || 0}{" "}
+            {!hideTotal && <>of {total || 0} results</>}
         </Typography>
     );
 };


### PR DESCRIPTION
## Screenshots (if relevant)

![Screenshot 2025-05-28 at 11 24 45](https://github.com/user-attachments/assets/0969eefc-7f05-4058-a469-ded4644eb76f)

![Screenshot 2025-05-28 at 11 26 25](https://github.com/user-attachments/assets/75568717-f04a-49bc-b12c-2c5babb54d16)

## Describe your changes
Previously the search display would show "Showing 1-25 of 99 There are more than 100 results. We recommend refining your search." as the elastic total would be over 100 while the total returned would be less than 100. We now check for this condition and hide the total if this is the case

## Issue ticket link
https://hdruk.atlassian.net/browse/GAT-5468

## Checklist before requesting a review

-   [ ] I have performed a self-review of my code
-   [ ] I have added appropriate unit tests
-   [ ] I have created mocks for unit tests (where appropriate)
-   [ ] The interface is responsive (where appropriate)
-   [ ] The interface is at least AA (where appropriate)
