### PR TITLE
feat(GAT-5792): Add cohort discovery button to data custodian page

### DIFF
--- a/src/app/[locale]/(logged-out)/data-custodian/[dataCustodianId]/components/ActionBar/ActionBar.tsx
+++ b/src/app/[locale]/(logged-out)/data-custodian/[dataCustodianId]/components/ActionBar/ActionBar.tsx
@@ -3,6 +3,7 @@
 import { Box, Button } from "@mui/material";
 import { useTranslations } from "next-intl";
 import { usePathname, useRouter } from "next/navigation";
+import { PageTemplatePromo } from "@/interfaces/Cms";
 import { SearchCategory } from "@/interfaces/Search";
 import { Team } from "@/interfaces/Team";
 import BackButton from "@/components/BackButton";
@@ -10,15 +11,21 @@ import useAuth from "@/hooks/useAuth";
 import useGeneralEnquiry from "@/hooks/useGeneralEnquiry";
 import { SpeechBubbleIcon } from "@/consts/customIcons";
 import { RouteName } from "@/consts/routeName";
-import { ActionBarWrapper } from "./ActionBar.styles";
 import CohortDiscoveryButton from "@/app/[locale]/(logged-out)/about/cohort-discovery/components/CohortDiscoveryButton";
+import { ActionBarWrapper } from "./ActionBar.styles";
 
 const TRANSLATION_PATH = "pages.dataCustodian.components.ActionBar";
 interface ActionBarProps {
     team: Pick<Team, "id" | "name" | "member_of">;
+    cohortDiscovery: PageTemplatePromo | null;
+    cohortDiscoveryEnabled: boolean;
 }
 
