### PR TITLE
fix(GAT-7267): Don't make access call when redirecting to profile page.

### DIFF
--- a/src/app/[locale]/(logged-out)/about/cohort-discovery/components/CohortDiscoveryButton/CohortDiscoveryButton.tsx
+++ b/src/app/[locale]/(logged-out)/about/cohort-discovery/components/CohortDiscoveryButton/CohortDiscoveryButton.tsx
@@ -49,17 +49,20 @@ const CohortDiscoveryButton = ({
         }
     );
 
-    const { data: accessData } = useGet<accessRequestType>(
-        `${apis.cohortRequestsV1Url}/access`,
-        {
-            shouldFetch: isClicked && userData?.request_status === "APPROVED",
-        }
-    );
-
     const openAthensInvalid =
         isLoggedIn &&
         user?.provider === "open-athens" &&
         !user?.secondary_email;
+
+    const { data: accessData } = useGet<accessRequestType>(
+        `${apis.cohortRequestsV1Url}/access`,
+        {
+            shouldFetch:
+                isClicked &&
+                !openAthensInvalid &&
+                userData?.request_status === "APPROVED",
+        }
+    );
 
     useEffect(() => {
         if (isClicked) {


### PR DESCRIPTION
## Screenshots (if relevant)

## Describe your changes
We were seeing an error message show to the user under certain circumstances when they are directed to set their secondary email. This small fix stops that call being made unnecessarily.

## Issue ticket link
https://hdruk.atlassian.net/browse/GAT-7267

## Checklist before requesting a review

-   [x] I have performed a self-review of my code
-   [ ] I have added appropriate unit tests
-   [ ] I have created mocks for unit tests (where appropriate)
-   [ ] The interface is responsive (where appropriate)
-   [ ] The interface is at least AA (where appropriate)
