### PR TITLE
feat(GAT-7249): Reduce cohort api calls

### DIFF
--- a/src/app/[locale]/(logged-out)/search/components/ResultCard/ResultCard.tsx
+++ b/src/app/[locale]/(logged-out)/search/components/ResultCard/ResultCard.tsx
@@ -169,6 +169,7 @@ const ResultCard = ({
                               }
                               showDatasetExplanatoryTooltip
                               variant="link"
+                              clickedAction={() => setAnchorElement(null)}
                           />
                       ),
                       icon: (

--- a/src/app/[locale]/(logged-out)/search/components/ResultsTable/ResultsTable.tsx
+++ b/src/app/[locale]/(logged-out)/search/components/ResultsTable/ResultsTable.tsx
@@ -4,7 +4,6 @@ import { get } from "lodash";
 import { useTranslations } from "next-intl";
 import { KeyedMutator } from "swr";
 import { PageTemplatePromo } from "@/interfaces/Cms";
-import { CohortRequest } from "@/interfaces/CohortRequest";
 import { Library } from "@/interfaces/Library";
 import { SearchResultDataset } from "@/interfaces/Search";
 import EllipsisLineLimit from "@/components/EllipsisLineLimit";
@@ -12,6 +11,7 @@ import Link from "@/components/Link";
 import Paper from "@/components/Paper";
 import Table from "@/components/Table";
 import useAuth from "@/hooks/useAuth";
+import { useCohortStatus } from "@/hooks/useCohortStatus";
 import useGet from "@/hooks/useGet";
 import apis from "@/config/apis";
 import { CheckIcon } from "@/consts/icons";
@@ -276,23 +276,16 @@ const ResultTable = ({
     const t = useTranslations(RESULTS_TABLE_TRANSLATION_PATH);
     const { isLoggedIn, user } = useAuth();
 
+    const { requestStatus } = useCohortStatus(user?.id);
+
     const { data: libraryData, mutate: mutateLibraries } = useGet<Library[]>(
         `${apis.librariesV1Url}?per_page=-1`,
         { shouldFetch: isLoggedIn }
     );
 
-    const { data: userData } = useGet<CohortRequest>(
-        `${apis.cohortRequestsV1Url}/user/${user?.id}`,
-        {
-            shouldFetch: !!user?.id,
-        }
-    );
-
     const isCohortDiscoveryDisabled =
-        isLoggedIn && userData
-            ? !["APPROVED", "REJECTED", "EXPIRED"].includes(
-                  userData.request_status
-              )
+        isLoggedIn && requestStatus
+            ? !["APPROVED", "REJECTED", "EXPIRED"].includes(requestStatus)
             : false;
 
     const translations = {

--- a/src/app/[locale]/(logged-out)/search/components/Search/Search.tsx
+++ b/src/app/[locale]/(logged-out)/search/components/Search/Search.tsx
@@ -24,7 +24,6 @@ import Cookies from "js-cookie";
 import { useTranslations } from "next-intl";
 import { usePathname, useRouter, useSearchParams } from "next/navigation";
 import { PageTemplatePromo } from "@/interfaces/Cms";
-import { CohortRequest } from "@/interfaces/CohortRequest";
 import { Filter } from "@/interfaces/Filter";
 import { Library } from "@/interfaces/Library";
 import {
@@ -57,6 +56,7 @@ import SaveSearchDialog, {
     SaveSearchValues,
 } from "@/modules/SaveSearchDialog.tsx";
 import useAuth from "@/hooks/useAuth";
+import { useCohortStatus } from "@/hooks/useCohortStatus";
 import useDataAccessRequest from "@/hooks/useDataAccessRequest";
 import useDialog from "@/hooks/useDialog";
 import useGTMEvent from "@/hooks/useGTMEvent";
@@ -557,18 +557,11 @@ const Search = ({ filters, cohortDiscovery }: SearchProps) => {
         setIsDownloading(false);
     };
 
-    const { data: userData } = useGet<CohortRequest>(
-        `${apis.cohortRequestsV1Url}/user/${user?.id}`,
-        {
-            shouldFetch: !!user?.id,
-        }
-    );
+    const { requestStatus } = useCohortStatus(user?.id);
 
     const isCohortDiscoveryDisabled =
-        isLoggedIn && userData
-            ? !["APPROVED", "REJECTED", "EXPIRED"].includes(
-                  userData.request_status
-              )
+        isLoggedIn && requestStatus
+            ? !["APPROVED", "REJECTED", "EXPIRED"].includes(requestStatus)
             : false;
 
     const renderResultCard = (result: SearchResult) => {

--- a/src/app/actions/getCohortStatusAndRedirectAction.test.ts
+++ b/src/app/actions/getCohortStatusAndRedirectAction.test.ts
@@ -1,0 +1,73 @@
+import { cookies } from "next/headers";
+import { getUserCohortRequest, getCohortAccessRedirect } from "@/utils/api";
+import { getCohortStatusAndRedirect } from "./getCohortStatusAndRedirectAction";
+
+jest.mock("next/headers", () => ({
+    cookies: jest.fn(),
+}));
+
+jest.mock("@/utils/api", () => ({
+    getUserCohortRequest: jest.fn(),
+    getCohortAccessRedirect: jest.fn(),
+}));
+
+describe("getCohortStatusAndRedirect", () => {
+    const mockCookieStore = {
+        get: jest.fn().mockReturnValue({ value: "fakeJWTToken" }),
+    };
+
+    beforeEach(() => {
+        jest.clearAllMocks();
+        (cookies as jest.Mock).mockReturnValue(mockCookieStore);
+    });
+
+    it("should return correct cohort response when both API calls succeed", async () => {
+        const mockUserRequest = { request_status: "APPROVED" };
+        const mockAccessRedirect = {
+            redirect_url: "https://example.com/redirect",
+        };
+
+        (getUserCohortRequest as jest.Mock).mockResolvedValue(mockUserRequest);
+        (getCohortAccessRedirect as jest.Mock).mockResolvedValue(
+            mockAccessRedirect
+        );
+
+        const result = await getCohortStatusAndRedirect(123);
+
+        expect(cookies).toHaveBeenCalled();
+        expect(getUserCohortRequest).toHaveBeenCalledWith(
+            mockCookieStore,
+            "123"
+        );
+        expect(getCohortAccessRedirect).toHaveBeenCalledWith(mockCookieStore);
+        expect(result).toEqual({
+            requestStatus: "APPROVED",
+            redirectUrl: "https://example.com/redirect",
+        });
+    });
+
+    it("should return null if one of the API calls fails", async () => {
+        (getUserCohortRequest as jest.Mock).mockRejectedValue(
+            new Error("API error")
+        );
+        (getCohortAccessRedirect as jest.Mock).mockResolvedValue({
+            redirect_url: "url",
+        });
+
+        const result = await getCohortStatusAndRedirect(123);
+
+        expect(result).toBeNull();
+    });
+
+    it("should handle missing request_status or redirect_url", async () => {
+        (getUserCohortRequest as jest.Mock).mockResolvedValue({});
+        (getCohortAccessRedirect as jest.Mock).mockResolvedValue({});
+
+        const result = await getCohortStatusAndRedirect(123);
+
+        expect(result).toEqual({
+            requestStatus: null,
+            redirectUrl: null,
+        });
+    });
+});

--- a/src/app/actions/getCohortStatusAndRedirectAction.ts
+++ b/src/app/actions/getCohortStatusAndRedirectAction.ts
@@ -3,6 +3,8 @@
 import { cookies } from "next/headers";
 import { CohortResponse } from "@/interfaces/CohortRequest";
 import { getCohortAccessRedirect, getUserCohortRequest } from "@/utils/api";
+import { getSessionCookie } from "@/utils/getSessionCookie";
+import { logger } from "@/utils/logger";
 
 export const getCohortStatusAndRedirect = async (
     userId: number
@@ -19,8 +21,18 @@ export const getCohortStatusAndRedirect = async (
             requestStatus: userRequest.request_status ?? null,
             redirectUrl: accessRedirect.redirect_url ?? null,
         };
-    } catch (err) {
-        console.error("Cohort server action error:", err);
+    } catch (error) {
+        const session = await getSessionCookie();
+        const err = error as {
+            response?: {
+                status: number;
+                data?: { message: string };
+            };
+            stack?: unknown;
+            message: string;
+        };
+        logger.error(err, session, `api/logout`);
+
         return null;
     }
 };

--- a/src/app/actions/getCohortStatusAndRedirectAction.ts
+++ b/src/app/actions/getCohortStatusAndRedirectAction.ts
@@ -1,0 +1,26 @@
+"use server";
+
+import { cookies } from "next/headers";
+import { CohortResponse } from "@/interfaces/CohortRequest";
+import { getCohortAccessRedirect, getUserCohortRequest } from "@/utils/api";
+
+export const getCohortStatusAndRedirect = async (
+    userId: number
+): Promise<CohortResponse | null> => {
+    try {
+        const cookieStore = cookies();
+
+        const [userRequest, accessRedirect] = await Promise.all([
+            getUserCohortRequest(cookieStore, userId.toString()),
+            getCohortAccessRedirect(cookieStore),
+        ]);
+
+        return {
+            requestStatus: userRequest.request_status ?? null,
+            redirectUrl: accessRedirect.redirect_url ?? null,
+        };
+    } catch (err) {
+        console.error("Cohort server action error:", err);
+        return null;
+    }
+};

--- a/src/hooks/useCohortStatus.test.tsx
+++ b/src/hooks/useCohortStatus.test.tsx
@@ -1,0 +1,64 @@
+import { useCohortStatus } from "@/hooks/useCohortStatus";
+import { renderHook, act } from "@/utils/testUtils";
+import { getCohortStatusAndRedirect } from "../app/actions/getCohortStatusAndRedirectAction";
+
+jest.mock("../app/actions/getCohortStatusAndRedirectAction", () => ({
+    getCohortStatusAndRedirect: jest.fn(),
+}));
+
+describe("useCohortStatus", () => {
+    const mockData = {
+        requestStatus: "APPROVED",
+        redirectUrl: "https://example.com/redirect",
+    };
+
+    beforeEach(() => {
+        jest.clearAllMocks();
+    });
+
+    it("should fetch and return cohort data", async () => {
+        (getCohortStatusAndRedirect as jest.Mock).mockResolvedValue(mockData);
+
+        const { result } = renderHook(() => useCohortStatus(123));
+
+        expect(result.current.isLoading).toBe(true);
+        expect(result.current.requestStatus).toBeNull();
+        expect(result.current.redirectUrl).toBeNull();
+
+        // Wait for hook to update after async call
+        await act(async () => {
+            await Promise.resolve();
+        });
+
+        expect(result.current.isLoading).toBe(false);
+        expect(result.current.requestStatus).toBe("APPROVED");
+        expect(result.current.redirectUrl).toBe("https://example.com/redirect");
+    });
+
+    it("should not fetch if userId is undefined", async () => {
+        const { result } = renderHook(() => useCohortStatus(undefined));
+
+        await act(async () => {
+            await Promise.resolve();
+        });
+
+        expect(getCohortStatusAndRedirect).not.toHaveBeenCalled();
+        expect(result.current.requestStatus).toBeNull();
+    });
+
+    it("should handle fetch failure", async () => {
+        (getCohortStatusAndRedirect as jest.Mock).mockRejectedValue(
+            new Error("fail")
+        );
+
+        const { result } = renderHook(() => useCohortStatus(456));
+
+        await act(async () => {
+            await Promise.resolve();
+        });
+
+        expect(result.current.isLoading).toBe(false);
+        expect(result.current.requestStatus).toBeNull();
+        expect(result.current.redirectUrl).toBeNull();
+    });
+});

--- a/src/hooks/useCohortStatus.ts
+++ b/src/hooks/useCohortStatus.ts
@@ -1,0 +1,36 @@
+"use client";
+
+import { useEffect, useState } from "react";
+import { CohortResponse } from "@/interfaces/CohortRequest";
+import { getCohortStatusAndRedirect } from "@/app/actions/getCohortStatusAndRedirectAction";
+
+export const useCohortStatus = (userId?: number) => {
+    const [data, setData] = useState<CohortResponse | null>(null);
+    const [isLoading, setIsLoading] = useState(false);
+
+    useEffect(() => {
+        if (!userId || data) return;
+
+        const fetchData = async () => {
+            setIsLoading(true);
+
+            try {
+                const result = await getCohortStatusAndRedirect(userId);
+                setData(result);
+            } catch (err) {
+                console.error("Error fetching cohort status:", err);
+                setData(null);
+            } finally {
+                setIsLoading(false);
+            }
+        };
+
+        fetchData();
+    }, [data, userId]);
+
+    return {
+        requestStatus: data?.requestStatus ?? null,
+        redirectUrl: data?.redirectUrl ?? null,
+        isLoading,
+    };
+};

--- a/src/interfaces/CohortRequest.ts
+++ b/src/interfaces/CohortRequest.ts
@@ -33,4 +33,34 @@ interface CohortRequestForm {
     request_status: CohortRequestStatus;
 }
 
-export type { CohortRequest, Log, CohortRequestStatus, CohortRequestForm };
+interface CohortRequestUser {
+    id: number;
+    user_id: number;
+    request_status: CohortRequestStatus;
+    cohort_status: boolean;
+    is_nhse_sde_approval: boolean;
+    request_expire_at: string;
+    created_at: string;
+    updated_at: string;
+    deleted_at: string;
+    accept_declaration: boolean;
+}
+
+interface CohortRequestAccess {
+    redirect_url: string;
+}
+
+interface CohortResponse {
+    requestStatus: string;
+    redirectUrl: string;
+}
+
+export type {
+    CohortRequest,
+    Log,
+    CohortRequestStatus,
+    CohortRequestForm,
+    CohortRequestUser,
+    CohortRequestAccess,
+    CohortResponse,
+};

--- a/src/utils/api.ts
+++ b/src/utils/api.ts
@@ -4,7 +4,11 @@ import { ReadonlyRequestCookies } from "next/dist/server/web/spec-extension/adap
 import { cookies } from "next/headers";
 import { Application } from "@/interfaces/Application";
 import { AuthUser } from "@/interfaces/AuthUser";
-import { CohortRequest } from "@/interfaces/CohortRequest";
+import {
+    CohortRequest,
+    CohortRequestAccess,
+    CohortRequestUser,
+} from "@/interfaces/CohortRequest";
 import { ReducedCollection } from "@/interfaces/Collection";
 import {
     DarApplicationAnswer,
@@ -311,6 +315,37 @@ async function getCohort(
     return get<CohortRequest>(
         cookieStore,
         `${apis.cohortRequestsV1UrlIP}/${cohortId}`
+    );
+}
+
+export async function getUserCohortRequest(
+    cookieStore: ReadonlyRequestCookies,
+    userId: string
+): Promise<CohortRequestUser> {
+    const cache: Cache = {
+        tags: ["cohort"],
+        revalidate: 2 * 60 * 60,
+    };
+
+    return get<CohortRequestUser>(
+        cookieStore,
+        `${apis.cohortRequestsV1UrlIP}/user/${userId}`,
+        { cache }
+    );
+}
+
+export async function getCohortAccessRedirect(
+    cookieStore: ReadonlyRequestCookies
+): Promise<CohortRequestAccess> {
+    const cache: Cache = {
+        tags: ["cohort"],
+        revalidate: 2 * 60 * 60,
+    };
+
+    return get<CohortRequestAccess>(
+        cookieStore,
+        `${apis.cohortRequestsV1UrlIP}/access`,
+        { cache }
     );
 }
 

--- a/src/utils/api.ts
+++ b/src/utils/api.ts
@@ -324,7 +324,6 @@ export async function getUserCohortRequest(
 ): Promise<CohortRequestUser> {
     const cache: Cache = {
         tags: ["cohort"],
-        revalidate: 2 * 60 * 60,
     };
 
     return get<CohortRequestUser>(
@@ -339,7 +338,6 @@ export async function getCohortAccessRedirect(
 ): Promise<CohortRequestAccess> {
     const cache: Cache = {
         tags: ["cohort"],
-        revalidate: 2 * 60 * 60,
     };
 
     return get<CohortRequestAccess>(

--- a/src/utils/api.ts
+++ b/src/utils/api.ts
@@ -324,6 +324,7 @@ export async function getUserCohortRequest(
 ): Promise<CohortRequestUser> {
     const cache: Cache = {
         tags: ["cohort"],
+        revalidate: 15 * 60, // 15 minutes
     };
 
     return get<CohortRequestUser>(
@@ -338,6 +339,7 @@ export async function getCohortAccessRedirect(
 ): Promise<CohortRequestAccess> {
     const cache: Cache = {
         tags: ["cohort"],
+        revalidate: 15 * 60, // 15 minutes
     };
 
     return get<CohortRequestAccess>(


### PR DESCRIPTION
## Screenshots (if relevant)

## Describe your changes
Reduces repeat cohort api calls, previously fired every time search result table was rendered or action button was clicked
Now makes one call through a server action, stores in cache for 2 hours
Added hook to initiate server action client side
Fixed bug where action menu wasn't closed when clicking `Access Cohort Discovery`

## Issue ticket link
https://hdruk.atlassian.net/browse/GAT-7249

## Checklist before requesting a review

-   [ ] I have performed a self-review of my code
-   [ ] I have added appropriate unit tests
-   [ ] I have created mocks for unit tests (where appropriate)
-   [ ] The interface is responsive (where appropriate)
-   [ ] The interface is at least AA (where appropriate)
