### PR TITLE
feat(GAT-7092): Synthetic data web link tweaks

### DIFF
--- a/mocks/data/dataset/v1/dataset.data.ts
+++ b/mocks/data/dataset/v1/dataset.data.ts
@@ -170,7 +170,7 @@ const generatePageDataSetV1 = (): Dataset => {
                                     ],
                                 },
                             ],
-                            syntheticDataWebLink: null,
+                            syntheticDataWebLink: [],
                         },
                     },
                 },

--- a/src/app/[locale]/(logged-out)/dataset/[datasetId]/components/DatasetMindMap/DatasetMindMap.tsx
+++ b/src/app/[locale]/(logged-out)/dataset/[datasetId]/components/DatasetMindMap/DatasetMindMap.tsx
@@ -80,7 +80,7 @@ const DatasetMindMap = ({
                 if (node.id === "node-synthetic") {
                     href =
                         data.metadata.metadata?.structuralMetadata
-                            ?.syntheticDataWebLink;
+                            ?.syntheticDataWebLink[0];
 
                     if (!href) {
                         emptyNodes.push(node.id);

--- a/src/app/[locale]/(logged-out)/dataset/[datasetId]/components/DatasetStats/DatasetStats.tsx
+++ b/src/app/[locale]/(logged-out)/dataset/[datasetId]/components/DatasetStats/DatasetStats.tsx
@@ -45,8 +45,12 @@ const DatasetStats = ({ data }: { data: Partial<VersionItem> }) => {
             unit: t("populationUnit"),
             iconSrc: "/images/dataset/bar-chart.svg",
             largeStatText: true,
-            targetScroll: "anchor-Observations",
-            enableScroll: !!populationStat,
+            targetScroll: "anchor-Documentation",
+            enableScroll: populationStat
+                ? populationStat.toString() === "-1"
+                    ? false
+                    : !!populationStat
+                : false,
         },
         {
             title: t("yearTitle"),

--- a/src/app/[locale]/(logged-out)/dataset/[datasetId]/config.tsx
+++ b/src/app/[locale]/(logged-out)/dataset/[datasetId]/config.tsx
@@ -71,7 +71,7 @@ const datasetFields: DatasetSection[] = [
             },
             {
                 path: "metadata.metadata.structuralMetadata.syntheticDataWebLink",
-                type: FieldType.TEXT,
+                type: FieldType.LINK_LIST,
                 label: "Synthetic data web link",
                 tooltip:
                     "Website with information on your synthetic dataset creation, or the location where a synthetic version of the dataset can be accessed.",


### PR DESCRIPTION
## Screenshots (if relevant)
![image](https://github.com/user-attachments/assets/bb498df7-b00b-43d9-8d28-ce0e0a47f18b)

## Describe your changes
Noticed no dataset landing pages were loading on dev. This is because the synthetic web link had been added incorrectly to the mindmap diagram, though is only now apparent due to BE changes which now populate this field. 

## Issue ticket link
https://hdruk.atlassian.net/browse/GAT-7092

## Checklist before requesting a review

-   [ ] I have performed a self-review of my code
-   [ ] I have added appropriate unit tests
-   [ ] I have created mocks for unit tests (where appropriate)
-   [ ] The interface is responsive (where appropriate)
-   [ ] The interface is at least AA (where appropriate)