-const ActionBar = ({ team }: ActionBarProps) => {
+const ActionBar = ({
+    team,
+    cohortDiscovery,
+    cohortDiscoveryEnabled,
+}: ActionBarProps) => {
     const router = useRouter();
     const path = usePathname();
     const { isLoggedIn } = useAuth();
@@ -63,14 +70,20 @@ const ActionBar = ({ team }: ActionBarProps) => {
                     startIcon={<SpeechBubbleIcon />}>
                     {t("enquire")}
                 </Button>
-                <CohortDiscoveryButton />
-                <Button
-                    color="primary"
-                    variant="contained"
-                    onClick={handleGeneralEnquiryClick}
-                    startIcon={<SpeechBubbleIcon />}>
-                    {t("cohortDiscovery")}
-                </Button>
+                {cohortDiscovery?.template?.promofields?.ctaLink && (
+                    <CohortDiscoveryButton
+                        ctaLink={
+                            cohortDiscovery?.template?.promofields?.ctaLink
+                        }
+                        disabledOuter={!cohortDiscoveryEnabled}
+                        tooltipOverride={
+                            cohortDiscoveryEnabled
+                                ? ""
+                                : t("cohortDiscoveryDisabled")
+                        }
+                        showDatasetExplanatoryTooltip
+                    />
+                )}
             </Box>
         </ActionBarWrapper>
     );

--- a/src/app/[locale]/(logged-out)/data-custodian/[dataCustodianId]/components/ActionBar/ActionBar.tsx
+++ b/src/app/[locale]/(logged-out)/data-custodian/[dataCustodianId]/components/ActionBar/ActionBar.tsx
@@ -11,6 +11,7 @@ import useGeneralEnquiry from "@/hooks/useGeneralEnquiry";
 import { SpeechBubbleIcon } from "@/consts/customIcons";
 import { RouteName } from "@/consts/routeName";
 import { ActionBarWrapper } from "./ActionBar.styles";
+import CohortDiscoveryButton from "@/app/[locale]/(logged-out)/about/cohort-discovery/components/CohortDiscoveryButton";
 
 const TRANSLATION_PATH = "pages.dataCustodian.components.ActionBar";
 interface ActionBarProps {
@@ -61,6 +62,14 @@ const ActionBar = ({ team }: ActionBarProps) => {
                     onClick={handleGeneralEnquiryClick}
                     startIcon={<SpeechBubbleIcon />}>
                     {t("enquire")}
+                </Button>
+                <CohortDiscoveryButton />
+                <Button
+                    color="primary"
+                    variant="contained"
+                    onClick={handleGeneralEnquiryClick}
+                    startIcon={<SpeechBubbleIcon />}>
+                    {t("cohortDiscovery")}
                 </Button>
             </Box>
         </ActionBarWrapper>

--- a/src/app/[locale]/(logged-out)/data-custodian/[dataCustodianId]/page.tsx
+++ b/src/app/[locale]/(logged-out)/data-custodian/[dataCustodianId]/page.tsx
@@ -46,11 +46,9 @@ export default async function DataCustodianItemPage({
 
     const cohortDiscovery = await getCohortDiscovery();
 
-    const promises = [];
-
-    for (const dataset of data.datasets) {
-        promises.push(getDataset(cookieStore, dataset.id.toString()));
-    }
+    const promises = data.datasets.map(x =>
+        getDataset(cookieStore, x.id.toString())
+    );
 
     const datasets = await Promise.all(promises);
 

--- a/src/app/[locale]/(logged-out)/data-custodian/[dataCustodianId]/page.tsx
+++ b/src/app/[locale]/(logged-out)/data-custodian/[dataCustodianId]/page.tsx
@@ -15,11 +15,7 @@ import Typography from "@/components/Typography";
 import ActiveListSidebar from "@/modules/ActiveListSidebar";
 import { StaticImages } from "@/config/images";
 import { AspectRatioImage } from "@/config/theme";
-import {
-    getDataCustodianNetworks,
-    getDataset,
-    getTeamSummary,
-} from "@/utils/api";
+import { getDataset, getTeamSummary } from "@/utils/api";
 import { getCohortDiscovery } from "@/utils/cms";
 import metaData from "@/utils/metadata";
 import ActionBar from "./components/ActionBar";
@@ -50,16 +46,15 @@ export default async function DataCustodianItemPage({
 
     const cohortDiscovery = await getCohortDiscovery();
 
-    let enableCohortDiscovery = false;
+    const promises = [];
 
     for (const dataset of data.datasets) {
-        const datasetInfo = await getDataset(
-            cookieStore,
-            dataset.id.toString()
-        );
-        enableCohortDiscovery =
-            enableCohortDiscovery || datasetInfo.is_cohort_discovery;
+        promises.push(getDataset(cookieStore, dataset.id.toString()));
     }
+
+    const datasets = await Promise.all(promises);
+
+    const enableCohortDiscovery = datasets.some(x => x.is_cohort_discovery);
 
     const populatedSections = dataCustodianFields.filter(section =>
         section.fields.some(field => !isEmpty(get(data, field.path)))

--- a/src/app/[locale]/(logged-out)/data-custodian/[dataCustodianId]/page.tsx
+++ b/src/app/[locale]/(logged-out)/data-custodian/[dataCustodianId]/page.tsx
@@ -15,7 +15,12 @@ import Typography from "@/components/Typography";
 import ActiveListSidebar from "@/modules/ActiveListSidebar";
 import { StaticImages } from "@/config/images";
 import { AspectRatioImage } from "@/config/theme";
-import { getTeamSummary } from "@/utils/api";
+import {
+    getDataCustodianNetworks,
+    getDataset,
+    getTeamSummary,
+} from "@/utils/api";
+import { getCohortDiscovery } from "@/utils/cms";
 import metaData from "@/utils/metadata";
 import ActionBar from "./components/ActionBar";
 import DataCustodianContent from "./components/DataCustodianContent";
@@ -42,6 +47,19 @@ export default async function DataCustodianItemPage({
     });
 
     if (!data) notFound();
+
+    const cohortDiscovery = await getCohortDiscovery();
+
+    let enableCohortDiscovery = false;
+
+    for (const dataset of data.datasets) {
+        const datasetInfo = await getDataset(
+            cookieStore,
+            dataset.id.toString()
+        );
+        enableCohortDiscovery =
+            enableCohortDiscovery || datasetInfo.is_cohort_discovery;
+    }
 
     const populatedSections = dataCustodianFields.filter(section =>
         section.fields.some(field => !isEmpty(get(data, field.path)))
@@ -77,6 +95,8 @@ export default async function DataCustodianItemPage({
                             name: data.name,
                             member_of: data.member_of,
                         }}
+                        cohortDiscovery={cohortDiscovery}
+                        cohortDiscoveryEnabled={enableCohortDiscovery}
                     />
                     <Box
                         sx={{

--- a/src/config/messages/en.json
+++ b/src/config/messages/en.json
@@ -1190,7 +1190,8 @@
                 "ActionBar": {
                     "label": "Back",
                     "enquire": "Make a general enquiry",
-                    "cohortDiscovery": "Start a Cohort Discovery query"
+                    "cohortDiscoveryEnabled": "Start a Cohort Discovery query",
+                    "cohortDiscoveryDisabled": "This data custodian does not support Cohort Discovery"
                 },
                 "CollectionsContent": {
                     "heading": "Collections ({ length })"

--- a/src/config/messages/en.json
+++ b/src/config/messages/en.json
@@ -1189,7 +1189,8 @@
                 },
                 "ActionBar": {
                     "label": "Back",
-                    "enquire": "Make a general enquiry"
+                    "enquire": "Make a general enquiry",
+                    "cohortDiscovery": "Start a Cohort Discovery query"
                 },
                 "CollectionsContent": {
                     "heading": "Collections ({ length })"


### PR DESCRIPTION
## Screenshots (if relevant)
![Screenshot 2025-05-30 at 11 53 14](https://github.com/user-attachments/assets/75629610-1ffc-4514-9cc5-3f25782f05ab)

![Screenshot 2025-05-30 at 12 20 10](https://github.com/user-attachments/assets/b44fd342-4aa4-49cd-8ddc-fe86107e1abf)

https://github.com/user-attachments/assets/afb18378-3257-477e-ac1c-b8c8c1448cf3

## Describe your changes

## Issue ticket link
https://hdruk.atlassian.net/browse/GAT-6463

## Checklist before requesting a review

-   [ ] I have performed a self-review of my code
-   [ ] I have added appropriate unit tests
-   [ ] I have created mocks for unit tests (where appropriate)
-   [ ] The interface is responsive (where appropriate)
-   [ ] The interface is at least AA (where appropriate)
