### PR TITLE
feat(GAT-7133): Responsive tabs on search UI

### DIFF
--- a/src/app/[locale]/(logged-out)/search/components/Search/Search.tsx
+++ b/src/app/[locale]/(logged-out)/search/components/Search/Search.tsx
@@ -109,6 +109,7 @@ import searchFormConfig, {
     sortByOptionsPublications,
     sortByOptionsTool,
 } from "@/config/forms/search";
+import { colors } from "@/config/theme";
 import { ChevronThinIcon, DownloadIcon, TableIcon } from "@/consts/icons";
 import { PostLoginActions } from "@/consts/postLoginActions";
 import { RouteName } from "@/consts/routeName";
@@ -911,7 +912,11 @@ const Search = ({ filters, cohortDiscovery }: SearchProps) => {
                     />
                 )}
                 {isMobile && (
-                    <>
+                    <Box
+                        sx={{
+                            borderBottom: `3px solid ${colors.green400}`,
+                            width: "100%",
+                        }}>
                         <Button
                             aria-controls="tab-menu"
                             aria-haspopup="true"
@@ -919,8 +924,13 @@ const Search = ({ filters, cohortDiscovery }: SearchProps) => {
                             aria-label="Open to show search type options"
                             title="Open to show search type options"
                             color="secondary"
-                            sx={{ backgroundColor: "white" }}
-                            endIcon={<ChevronThinIcon />}>
+                            sx={{
+                                backgroundColor: "white",
+                                fontSize: "15px",
+                                fontWeight: 600,
+                                "&:hover": { background: "white" },
+                            }}
+                            endIcon={<ChevronThinIcon color="primary" />}>
                             {categoryDropdowns[queryParams.type]}
                         </Button>
                         <Menu
@@ -939,14 +949,15 @@ const Search = ({ filters, cohortDiscovery }: SearchProps) => {
                                             updatePath("type", item.value);
                                             handleClose();
                                         }}
-                                        key={item.label}
-                                        value={item.value}>
-                                        {item.label}
+                                        key={categoryDropdowns[item.value]}
+                                        value={item.value}
+                                        sx={{ fontSize: "15px" }}>
+                                        {categoryDropdowns[item.value]}
                                     </MenuItem>
                                 );
                             })}
                         </Menu>
-                    </>
+                    </Box>
                 )}
             </Box>
             <BoxContainer

