### PR TITLE
fix(GAT-7288): trim off coverage if its a url

### DIFF
--- a/src/app/[locale]/(logged-out)/dataset/[datasetId]/components/DatasetStats/DatasetStats.tsx
+++ b/src/app/[locale]/(logged-out)/dataset/[datasetId]/components/DatasetStats/DatasetStats.tsx
@@ -11,6 +11,8 @@ import {
     parseLeadTime,
     splitStringList,
 } from "@/utils/dataset";
+import { isValidUrl } from "@/utils/isValidUrl";
+import { truncateUrl } from "@/utils/truncateUrl";
 
 const TRANSLATION_PATH = "pages.dataset.components.DatasetStats";
 
@@ -29,9 +31,15 @@ const DatasetStats = ({ data }: { data: Partial<VersionItem> }) => {
         get(data, "metadata.metadata.provenance.temporal.endDate")
     );
     const tissueStat = get(data, "metadata.metadata.coverage.materialType");
-    const coverageStat = spatialCoverage
+    let coverage = spatialCoverage
         ? Array.from(new Set(splitStringList(spatialCoverage)))
         : "";
+
+    if (Array.isArray(coverage) && isValidUrl(coverage[0])) {
+        coverage = truncateUrl(coverage[0], 15);
+    }
+
+    const coverageStat = coverage;
     const leadTimeStat = parseLeadTime(
         get(data, "metadata.metadata.accessibility.access.deliveryLeadTime") ||
             ""

--- a/src/utils/isValidUrl.ts
+++ b/src/utils/isValidUrl.ts
@@ -1,0 +1,9 @@
+export function isValidUrl(str: string): boolean {
+    try {
+        // eslint-disable-next-line no-new
+        new URL(str);
+        return true;
+    } catch {
+        return false;
+    }
+}

--- a/src/utils/truncateUrl.ts
+++ b/src/utils/truncateUrl.ts
@@ -1,0 +1,4 @@
+export function truncateUrl(url: string, maxLength = 40): string {
+    if (url.length <= maxLength) return url;
+    return `${url.slice(0, maxLength - 3)}...`;
+}


### PR DESCRIPTION
## Screenshots (if relevant)
![image](https://github.com/user-attachments/assets/bc0eaa35-c51b-4ee5-8c06-0e2704c3328e)

## Describe your changes
They upset me. Alternative here: https://github.com/HDRUK/gateway-web/pull/1218 but apparently the data in that field is incorrect.

## Issue ticket link

## Checklist before requesting a review

-   [ ] I have performed a self-review of my code
-   [ ] I have added appropriate unit tests
-   [ ] I have created mocks for unit tests (where appropriate)
-   [ ] The interface is responsive (where appropriate)
-   [ ] The interface is at least AA (where appropriate)
