### PR TITLE
feat(GAT-6782): Scroll data custodian link into view

### DIFF
--- a/src/app/[locale]/(logged-out)/search/components/ResultsTable/ResultsTable.tsx
+++ b/src/app/[locale]/(logged-out)/search/components/ResultsTable/ResultsTable.tsx
@@ -1,4 +1,4 @@
-import { Tooltip } from "@mui/material";
+import { TableContainer, Tooltip } from "@mui/material";
 import { createColumnHelper } from "@tanstack/react-table";
 import { get } from "lodash";
 import { useTranslations } from "next-intl";
@@ -103,7 +103,15 @@ const getColumns = ({
             return (
                 <div style={{ textAlign: "center" }}>
                     {isNumber && (
-                        <Link href={linkHref}>
+                        <Link
+                            href={linkHref}
+                            onFocus={e => {
+                                e.currentTarget.scrollIntoView({
+                                    behavior: "smooth",
+                                    inline: "center",
+                                    block: "nearest",
+                                });
+                            }}>
                             <EllipsisLineLimit
                                 text={get(original, PUBLISHER_NAME_PATH)}
                             />
@@ -315,22 +323,21 @@ const ResultTable = ({
             sx={{
                 p: 0,
                 border: "1px solid lightgray",
-                overflowX: "scroll",
-                width: "100%",
-                position: "relative",
                 mb: 4,
             }}>
-            <Table<SearchResultDataset>
-                columns={getColumns({
-                    translations,
-                    libraryData,
-                    showLibraryModal,
-                    mutateLibraries,
-                    isCohortDiscoveryDisabled,
-                    cohortDiscovery,
-                })}
-                rows={results}
-            />
+            <TableContainer>
+                <Table<SearchResultDataset>
+                    columns={getColumns({
+                        translations,
+                        libraryData,
+                        showLibraryModal,
+                        mutateLibraries,
+                        isCohortDiscoveryDisabled,
+                        cohortDiscovery,
+                    })}
+                    rows={results}
+                />
+            </TableContainer>
         </Paper>
     );
 };


### PR DESCRIPTION
## Screenshots (if relevant)
https://github.com/user-attachments/assets/ba3fd875-5939-488c-80cf-67b9cdff7d34

## Describe your changes
Scroll data custodian link into view when focusing in dataset search results table
Use mui table container rather than custom scroll styles 

## Issue ticket link
https://hdruk.atlassian.net/browse/GAT-6782

## Checklist before requesting a review

-   [ ] I have performed a self-review of my code
-   [ ] I have added appropriate unit tests
-   [ ] I have created mocks for unit tests (where appropriate)
-   [ ] The interface is responsive (where appropriate)
-   [ ] The interface is at least AA (where appropriate)
