### PR TITLE
feat(GAT-7134): convert helper text to hover-over

### DIFF
--- a/src/app/[locale]/(logged-out)/data-use/[dataUseId]/components/DataUseContent/DataUseContent.tsx
+++ b/src/app/[locale]/(logged-out)/data-use/[dataUseId]/components/DataUseContent/DataUseContent.tsx
@@ -9,7 +9,7 @@ import BoxContainer from "@/components/BoxContainer";
 import EllipsisCharacterLimit from "@/components/EllipsisCharacterLimit";
 import Link from "@/components/Link";
 import Paper from "@/components/Paper";
-import TooltipIcon from "@/components/TooltipIcon";
+import TooltipText from "@/components/TooltipText";
 import Typography from "@/components/Typography";
 import { RouteName } from "@/consts/routeName";
 import { formatDate } from "@/utils/date";
@@ -171,7 +171,7 @@ const DataUseContent = ({
                                         <BoxContainer
                                             sx={{
                                                 gridTemplateColumns: {
-                                                    desktop: "repeat(3, 1fr)",
+                                                    desktop: "repeat(4, 1fr)",
                                                 },
                                                 gap: 1,
                                                 "&:not(:last-of-type)": {
@@ -187,7 +187,7 @@ const DataUseContent = ({
                                                     p: 0,
                                                 }}>
                                                 {!field.hideTooltip ? (
-                                                    <TooltipIcon
+                                                    <TooltipText
                                                         content={t(
                                                             `${label}${TOOLTIP_SUFFIX}`
                                                         )}

--- a/src/app/[locale]/(logged-out)/dataset/[datasetId]/components/DatasetContent/DatasetContent.tsx
+++ b/src/app/[locale]/(logged-out)/dataset/[datasetId]/components/DatasetContent/DatasetContent.tsx
@@ -15,7 +15,7 @@ import { MarkDownSanitizedWithHtml } from "@/components/MarkDownSanitizedWithHTM
 import Paper from "@/components/Paper";
 import StructuralMetadataAccordion from "@/components/StructuralMetadataAccordion";
 import Table from "@/components/Table";
-import TooltipIcon from "@/components/TooltipIcon";
+import TooltipText from "@/components/TooltipText";
 import Typography from "@/components/Typography";
 import useModal from "@/hooks/useModal";
 import { RouteName } from "@/consts/routeName";
@@ -57,11 +57,7 @@ const getColumns = (notReportedText: string) =>
                     </p>
                 ),
             header: () => (
-                <TooltipIcon
-                    content={column.tooltip}
-                    label={column.header}
-                    buttonSx={{ p: 0 }}
-                />
+                <TooltipText content={column.tooltip} label={column.header} />
             ),
         })
     );
@@ -298,13 +294,9 @@ const DatasetContent = ({
                                                     p: 0,
                                                 }}>
                                                 {field.tooltip ? (
-                                                    <TooltipIcon
+                                                    <TooltipText
                                                         content={field.tooltip}
                                                         label={field.label}
-                                                        buttonSx={{
-                                                            p: 0,
-                                                            mr: 1,
-                                                        }}
                                                     />
                                                 ) : (
                                                     field.label

--- a/src/app/[locale]/(logged-out)/search/components/FilterPanel/FilterPanel.tsx
+++ b/src/app/[locale]/(logged-out)/search/components/FilterPanel/FilterPanel.tsx
@@ -2,6 +2,7 @@
 
 import { useEffect, useMemo, useState } from "react";
 import { useForm } from "react-hook-form";
+import { Tooltip } from "@mui/material";
 import { get } from "lodash";
 import { useTranslations } from "next-intl";
 import { useSearchParams } from "next/navigation";
@@ -12,7 +13,6 @@ import Box from "@/components/Box";
 import FilterSection from "@/components/FilterSection";
 import FilterSectionRadio from "@/components/FilterSectionRadio";
 import MapUK, { SelectedType } from "@/components/MapUK/MapUK";
-import TooltipIcon from "@/components/TooltipIcon";
 import Typography from "@/components/Typography";
 import useGTMEvent from "@/hooks/useGTMEvent";
 import {
@@ -560,15 +560,17 @@ const FilterPanel = ({
                                     width: "100%",
                                     pr: 3.25,
                                 }}>
-                                <Typography fontWeight="400" fontSize={20}>
-                                    {t(label)}
-                                </Typography>
-                                <TooltipIcon
-                                    content={t(`${label}${TOOLTIP_SUFFIX}`)}
-                                    label=""
-                                    buttonSx={{ p: 0 }}
-                                    size="small"
-                                />
+                                <Tooltip
+                                    describeChild
+                                    title={t(`${label}${TOOLTIP_SUFFIX}`)}>
+                                    <div>
+                                        <Typography
+                                            fontWeight="400"
+                                            fontSize={20}>
+                                            {t(label)}
+                                        </Typography>
+                                    </div>
+                                </Tooltip>
                             </Box>
                         }
                         onChange={() =>

--- a/src/app/[locale]/(logged-out)/search/components/FilterSectionInlineSwitch/FilterSectionInlineSwitch.tsx
+++ b/src/app/[locale]/(logged-out)/search/components/FilterSectionInlineSwitch/FilterSectionInlineSwitch.tsx
@@ -1,11 +1,11 @@
 "use client";
 
 import { useId } from "react";
+import { Tooltip } from "@mui/material";
 import MuiSwitch from "@mui/material/Switch";
 import { useTranslations } from "next-intl";
 import { BucketCheckbox } from "@/interfaces/Filter";
 import Box from "@/components/Box";
-import TooltipIcon from "@/components/TooltipIcon";
 import Typography from "@/components/Typography";
 
 const TRANSLATION_PATH = "pages.search.components.FilterPanel.filters";
@@ -34,32 +34,26 @@ const FilterSectionInlineSwitch = ({
                 justifyContent: "space-between",
                 alignItems: "center",
             }}>
-            <Typography
-                fontWeight="400"
-                fontSize="20px"
-                component="label"
-                for={id}>
-                {t(label)}
-            </Typography>
-            <Box
-                sx={{
-                    display: "flex",
-                    gap: 1,
-                    p: 0,
-                }}>
-                <TooltipIcon
-                    buttonSx={{ p: 0 }}
-                    size="small"
-                    label=""
-                    content={t(`${label}${TOOLTIP_SUFFIX}`)}
-                />
-                <MuiSwitch
-                    id={id}
-                    disableRipple
-                    onChange={handleRadioChange}
-                    checked={!!selectedFilters[filterItem.label]?.length}
-                />
-            </Box>
+            <Tooltip
+                describeChild
+                tabIndex={0}
+                title={t(`${label}${TOOLTIP_SUFFIX}`)}>
+                <div>
+                    <Typography
+                        fontWeight="400"
+                        fontSize={20}
+                        component="label"
+                        for={id}>
+                        {t(label)}
+                    </Typography>
+                </div>
+            </Tooltip>
+            <MuiSwitch
+                id={id}
+                disableRipple
+                onChange={handleRadioChange}
+                checked={!!selectedFilters[filterItem.label]?.length}
+            />
         </Box>
     );
 };

--- a/src/app/[locale]/(logged-out)/search/components/ResultCardDataUse/ResultCardDataUse.styles.ts
+++ b/src/app/[locale]/(logged-out)/search/components/ResultCardDataUse/ResultCardDataUse.styles.ts
@@ -5,6 +5,7 @@ export const ResultRow = styled("div")(({ theme }) => ({
     display: "flex",
     flexDirection: "row",
     alignItems: "center",
+    marginBottom: 8,
 
     "&:first-of-type": {
         marginTop: theme.spacing(2),

--- a/src/app/[locale]/(logged-out)/search/components/ResultCardDataUse/ResultCardDataUse.tsx
+++ b/src/app/[locale]/(logged-out)/search/components/ResultCardDataUse/ResultCardDataUse.tsx
@@ -6,7 +6,7 @@ import Button from "@/components/Button";
 import EllipsisCharacterLimit from "@/components/EllipsisCharacterLimit";
 import EllipsisLineLimit from "@/components/EllipsisLineLimit";
 import Link from "@/components/Link";
-import TooltipIcon from "@/components/TooltipIcon";
+import TooltipText from "@/components/TooltipText";
 import Typography from "@/components/Typography";
 import DataUseDetailsDialog from "@/modules/DataUseDetailsDialog";
 import useDialog from "@/hooks/useDialog";
@@ -102,7 +102,7 @@ const ResultCardDataUse = ({ result }: ResultCardProps) => {
                         <>
                             <ResultRow>
                                 <ResultRowCategory>
-                                    <TooltipIcon
+                                    <TooltipText
                                         content={t(
                                             `leadOrganisation${TOOLTIP_SUFFIX}`
                                         )}
@@ -125,7 +125,7 @@ const ResultCardDataUse = ({ result }: ResultCardProps) => {
 
                             <ResultRow>
                                 <ResultRowCategory>
-                                    <TooltipIcon
+                                    <TooltipText
                                         content={t(`datasets${TOOLTIP_SUFFIX}`)}
                                         label={t("datasets")}
                                     />
@@ -183,7 +183,7 @@ const ResultCardDataUse = ({ result }: ResultCardProps) => {
 
                             <ResultRow>
                                 <ResultRowCategory>
-                                    <TooltipIcon
+                                    <TooltipText
                                         content={t(
                                             `dataCustodian${TOOLTIP_SUFFIX}`
                                         )}

--- a/src/app/[locale]/(logged-out)/search/components/ResultsTable/ResultsTable.tsx
+++ b/src/app/[locale]/(logged-out)/search/components/ResultsTable/ResultsTable.tsx
@@ -125,7 +125,7 @@ const getColumns = ({
                 describeChild
                 title={translations.dataProviderTooltip}
                 tabIndex={0}>
-                <span>{translations.dataProviderLabel}</span>
+                <>{translations.dataProviderLabel}</>
             </Tooltip>
         ),
         size: 120,
@@ -146,7 +146,7 @@ const getColumns = ({
                 describeChild
                 title={translations.populationSizeTooltip}
                 tabIndex={0}>
-                <span>{translations.populationSizeLabel}</span>
+                <>{translations.populationSizeLabel}</>
             </Tooltip>
         ),
         size: 120,
@@ -164,7 +164,7 @@ const getColumns = ({
                 describeChild
                 title={translations.dateRangePublisherTooltip}
                 tabIndex={0}>
-                <span>{translations.dateRangePublisherLabel}</span>
+                <>{translations.dateRangePublisherLabel}</>
             </Tooltip>
         ),
         size: 120,
@@ -182,7 +182,7 @@ const getColumns = ({
                 describeChild
                 title={translations.accessServiceTooltip}
                 tabIndex={0}>
-                <span>{translations.accessServiceLabel}</span>
+                <>{translations.accessServiceLabel}</>
             </Tooltip>
         ),
         size: 120,
@@ -200,7 +200,7 @@ const getColumns = ({
                 describeChild
                 title={translations.dataStandardTooltip}
                 tabIndex={0}>
-                <span>{translations.dataStandardLabel}</span>
+                <>{translations.dataStandardLabel}</>
             </Tooltip>
         ),
         size: 120,
@@ -221,7 +221,7 @@ const getColumns = ({
                 describeChild
                 title={translations.cohortDiscoveryTooltip}
                 tabIndex={0}>
-                <span>{translations.cohortDiscoveryLabel}</span>
+                <>{translations.cohortDiscoveryLabel}</>
             </Tooltip>
         ),
         size: 120,
@@ -242,7 +242,7 @@ const getColumns = ({
                 describeChild
                 title={translations.containsTissueTooltip}
                 tabIndex={0}>
-                <span>{translations.containsTissueLabel}</span>
+                <>{translations.containsTissueLabel}</>
             </Tooltip>
         ),
         size: 120,
@@ -263,7 +263,7 @@ const getColumns = ({
                 describeChild
                 title={translations.hasTechnicalMetadataTooltip}
                 tabIndex={0}>
-                <span>{translations.hasTechnicalMetadataLabel}</span>
+                <>{translations.hasTechnicalMetadataLabel}</>
             </Tooltip>
         ),
         size: 120,

--- a/src/app/[locale]/(logged-out)/search/components/ResultsTable/ResultsTable.tsx
+++ b/src/app/[locale]/(logged-out)/search/components/ResultsTable/ResultsTable.tsx
@@ -125,7 +125,7 @@ const getColumns = ({
                 describeChild
                 title={translations.dataProviderTooltip}
                 tabIndex={0}>
-                <>{translations.dataProviderLabel}</>
+                {translations.dataProviderLabel}
             </Tooltip>
         ),
         size: 120,
@@ -146,7 +146,7 @@ const getColumns = ({
                 describeChild
                 title={translations.populationSizeTooltip}
                 tabIndex={0}>
-                <>{translations.populationSizeLabel}</>
+                {translations.populationSizeLabel}
             </Tooltip>
         ),
         size: 120,
@@ -164,7 +164,7 @@ const getColumns = ({
                 describeChild
                 title={translations.dateRangePublisherTooltip}
                 tabIndex={0}>
-                <>{translations.dateRangePublisherLabel}</>
+                {translations.dateRangePublisherLabel}
             </Tooltip>
         ),
         size: 120,
@@ -182,7 +182,7 @@ const getColumns = ({
                 describeChild
                 title={translations.accessServiceTooltip}
                 tabIndex={0}>
-                <>{translations.accessServiceLabel}</>
+                {translations.accessServiceLabel}
             </Tooltip>
         ),
         size: 120,
@@ -200,7 +200,7 @@ const getColumns = ({
                 describeChild
                 title={translations.dataStandardTooltip}
                 tabIndex={0}>
-                <>{translations.dataStandardLabel}</>
+                {translations.dataStandardLabel}
             </Tooltip>
         ),
         size: 120,
@@ -221,7 +221,7 @@ const getColumns = ({
                 describeChild
                 title={translations.cohortDiscoveryTooltip}
                 tabIndex={0}>
-                <>{translations.cohortDiscoveryLabel}</>
+                {translations.cohortDiscoveryLabel}
             </Tooltip>
         ),
         size: 120,
@@ -242,7 +242,7 @@ const getColumns = ({
                 describeChild
                 title={translations.containsTissueTooltip}
                 tabIndex={0}>
-                <>{translations.containsTissueLabel}</>
+                {translations.containsTissueLabel}
             </Tooltip>
         ),
         size: 120,
@@ -263,7 +263,7 @@ const getColumns = ({
                 describeChild
                 title={translations.hasTechnicalMetadataTooltip}
                 tabIndex={0}>
-                <>{translations.hasTechnicalMetadataLabel}</>
+                {translations.hasTechnicalMetadataLabel}
             </Tooltip>
         ),
         size: 120,

--- a/src/app/[locale]/(logged-out)/search/components/ResultsTable/ResultsTable.tsx
+++ b/src/app/[locale]/(logged-out)/search/components/ResultsTable/ResultsTable.tsx
@@ -1,3 +1,4 @@
+import { Tooltip } from "@mui/material";
 import { createColumnHelper } from "@tanstack/react-table";
 import { get } from "lodash";
 import { useTranslations } from "next-intl";
@@ -10,7 +11,6 @@ import EllipsisLineLimit from "@/components/EllipsisLineLimit";
 import Link from "@/components/Link";
 import Paper from "@/components/Paper";
 import Table from "@/components/Table";
-import TooltipIcon from "@/components/TooltipIcon";
 import useAuth from "@/hooks/useAuth";
 import useGet from "@/hooks/useGet";
 import apis from "@/config/apis";
@@ -121,12 +121,9 @@ const getColumns = ({
             );
         },
         header: () => (
-            <TooltipIcon
-                buttonSx={{ p: 0 }}
-                label={translations.dataProviderLabel}
-                size="small"
-                content={translations.dataProviderTooltip}
-            />
+            <Tooltip title={translations.dataProviderTooltip} tabIndex={0}>
+                {translations.dataProviderLabel}
+            </Tooltip>
         ),
         size: 120,
     }),
@@ -142,12 +139,9 @@ const getColumns = ({
             </div>
         ),
         header: () => (
-            <TooltipIcon
-                buttonSx={{ p: 0 }}
-                size="small"
-                label={translations.populationSizeLabel}
-                content={translations.populationSizeTooltip}
-            />
+            <Tooltip title={translations.populationSizeTooltip} tabIndex={0}>
+                {translations.populationSizeLabel}
+            </Tooltip>
         ),
         size: 120,
     }),
@@ -160,12 +154,11 @@ const getColumns = ({
             </div>
         ),
         header: () => (
-            <TooltipIcon
-                buttonSx={{ p: 0 }}
-                size="small"
-                label={translations.dateRangePublisherLabel}
-                content={translations.dateRangePublisherTooltip}
-            />
+            <Tooltip
+                title={translations.dateRangePublisherTooltip}
+                tabIndex={0}>
+                {translations.dateRangePublisherLabel}
+            </Tooltip>
         ),
         size: 120,
     }),
@@ -178,12 +171,9 @@ const getColumns = ({
             </div>
         ),
         header: () => (
-            <TooltipIcon
-                buttonSx={{ p: 0 }}
-                label={translations.accessServiceLabel}
-                size="small"
-                content={translations.accessServiceTooltip}
-            />
+            <Tooltip title={translations.accessServiceTooltip} tabIndex={0}>
+                {translations.accessServiceLabel}
+            </Tooltip>
         ),
         size: 120,
     }),
@@ -196,12 +186,9 @@ const getColumns = ({
             </div>
         ),
         header: () => (
-            <TooltipIcon
-                buttonSx={{ p: 0 }}
-                size="small"
-                label={translations.dataStandardLabel}
-                content={translations.dataStandardTooltip}
-            />
+            <Tooltip title={translations.dataStandardTooltip} tabIndex={0}>
+                {translations.dataStandardLabel}
+            </Tooltip>
         ),
         size: 120,
     }),
@@ -217,12 +204,9 @@ const getColumns = ({
             );
         },
         header: () => (
-            <TooltipIcon
-                buttonSx={{ p: 0 }}
-                label={translations.cohortDiscoveryLabel}
-                size="small"
-                content={translations.cohortDiscoveryTooltip}
-            />
+            <Tooltip title={translations.cohortDiscoveryTooltip} tabIndex={0}>
+                {translations.cohortDiscoveryLabel}
+            </Tooltip>
         ),
         size: 120,
     }),
@@ -238,12 +222,9 @@ const getColumns = ({
             );
         },
         header: () => (
-            <TooltipIcon
-                buttonSx={{ p: 0 }}
-                label={translations.containsTissueLabel}
-                size="small"
-                content={translations.containsTissueTooltip}
-            />
+            <Tooltip title={translations.containsTissueTooltip} tabIndex={0}>
+                {translations.containsTissueLabel}
+            </Tooltip>
         ),
         size: 120,
     }),
@@ -259,12 +240,11 @@ const getColumns = ({
             );
         },
         header: () => (
-            <TooltipIcon
-                buttonSx={{ p: 0 }}
-                label={translations.hasTechnicalMetadataLabel}
-                size="small"
-                content={translations.hasTechnicalMetadataTooltip}
-            />
+            <Tooltip
+                title={translations.hasTechnicalMetadataTooltip}
+                tabIndex={0}>
+                {translations.hasTechnicalMetadataLabel}
+            </Tooltip>
         ),
         size: 120,
     }),

--- a/src/app/[locale]/(logged-out)/search/components/ResultsTable/ResultsTable.tsx
+++ b/src/app/[locale]/(logged-out)/search/components/ResultsTable/ResultsTable.tsx
@@ -121,8 +121,11 @@ const getColumns = ({
             );
         },
         header: () => (
-            <Tooltip title={translations.dataProviderTooltip} tabIndex={0}>
-                {translations.dataProviderLabel}
+            <Tooltip
+                describeChild
+                title={translations.dataProviderTooltip}
+                tabIndex={0}>
+                <span>{translations.dataProviderLabel}</span>
             </Tooltip>
         ),
         size: 120,
@@ -139,8 +142,11 @@ const getColumns = ({
             </div>
         ),
         header: () => (
-            <Tooltip title={translations.populationSizeTooltip} tabIndex={0}>
-                {translations.populationSizeLabel}
+            <Tooltip
+                describeChild
+                title={translations.populationSizeTooltip}
+                tabIndex={0}>
+                <span>{translations.populationSizeLabel}</span>
             </Tooltip>
         ),
         size: 120,
@@ -155,9 +161,10 @@ const getColumns = ({
         ),
         header: () => (
             <Tooltip
+                describeChild
                 title={translations.dateRangePublisherTooltip}
                 tabIndex={0}>
-                {translations.dateRangePublisherLabel}
+                <span>{translations.dateRangePublisherLabel}</span>
             </Tooltip>
         ),
         size: 120,
@@ -171,8 +178,11 @@ const getColumns = ({
             </div>
         ),
         header: () => (
-            <Tooltip title={translations.accessServiceTooltip} tabIndex={0}>
-                {translations.accessServiceLabel}
+            <Tooltip
+                describeChild
+                title={translations.accessServiceTooltip}
+                tabIndex={0}>
+                <span>{translations.accessServiceLabel}</span>
             </Tooltip>
         ),
         size: 120,
@@ -186,8 +196,11 @@ const getColumns = ({
             </div>
         ),
         header: () => (
-            <Tooltip title={translations.dataStandardTooltip} tabIndex={0}>
-                {translations.dataStandardLabel}
+            <Tooltip
+                describeChild
+                title={translations.dataStandardTooltip}
+                tabIndex={0}>
+                <span>{translations.dataStandardLabel}</span>
             </Tooltip>
         ),
         size: 120,
@@ -204,8 +217,11 @@ const getColumns = ({
             );
         },
         header: () => (
-            <Tooltip title={translations.cohortDiscoveryTooltip} tabIndex={0}>
-                {translations.cohortDiscoveryLabel}
+            <Tooltip
+                describeChild
+                title={translations.cohortDiscoveryTooltip}
+                tabIndex={0}>
+                <span>{translations.cohortDiscoveryLabel}</span>
             </Tooltip>
         ),
         size: 120,
@@ -222,8 +238,11 @@ const getColumns = ({
             );
         },
         header: () => (
-            <Tooltip title={translations.containsTissueTooltip} tabIndex={0}>
-                {translations.containsTissueLabel}
+            <Tooltip
+                describeChild
+                title={translations.containsTissueTooltip}
+                tabIndex={0}>
+                <span>{translations.containsTissueLabel}</span>
             </Tooltip>
         ),
         size: 120,
@@ -241,9 +260,10 @@ const getColumns = ({
         },
         header: () => (
             <Tooltip
+                describeChild
                 title={translations.hasTechnicalMetadataTooltip}
                 tabIndex={0}>
-                {translations.hasTechnicalMetadataLabel}
+                <span>{translations.hasTechnicalMetadataLabel}</span>
             </Tooltip>
         ),
         size: 120,

--- a/src/app/[locale]/(logged-out)/search/components/TabTooltip/TabTooltip.tsx
+++ b/src/app/[locale]/(logged-out)/search/components/TabTooltip/TabTooltip.tsx
@@ -1,6 +1,5 @@
 import { ReactNode } from "react";
-import { Box } from "@mui/material";
-import TooltipIcon from "@/components/TooltipIcon";
+import { Tooltip } from "@mui/material";
 
 interface TabTooltipProps {
     children: ReactNode;
@@ -9,10 +8,9 @@ interface TabTooltipProps {
 
 const TabTooltip = ({ children, content }: TabTooltipProps) => {
     return (
-        <Box sx={{ display: "flex", gap: 1 }}>
+        <Tooltip describeChild title={content} size="small">
             {children}
-            <TooltipIcon content={content} buttonSx={{ p: 0 }} size="small" />
-        </Box>
+        </Tooltip>
     );
 };
 

--- a/src/app/[locale]/(logged-out)/tool/[toolId]/components/ToolContent/ToolContent.tsx
+++ b/src/app/[locale]/(logged-out)/tool/[toolId]/components/ToolContent/ToolContent.tsx
@@ -8,7 +8,7 @@ import BoxContainer from "@/components/BoxContainer";
 import Link from "@/components/Link";
 import { MarkDownSanitizedWithHtml } from "@/components/MarkDownSanitizedWithHTML";
 import Paper from "@/components/Paper";
-import TooltipIcon from "@/components/TooltipIcon";
+import TooltipText from "@/components/TooltipText";
 import Typography from "@/components/Typography";
 import { formatDate } from "@/utils/date";
 import { ToolSection, FieldType } from "../../config";
@@ -102,7 +102,7 @@ const ToolContent = ({
                                     <BoxContainer
                                         sx={{
                                             gridTemplateColumns: {
-                                                desktop: "repeat(3, 1fr)",
+                                                desktop: "repeat(4, 1fr)",
                                             },
                                             gap: 1,
                                             "&:not(:last-of-type)": {
@@ -118,7 +118,7 @@ const ToolContent = ({
                                                 p: 0,
                                             }}>
                                             {!field.hideTooltip ? (
-                                                <TooltipIcon
+                                                <TooltipText
                                                     content={t(
                                                         `${label}${TOOLTIP_SUFFIX}`
                                                     )}

--- a/src/components/StructuralMetadataAccordion/StructuralMetadataAccordion.tsx
+++ b/src/components/StructuralMetadataAccordion/StructuralMetadataAccordion.tsx
@@ -18,7 +18,6 @@ import {
 import Accordion from "@/components/Accordion";
 import Box from "@/components/Box";
 import TooltipText from "@/components/TooltipText";
-import Typography from "@/components/Typography";
 import { colors } from "@/config/theme";
 import { formatTextWithLinks } from "@/utils/dataset";
 

--- a/src/components/StructuralMetadataAccordion/StructuralMetadataAccordion.tsx
+++ b/src/components/StructuralMetadataAccordion/StructuralMetadataAccordion.tsx
@@ -17,7 +17,7 @@ import {
 } from "@/interfaces/Dataset";
 import Accordion from "@/components/Accordion";
 import Box from "@/components/Box";
-import TooltipIcon from "@/components/TooltipIcon";
+import TooltipText from "@/components/TooltipText";
 import Typography from "@/components/Typography";
 import { colors } from "@/config/theme";
 import { formatTextWithLinks } from "@/utils/dataset";
@@ -100,20 +100,13 @@ const StructuralMetadataAccordion = ({
                             sx={{
                                 p: 0,
                                 display: "flex",
-                                justifyContent: "space-between",
-                                alignItems: "center",
                                 width: "100%",
                             }}>
-                            <Typography variant="h4" sx={{ m: 0 }}>
-                                {item.name}
-                            </Typography>
-                            {item.description && (
-                                <TooltipIcon
-                                    buttonSx={{ p: 0, pr: 2 }}
-                                    content={item.description}
-                                    label=""
-                                />
-                            )}
+                            <TooltipText
+                                content={item?.description}
+                                label={item?.name}
+                                variant="h4"
+                            />
                         </Box>
                     }
                     contents={

--- a/src/components/TooltipText/TooltipText.stories.tsx
+++ b/src/components/TooltipText/TooltipText.stories.tsx
@@ -1,0 +1,26 @@
+import type { Meta, StoryObj } from "@storybook/react";
+import Box from "@/components/Box";
+import TooltipText from "./TooltipText";
+
+const meta: Meta<typeof TooltipText> = {
+    component: TooltipText,
+    tags: ["autodocs"],
+    decorators: [
+        Story => (
+            <Box sx={{ width: 200 }}>
+                <Story />
+            </Box>
+        ),
+    ],
+};
+
+export default meta;
+
+type Story = StoryObj<typeof TooltipText>;
+
+export const Default: Story = {
+    args: {
+        content: "This is the tooltip",
+        label: <div>This is the anchor</div>,
+    },
+};

--- a/src/components/TooltipText/TooltipText.test.tsx
+++ b/src/components/TooltipText/TooltipText.test.tsx
@@ -1,0 +1,25 @@
+import React from "react";
+import userEvent from "@testing-library/user-event";
+import TooltipText from "@/components/TooltipText";
+import { render, screen, waitFor } from "@/utils/testUtils";
+
+describe("TooltipText", () => {
+    it("should render anchor and content", async () => {
+        render(
+            <TooltipText
+                label="tooltip label"
+                content={<div>tooltip content</div>}
+            />
+        );
+        const label = screen.getByText("tooltip label");
+        expect(label).toBeInTheDocument();
+
+        const anchor = screen.getByTestId("tooltipText");
+        userEvent.hover(anchor);
+
+        await waitFor(() => {
+            const title = screen.getByText("tooltip content");
+            expect(title).toBeInTheDocument();
+        });
+    });
+});

--- a/src/components/TooltipText/TooltipText.tsx
+++ b/src/components/TooltipText/TooltipText.tsx
@@ -1,42 +1,37 @@
 import { ReactNode } from "react";
-import { Box, SxProps, Tooltip, Typography } from "@mui/material";
+import { SxProps, Tooltip, Typography } from "@mui/material";
 
 interface TooltipTextProps {
     label?: ReactNode;
     content: ReactNode;
     size?: "medium" | "small" | "inherit" | "large";
-    boxSx?: SxProps;
+    sx?: SxProps;
 }
 
 const TooltipText = ({
     label,
     content,
     size = "medium",
-    boxSx,
+    sx,
     ...restProps
 }: TooltipTextProps) => {
     return (
-        <Box
-            display="flex"
-            alignItems="center"
-            justifyContent="space-between"
-            sx={boxSx}>
-            <Tooltip describeChild title={content}>
-                <Typography
-                    data-testid="tooltipText"
-                    sx={{
-                        fontSize: size,
-                        fontWeight: 600,
-                        textDecoration: "underline",
-                        textDecorationStyle: "dashed",
-                        textDecorationThickness: "1px",
-                        textUnderlineOffset: 5,
-                    }}
-                    {...restProps}>
-                    {label}
-                </Typography>
-            </Tooltip>
-        </Box>
+        <Tooltip describeChild tabIndex={0} title={content}>
+            <Typography
+                data-testid="tooltipText"
+                sx={{
+                    fontSize: size,
+                    fontWeight: 600,
+                    textDecoration: "underline",
+                    textDecorationStyle: "dashed",
+                    textDecorationThickness: "1px",
+                    textUnderlineOffset: 5,
+                    ...sx,
+                }}
+                {...restProps}>
+                {label}
+            </Typography>
+        </Tooltip>
     );
 };
 

--- a/src/components/TooltipText/TooltipText.tsx
+++ b/src/components/TooltipText/TooltipText.tsx
@@ -21,7 +21,7 @@ const TooltipText = ({
             alignItems="center"
             justifyContent="space-between"
             sx={boxSx}>
-            <Tooltip title={content}>
+            <Tooltip describeChild title={content}>
                 <Typography
                     data-testid="tooltipText"
                     sx={{

--- a/src/components/TooltipText/TooltipText.tsx
+++ b/src/components/TooltipText/TooltipText.tsx
@@ -13,6 +13,7 @@ const TooltipText = ({
     content,
     size = "medium",
     boxSx,
+    ...restProps
 }: TooltipTextProps) => {
     return (
         <Box
@@ -30,7 +31,8 @@ const TooltipText = ({
                         textDecorationStyle: "dashed",
                         textDecorationThickness: "1px",
                         textUnderlineOffset: 5,
-                    }}>
+                    }}
+                    {...restProps}>
                     {label}
                 </Typography>
             </Tooltip>

--- a/src/components/TooltipText/TooltipText.tsx
+++ b/src/components/TooltipText/TooltipText.tsx
@@ -1,0 +1,41 @@
+import { ReactNode } from "react";
+import { Box, SxProps, Tooltip, Typography } from "@mui/material";
+
+interface TooltipTextProps {
+    label?: ReactNode;
+    content: ReactNode;
+    size?: "medium" | "small" | "inherit" | "large";
+    boxSx?: SxProps;
+}
+
+const TooltipText = ({
+    label,
+    content,
+    size = "medium",
+    boxSx,
+}: TooltipTextProps) => {
+    return (
+        <Box
+            display="flex"
+            alignItems="center"
+            justifyContent="space-between"
+            sx={boxSx}>
+            <Tooltip title={content}>
+                <Typography
+                    data-testid="tooltipText"
+                    sx={{
+                        fontSize: size,
+                        fontWeight: 600,
+                        textDecoration: "underline",
+                        textDecorationStyle: "dashed",
+                        textDecorationThickness: "1px",
+                        textUnderlineOffset: 5,
+                    }}>
+                    {label}
+                </Typography>
+            </Tooltip>
+        </Box>
+    );
+};
+
+export default TooltipText;

--- a/src/components/TooltipText/index.ts
+++ b/src/components/TooltipText/index.ts
@@ -1,0 +1,3 @@
+import TooltipText from "./TooltipText";
+
+export default TooltipText;

--- a/src/config/messages/en.json
+++ b/src/config/messages/en.json
@@ -1074,7 +1074,7 @@
                     "populationSizeNotReported": "not reported",
                     "populationSize": "Dataset population size",
                     "dateLabel": "Date range",
-                    "leadOrganisation": "Lead applicant organisation",
+                    "leadOrganisation": "Lead Organisation",
                     "leadOrganisationTooltip": "The name of the legal entity that signs the contract to access the data",
                     "datasets": "Datasets",
                     "datasetsTooltip": "The name of the dataset(s) being accessed",

--- a/src/config/theme.ts
+++ b/src/config/theme.ts
@@ -716,6 +716,9 @@ const theme = createTheme({
                         backgroundColor: palette.error.main,
                         opacity: 1,
                     },
+                    "& .Mui-focusVisible": {
+                        outline: `3px solid ${palette.primary.main}`,
+                    },
                 },
             },
         },


### PR DESCRIPTION
## Screenshots (if relevant)

https://github.com/user-attachments/assets/f87e7bfe-f9bd-4d0e-88fd-7a549caaf0e4


## Describe your changes
Remove 'i' icon on entity tabs, filters, table-view column headings, and Data Use search cards, replacing with hover-over on objects.

Remove 'i' icon and change styling of headers with hover-over on Dataset, Data Use and Tool landing pages.

## Issue ticket link
https://hdruk.atlassian.net/browse/GAT-7134

## Checklist before requesting a review

-   [ ] I have performed a self-review of my code
-   [ ] I have added appropriate unit tests
-   [ ] I have created mocks for unit tests (where appropriate)
-   [ ] The interface is responsive (where appropriate)
-   [ ] The interface is at least AA (where appropriate)
