### PR TITLE
feat(GAT-6849): Default comment when Data Custodian changes DAR application from 'in review' to 'draft'

### DIFF
--- a/src/app/[locale]/account/(withoutLeftNav)/profile/data-access-requests/applications/[applicationId]/components/DarMessages.tsx
+++ b/src/app/[locale]/account/(withoutLeftNav)/profile/data-access-requests/applications/[applicationId]/components/DarMessages.tsx
@@ -1,6 +1,7 @@
 import { useEffect, useMemo, useRef, useState } from "react";
 import { useForm } from "react-hook-form";
 import { Divider, Typography } from "@mui/material";
+import DOMPurify from "dompurify";
 import { useTranslations } from "next-intl";
 import { DarReviewsResponse } from "@/interfaces/DataAccessReview";
 import Box from "@/components/Box";
@@ -289,7 +290,9 @@ const DarMessages = ({
                                 <Typography
                                     sx={{ pt: 1 }}
                                     dangerouslySetInnerHTML={{
-                                        __html: review.comment,
+                                        __html: DOMPurify.sanitize(
+                                            review.comment
+                                        ),
                                     }}
                                 />
                             </Box>

--- a/src/app/[locale]/account/(withoutLeftNav)/profile/data-access-requests/applications/[applicationId]/components/DarMessages.tsx
+++ b/src/app/[locale]/account/(withoutLeftNav)/profile/data-access-requests/applications/[applicationId]/components/DarMessages.tsx
@@ -1,7 +1,7 @@
 import { useEffect, useMemo, useRef, useState } from "react";
 import { useForm } from "react-hook-form";
 import { Divider, Typography } from "@mui/material";
-import DOMPurify from "dompurify";
+import DOMPurify from "isomorphic-dompurify";
 import { useTranslations } from "next-intl";
 import { DarReviewsResponse } from "@/interfaces/DataAccessReview";
 import Box from "@/components/Box";

--- a/src/app/[locale]/account/(withoutLeftNav)/profile/data-access-requests/applications/[applicationId]/components/DarMessages.tsx
+++ b/src/app/[locale]/account/(withoutLeftNav)/profile/data-access-requests/applications/[applicationId]/components/DarMessages.tsx
@@ -169,49 +169,60 @@ const DarMessages = ({
                     actionRequiredApplicant !== undefined &&
                     reviewComments && (
                         <>
-                            <Typography
-                                variant="h2"
-                                component="p"
-                                color={colors.purple500}>
-                                {t("status")}
-                            </Typography>
-                            <Typography
+                            <Box
                                 sx={{
                                     display: "flex",
-                                    color: colors.grey700,
+                                    alignItems: "center",
+                                    p: 0,
+                                    gap: 2,
                                     mb: 3,
                                 }}>
-                                {(actionRequiredApplicant && isResearcher) ||
-                                (!actionRequiredApplicant && !isResearcher) ? (
-                                    <ErrorIcon
-                                        sx={{
-                                            pr: 1,
-                                            color: colors.amber500,
-                                            height: ICON_SIZE,
-                                            width: ICON_SIZE,
-                                            p: 0,
-                                            mr: 1,
-                                        }}
-                                        fontSize="large"
-                                    />
-                                ) : (
-                                    <CheckCircleIcon
-                                        sx={{
-                                            pr: 1,
-                                            color: colors.green400,
-                                            height: ICON_SIZE,
-                                            width: ICON_SIZE,
-                                            p: 0,
-                                            mr: 1,
-                                        }}
-                                        fontSize="large"
-                                    />
-                                )}
-                                {t("actionRequiredBy")}
-                                {actionRequiredApplicant
-                                    ? "Applicant"
-                                    : "Custodian"}
-                            </Typography>
+                                <Typography
+                                    variant="h2"
+                                    component="p"
+                                    color={colors.purple500}
+                                    sx={{ m: 0 }}>
+                                    {t("status")}
+                                </Typography>
+                                <Typography
+                                    sx={{
+                                        display: "flex",
+                                        color: colors.grey700,
+                                    }}>
+                                    {(actionRequiredApplicant &&
+                                        isResearcher) ||
+                                    (!actionRequiredApplicant &&
+                                        !isResearcher) ? (
+                                        <ErrorIcon
+                                            sx={{
+                                                pr: 1,
+                                                color: colors.amber500,
+                                                height: ICON_SIZE,
+                                                width: ICON_SIZE,
+                                                p: 0,
+                                                mr: 1,
+                                            }}
+                                            fontSize="large"
+                                        />
+                                    ) : (
+                                        <CheckCircleIcon
+                                            sx={{
+                                                pr: 1,
+                                                color: colors.green400,
+                                                height: ICON_SIZE,
+                                                width: ICON_SIZE,
+                                                p: 0,
+                                                mr: 1,
+                                            }}
+                                            fontSize="large"
+                                        />
+                                    )}
+                                    {t("actionRequiredBy")}
+                                    {actionRequiredApplicant
+                                        ? "Applicant"
+                                        : "Custodian"}
+                                </Typography>
+                            </Box>
                         </>
                     )}
 

--- a/src/app/[locale]/account/(withoutLeftNav)/profile/data-access-requests/applications/[applicationId]/components/DarMessages.tsx
+++ b/src/app/[locale]/account/(withoutLeftNav)/profile/data-access-requests/applications/[applicationId]/components/DarMessages.tsx
@@ -168,62 +168,58 @@ const DarMessages = ({
                 {applicationInProgress &&
                     actionRequiredApplicant !== undefined &&
                     reviewComments && (
-                        <>
-                            <Box
+                        <Box
+                            sx={{
+                                display: "flex",
+                                alignItems: "center",
+                                p: 0,
+                                gap: 2,
+                                mb: 3,
+                            }}>
+                            <Typography
+                                variant="h2"
+                                component="p"
+                                color={colors.purple500}
+                                sx={{ m: 0 }}>
+                                {t("status")}
+                            </Typography>
+                            <Typography
                                 sx={{
                                     display: "flex",
-                                    alignItems: "center",
-                                    p: 0,
-                                    gap: 2,
-                                    mb: 3,
+                                    color: colors.grey700,
                                 }}>
-                                <Typography
-                                    variant="h2"
-                                    component="p"
-                                    color={colors.purple500}
-                                    sx={{ m: 0 }}>
-                                    {t("status")}
-                                </Typography>
-                                <Typography
-                                    sx={{
-                                        display: "flex",
-                                        color: colors.grey700,
-                                    }}>
-                                    {(actionRequiredApplicant &&
-                                        isResearcher) ||
-                                    (!actionRequiredApplicant &&
-                                        !isResearcher) ? (
-                                        <ErrorIcon
-                                            sx={{
-                                                pr: 1,
-                                                color: colors.amber500,
-                                                height: ICON_SIZE,
-                                                width: ICON_SIZE,
-                                                p: 0,
-                                                mr: 1,
-                                            }}
-                                            fontSize="large"
-                                        />
-                                    ) : (
-                                        <CheckCircleIcon
-                                            sx={{
-                                                pr: 1,
-                                                color: colors.green400,
-                                                height: ICON_SIZE,
-                                                width: ICON_SIZE,
-                                                p: 0,
-                                                mr: 1,
-                                            }}
-                                            fontSize="large"
-                                        />
-                                    )}
-                                    {t("actionRequiredBy")}
-                                    {actionRequiredApplicant
-                                        ? "Applicant"
-                                        : "Custodian"}
-                                </Typography>
-                            </Box>
-                        </>
+                                {(actionRequiredApplicant && isResearcher) ||
+                                (!actionRequiredApplicant && !isResearcher) ? (
+                                    <ErrorIcon
+                                        sx={{
+                                            pr: 1,
+                                            color: colors.amber500,
+                                            height: ICON_SIZE,
+                                            width: ICON_SIZE,
+                                            p: 0,
+                                            mr: 1,
+                                        }}
+                                        fontSize="large"
+                                    />
+                                ) : (
+                                    <CheckCircleIcon
+                                        sx={{
+                                            pr: 1,
+                                            color: colors.green400,
+                                            height: ICON_SIZE,
+                                            width: ICON_SIZE,
+                                            p: 0,
+                                            mr: 1,
+                                        }}
+                                        fontSize="large"
+                                    />
+                                )}
+                                {t("actionRequiredBy")}
+                                {actionRequiredApplicant
+                                    ? "Applicant"
+                                    : "Custodian"}
+                            </Typography>
+                        </Box>
                     )}
 
                 <Typography variant="h2" component="p" color={colors.purple500}>

--- a/src/app/[locale]/account/(withoutLeftNav)/profile/data-access-requests/applications/[applicationId]/components/DarMessages.tsx
+++ b/src/app/[locale]/account/(withoutLeftNav)/profile/data-access-requests/applications/[applicationId]/components/DarMessages.tsx
@@ -279,9 +279,12 @@ const DarMessages = ({
                                         )}
                                     </Typography>
                                 </Box>
-                                <Typography sx={{ pt: 1 }}>
-                                    {review.comment}
-                                </Typography>
+                                <Typography
+                                    sx={{ pt: 1 }}
+                                    dangerouslySetInnerHTML={{
+                                        __html: review.comment,
+                                    }}
+                                />
                             </Box>
                         ))
                     )}

--- a/src/config/messages/en.json
+++ b/src/config/messages/en.json
@@ -1700,7 +1700,8 @@
                 "rejectedInfo": "Any comments or notes regarding the rejection.",
                 "rejectedButtonText": "Reject",
                 "changeStatus": "Change Application Status",
-                "intro": "Use the options below to log your decision about this application."
+                "intro": "Use the options below to log your decision about this application.",
+                "defaultDraftMessage": "This is an automated notification that the application has been changed from 'In review' to 'Draft' status. No comment has been added by the Data Custodian."
             },
             "DarActionDialog": {
                 "actionPermanent": "I understand this action is permanent",

--- a/src/modules/DarManageDialog/DarManageDialog.tsx
+++ b/src/modules/DarManageDialog/DarManageDialog.tsx
@@ -112,7 +112,7 @@ const DarManageDialog = ({ applicationId }: DarManageDialogProps) => {
             payload: {
                 approval_status: null,
                 submission_status: DarApplicationStatus.DRAFT,
-                ...(draftComment && { comment: draftComment }),
+                comment: draftComment || t("defaultDraftMessage"),
             },
             redirectUrl: PATH_REDIRECT,
         },


### PR DESCRIPTION
## Screenshots (if relevant)
<img width="589" alt="image" src="https://github.com/user-attachments/assets/91913a85-5f27-4f59-8af7-9be9f0c18e15" />
<img width="894" alt="image" src="https://github.com/user-attachments/assets/bae306a4-bad9-4799-9291-1ced659eca65" />

## Describe your changes
Add default comment when Data Custodian changes DAR application from 'in review' to 'draft'
Update application status header styling 

## Issue ticket link
https://hdruk.atlassian.net/browse/GAT-6849

## Checklist before requesting a review

-   [ ] I have performed a self-review of my code
-   [ ] I have added appropriate unit tests
-   [ ] I have created mocks for unit tests (where appropriate)
-   [ ] The interface is responsive (where appropriate)
-   [ ] The interface is at least AA (where appropriate)