--- a/src/app/[locale]/(logged-out)/search/components/Search/Search.tsx
+++ b/src/app/[locale]/(logged-out)/search/components/Search/Search.tsx
@@ -857,16 +857,7 @@ const Search = ({ filters, cohortDiscovery }: SearchProps) => {
                     />
                 </Box>
             </Box>
-            <ActionBar>
-                <Box sx={{ flex: 1, p: 0 }}>
-                    <FilterChips
-                        label={t("filtersApplied")}
-                        selectedFilters={selectedFilters}
-                        handleDelete={removeFilter}
-                        filterCategory={FILTER_TYPE_MAPPING[queryParams.type]}
-                    />
-                </Box>
-            </ActionBar>
+
             <Box
                 sx={{
                     width: "100%",
@@ -956,6 +947,14 @@ const Search = ({ filters, cohortDiscovery }: SearchProps) => {
                             m: 2,
                         }}
                         aria-busy={isSearching}>
+                        <FilterChips
+                            label={t("filtersApplied")}
+                            selectedFilters={selectedFilters}
+                            handleDelete={removeFilter}
+                            filterCategory={
+                                FILTER_TYPE_MAPPING[queryParams.type]
+                            }
+                        />
                         {!isSearching && !isEuropePmcSearchNoQuery && (
                             <>
                                 <Box

--- a/src/app/[locale]/(logged-out)/search/components/Search/Search.tsx
+++ b/src/app/[locale]/(logged-out)/search/components/Search/Search.tsx
@@ -861,21 +861,30 @@ const Search = ({ filters, cohortDiscovery }: SearchProps) => {
             <Box
                 sx={{
                     width: "100%",
+                    display: "flex",
+                    alignItems: "center",
+                    backgroundColor: "white",
                 }}>
                 <Tabs
                     centered
                     tabs={categoryTabs}
                     tabBoxSx={{
-                        paddingLeft: 4,
-                        paddingRight: 4,
-                        borderBottom: `1px solid ${colors.green400}`,
-                        marginBottom: 1,
+                        paddingLeft: "5px",
+                        paddingRight: "5px",
+                        // borderBottom: `1px solid ${colors.green400}`,
+                        // marginBottom: 1,
                     }}
                     rootBoxSx={{ padding: 0 }}
-                    variant={TabVariant.STANDARD}
+                    variant={TabVariant.SEARCH}
+                    sx={{}}
                     paramName={TYPE_FIELD}
                     persistParams={false}
                     tabVariant="scrollable"
+                    // sx={{
+                    //     [`& .${tabsClasses.scroller}`]: {
+                    //         "&.MuiTabs-scrollableX": { flexGrow: "0" },
+                    //     },
+                    // }}
                     handleChange={(_, value) =>
                         resetQueryParamState(value as SearchCategory)
                     }
@@ -969,18 +978,16 @@ const Search = ({ filters, cohortDiscovery }: SearchProps) => {
                                     )}
                                 </Box>
                                 <ActionBar>
-                                    <Box sx={{ flex: 1, p: 0 }}>
-                                        <Box
-                                            sx={{ display: "flex" }}
-                                            id="result-summary"
-                                            role="alert"
-                                            aria-live="polite">
-                                            {data &&
-                                                data.path?.includes(
-                                                    queryParams.type
-                                                ) &&
-                                                getXofX()}
-                                        </Box>
+                                    <Box
+                                        sx={{ display: "flex" }}
+                                        id="result-summary"
+                                        role="alert"
+                                        aria-live="polite">
+                                        {data &&
+                                            data.path?.includes(
+                                                queryParams.type
+                                            ) &&
+                                            getXofX()}
                                     </Box>
                                     {!isMobile && !isTabletOrLaptop && (
                                         <Box sx={{ display: "flex", gap: 2 }}>

--- a/src/app/[locale]/(logged-out)/search/components/Search/Search.tsx
+++ b/src/app/[locale]/(logged-out)/search/components/Search/Search.tsx
@@ -881,9 +881,10 @@ const Search = ({ filters, cohortDiscovery }: SearchProps) => {
                         marginBottom: 1,
                     }}
                     rootBoxSx={{ padding: 0 }}
-                    variant={TabVariant.LARGE}
+                    variant={TabVariant.STANDARD}
                     paramName={TYPE_FIELD}
                     persistParams={false}
+                    tabVariant="scrollable"
                     handleChange={(_, value) =>
                         resetQueryParamState(value as SearchCategory)
                     }

--- a/src/app/[locale]/(logged-out)/search/components/Search/Search.tsx
+++ b/src/app/[locale]/(logged-out)/search/components/Search/Search.tsx
@@ -164,6 +164,12 @@ const Search = ({ filters, cohortDiscovery }: SearchProps) => {
     const isTabletOrLaptop = useMediaQuery(
         theme.breakpoints.between("tablet", "desktop")
     );
+    // This is a bit hacky because this is the exact width of the tabs with content,
+    // so it's susceptible to changes in font size or content.
+    // This is required because there's a documented feature (i.e. bug) in MUI Tabs
+    // that they can't simultaneously support centering AND scroll bars, so we have
+    // to do it ourselves.
+    const scrollableTabs = useMediaQuery("(max-width:1372px)");
 
     const redirectPath = searchParams
         ? `${pathname}?${searchParams.toString()}`
@@ -895,17 +901,18 @@ const Search = ({ filters, cohortDiscovery }: SearchProps) => {
                 }}>
                 {!isMobile && (
                     <Tabs
-                        centered
                         tabs={categoryTabs}
                         tabBoxSx={{
-                            paddingLeft: "5px",
-                            paddingRight: "5px",
+                            paddingLeft: !scrollableTabs ? "45px" : "5px",
+                            paddingRight: !scrollableTabs ? "45px" : "5px",
                         }}
                         rootBoxSx={{ padding: 0 }}
                         variant={TabVariant.SEARCH}
                         paramName={TYPE_FIELD}
                         persistParams={false}
-                        tabVariant="scrollable"
+                        tabVariant={scrollableTabs ? "scrollable" : "standard"}
+                        scrollButtons="on"
+                        centered={!scrollableTabs}
                         handleChange={(_, value) => {
                             resetQueryParamState(value as SearchCategory);
                         }}

--- a/src/components/Tabs/Tabs.stories.tsx
+++ b/src/components/Tabs/Tabs.stories.tsx
@@ -44,6 +44,6 @@ export const Default: Story = {
 };
 
 export const Large: Story = {
-    args: { variant: TabVariant.LARGE, renderTabContent: false },
+    args: { variant: TabVariant.SEARCH, renderTabContent: false },
     render: args => <WrapperComponent {...args} />,
 };

--- a/src/components/Tabs/Tabs.styles.ts
+++ b/src/components/Tabs/Tabs.styles.ts
@@ -2,6 +2,10 @@ import { css } from "@emotion/react";
 import { colors } from "@/config/theme";
 
 export const tabsStyle = {
+    searchTabList: css({
+        boxShadow: "none",
+    }),
+
     normal: () =>
         css({
             "&.MuiTab-root": {

--- a/src/components/Tabs/Tabs.styles.ts
+++ b/src/components/Tabs/Tabs.styles.ts
@@ -2,45 +2,6 @@ import { css } from "@emotion/react";
 import { colors } from "@/config/theme";
 
 export const tabsStyle = {
-    // tabList: css({
-    //     boxShadow: "none",
-
-    //     ".MuiTabs-indicator": {
-    //         display: "none",
-    //     },
-
-    //     ".MuiTabs-root": {
-    //         minHeight: "40px",
-    //     },
-    // }),
-
-    tab: () =>
-        css({
-            "&.MuiTab-root.Mui-selected": {
-                background: colors.green400,
-                color: colors.white,
-                boxShadow: "inherit",
-            },
-
-            "&.MuiTab-root": {
-                flex: 1,
-                borderRadius: "20px 20px 0px 0px",
-                fontSize: "20px",
-                marginTop: "2px",
-                boxShadow: "1px -1px 3px 0px #2626261A",
-                backgroundColor: colors.white,
-                maxWidth: "250px",
-                minHeight: "40px",
-                padding: "6px",
-
-                "&:focus:not(.Mui-selected), &:hover:not(.Mui-selected), &.Mui-focusVisible:not(.Mui-selected)":
-                    {
-                        background: colors.green100,
-                        color: "inherit",
-                    },
-            },
-        }),
-
     normal: () =>
         css({
             "&.MuiTab-root": {

--- a/src/components/Tabs/Tabs.styles.ts
+++ b/src/components/Tabs/Tabs.styles.ts
@@ -2,17 +2,17 @@ import { css } from "@emotion/react";
 import { colors } from "@/config/theme";
 
 export const tabsStyle = {
-    tabList: css({
-        boxShadow: "none",
+    // tabList: css({
+    //     boxShadow: "none",
 
-        ".MuiTabs-indicator": {
-            display: "none",
-        },
+    //     ".MuiTabs-indicator": {
+    //         display: "none",
+    //     },
 
-        ".MuiTabs-root": {
-            minHeight: "40px",
-        },
-    }),
+    //     ".MuiTabs-root": {
+    //         minHeight: "40px",
+    //     },
+    // }),
 
     tab: () =>
         css({
@@ -56,6 +56,25 @@ export const tabsStyle = {
 
                 "&t:active:not(.Mui-selected)": {
                     borderBottom: `3px solid ${colors.green400}`,
+                },
+            },
+        }),
+
+    search: () =>
+        css({
+            "&.MuiTab-root": {
+                fontSize: 20,
+                fontWeight: 400,
+                py: "5px",
+
+                "&:focus, &:hover": {
+                    background: colors.grey100,
+                    boxShadow: `inset 0 -1px 0 0px ${colors.green400}`,
+                },
+
+                "&.Mui-selected": {
+                    boxShadow: `inset 0 -3px 0 0px ${colors.green400}`,
+                    fontWeight: 600,
                 },
             },
         }),

--- a/src/components/Tabs/Tabs.tsx
+++ b/src/components/Tabs/Tabs.tsx
@@ -109,7 +109,7 @@ const Tabs = ({
                     <MuiTabList
                         aria-label={ariaLabel ?? "tab navigation"}
                         variant={tabVariant}
-                        scrollButtons={true}
+                        scrollButtons="auto"
                         sx={{
                             mb: variant === TabVariant.STANDARD ? 1 : 0,
                             ".MuiTabs-indicator": {

--- a/src/components/Tabs/Tabs.tsx
+++ b/src/components/Tabs/Tabs.tsx
@@ -96,16 +96,14 @@ const Tabs = ({
     return (
         <Box sx={{ width: "100%", typography: "body1", ...rootBoxSx }}>
             <MuiTabContext value={selectedTab}>
-                <Box
-                    // css={variant === TabVariant.LARGE && tabsStyle.tabList}
+                <Paper
+                    css={
+                        variant === TabVariant.SEARCH && tabsStyle.searchTabList
+                    }
                     sx={{
                         padding: 0,
                         background: "none",
-                        sx: {
-                            //TODO: only apply when needed
-                            display: "flex",
-                            justifyContent: "center",
-                        },
+
                         ...tabBoxSx,
                     }}>
                     <MuiTabList
@@ -143,7 +141,7 @@ const Tabs = ({
                             />
                         ))}
                     </MuiTabList>
-                </Box>
+                </Paper>
                 {introContent}
                 {renderTabContent &&
                     tabs.map(tab => (

--- a/src/components/Tabs/Tabs.tsx
+++ b/src/components/Tabs/Tabs.tsx
@@ -19,10 +19,8 @@ export interface Tab {
 }
 
 export enum TabVariant {
-    STANDARD = "standard",
-    LARGE = "large",
-    SLIM = "slim",
     SEARCH = "search",
+    STANDARD = "standard",
 }
 
 export interface TabProps {

--- a/src/components/Tabs/Tabs.tsx
+++ b/src/components/Tabs/Tabs.tsx
@@ -22,6 +22,7 @@ export enum TabVariant {
     STANDARD = "standard",
     LARGE = "large",
     SLIM = "slim",
+    SEARCH = "search",
 }
 
 export interface TabProps {
@@ -95,17 +96,22 @@ const Tabs = ({
     return (
         <Box sx={{ width: "100%", typography: "body1", ...rootBoxSx }}>
             <MuiTabContext value={selectedTab}>
-                <Paper
-                    css={variant === TabVariant.LARGE && tabsStyle.tabList}
+                <Box
+                    // css={variant === TabVariant.LARGE && tabsStyle.tabList}
                     sx={{
-                        paddingBottom: 0,
+                        padding: 0,
                         background: "none",
+                        sx: {
+                            //TODO: only apply when needed
+                            display: "flex",
+                            justifyContent: "center",
+                        },
                         ...tabBoxSx,
                     }}>
                     <MuiTabList
                         aria-label={ariaLabel ?? "tab navigation"}
                         variant={tabVariant}
-                        scrollButtons="auto"
+                        scrollButtons={true}
                         sx={{
                             mb: variant === TabVariant.STANDARD ? 1 : 0,
                             ".MuiTabs-indicator": {
@@ -128,8 +134,8 @@ const Tabs = ({
                                 value={tab.value}
                                 label={tab.label}
                                 css={
-                                    variant === TabVariant.LARGE
-                                        ? tabsStyle.tab
+                                    variant === TabVariant.SEARCH
+                                        ? tabsStyle.search
                                         : tabsStyle.normal
                                 }
                                 param={paramName}
@@ -137,7 +143,7 @@ const Tabs = ({
                             />
                         ))}
                     </MuiTabList>
-                </Paper>
+                </Box>
                 {introContent}
                 {renderTabContent &&
                     tabs.map(tab => (


### PR DESCRIPTION
## Screenshots (if relevant)

https://github.com/user-attachments/assets/a38a0782-06db-41c7-9600-b3a181d3173a


## Describe your changes
Changes Search tabs to new design. On larger screens, they are centred. On medium screens, tabs can be scrolled. On mobile, collapses to a dropdown menu.

## Issue ticket link
https://hdruk.atlassian.net/browse/GAT-7133

## Checklist before requesting a review

-   [ ] I have performed a self-review of my code
-   [ ] I have added appropriate unit tests
-   [ ] I have created mocks for unit tests (where appropriate)
-   [ ] The interface is responsive (where appropriate)
-   [ ] The interface is at least AA (where appropriate)
