### PR TITLE
fix(GAT-7290): set empty stirng ot undefined

### DIFF
--- a/src/app/[locale]/account/team/[teamId]/(withoutLeftNav)/datasets/components/CreateDataset/CreateDataset.tsx
+++ b/src/app/[locale]/account/team/[teamId]/(withoutLeftNav)/datasets/components/CreateDataset/CreateDataset.tsx
@@ -48,6 +48,7 @@ import {
     DATA_CUSTODIAN_NAME,
     DATASET_TYPE,
     INITIAL_FORM_SECTION,
+    PATIENT_PATHWAY_DESCRIPTION,
     STRUCTURAL_METADATA_FORM_SECTION,
     SUBMISSON_FORM_SECTION,
 } from "@/consts/createDataset";
@@ -316,6 +317,13 @@ const CreateDataset = ({
 
     const watchId = watch(DATA_CUSTODIAN_ID);
     const watchType = watch(DATASET_TYPE);
+
+    const patientPathway = watch(PATIENT_PATHWAY_DESCRIPTION);
+    useEffect(() => {
+        if (patientPathway === "") {
+            setValue(PATIENT_PATHWAY_DESCRIPTION, undefined);
+        }
+    }, [patientPathway, setValue]);
 
     // This is a bit of a hack
     // - the data_custodian_id is coming back as a persistent ID due to a confusing in naming/bug

--- a/src/consts/createDataset.ts
+++ b/src/consts/createDataset.ts
@@ -4,6 +4,7 @@ const STRUCTURAL_METADATA_FORM_SECTION = "structuralMetadata";
 const DATASET_TYPE = "Dataset type";
 const DATA_CUSTODIAN_ID = "identifier";
 const DATA_CUSTODIAN_NAME = "Name of data provider";
+const PATIENT_PATHWAY_DESCRIPTION = "Patient pathway description";
 const DATA_CUSTODIAN_FIELDS = [
     "Name of data provider",
     "Organisation Description",
@@ -20,4 +21,5 @@ export {
     DATA_CUSTODIAN_ID,
     DATA_CUSTODIAN_NAME,
     DATA_CUSTODIAN_FIELDS,
+    PATIENT_PATHWAY_DESCRIPTION,
 };


### PR DESCRIPTION
## Screenshots (if relevant)

## Describe your changes
So the issue, onload the initial value is undefined, then after typing and deleting it becomes an empty string.
This then triggers yups validation because its an empty string not undefined.

This was horrible, this is 100% a bug in schema-to-yup. I tried forcing it to have `excludeEmptyString`as true which is a valid yup prop and schema-to-yup honours it. but it ignores it because of the min: 2... I then tried setting it in the textarea component.. mui has to have an empty string once its been set... so i can't override it...
## Issue ticket link
https://hdruk.atlassian.net/jira/software/c/projects/GAT/boards/51?assignee=712020%3A05fbbf0f-9386-469a-a212-84cfbf9cc587&selectedIssue=GAT-7290
## Checklist before requesting a review

-   [ ] I have performed a self-review of my code
-   [ ] I have added appropriate unit tests
-   [ ] I have created mocks for unit tests (where appropriate)
-   [ ] The interface is responsive (where appropriate)
-   [ ] The interface is at least AA (where appropriate)
