### PR TITLE
fix(GAT-7264): Dataset relationship not showing on Analysis Script & Software on the landing page

### DIFF
--- a/src/app/[locale]/(logged-out)/tool/[toolId]/components/DatasetsContent/DatasetsContent.tsx
+++ b/src/app/[locale]/(logged-out)/tool/[toolId]/components/DatasetsContent/DatasetsContent.tsx
@@ -30,20 +30,7 @@ export default function DatasetContent({
                 length: datasetsLatestVersions.length,
             })}
             contents={datasetsLatestVersions.map(
-                (
-                    {
-                        metadata: {
-                            metadata: {
-                                summary: {
-                                    shortTitle,
-                                    datasetType,
-                                    populationSize,
-                                },
-                            },
-                        },
-                    },
-                    dataset_id: number
-                ) => (
+                ({ shortTitle, datasetType, populationSize, dataset_id }) => (
                     <>
                         <Link href={`/${RouteName.DATASET_ITEM}/${dataset_id}`}>
                             {shortTitle}

--- a/src/app/[locale]/(logged-out)/tool/[toolId]/page.tsx
+++ b/src/app/[locale]/(logged-out)/tool/[toolId]/page.tsx
@@ -10,7 +10,7 @@ import PublicationsContent from "@/components/PublicationsContent";
 import Typography from "@/components/Typography";
 import ActiveListSidebar from "@/modules/ActiveListSidebar";
 import { DataStatus } from "@/consts/application";
-import { getTool } from "@/utils/api";
+import { getReducedTool } from "@/utils/api";
 import metaData from "@/utils/metadata";
 import ActionBar from "./components/ActionBar";
 import DatasetsContent from "./components/DatasetsContent";
@@ -31,7 +31,7 @@ export default async function ToolPage({
 
     const { toolId } = params;
     const cookieStore = cookies();
-    const data = await getTool(cookieStore, toolId, {
+    const data = await getReducedTool(cookieStore, toolId, {
         suppressError: true,
     });
 

--- a/src/app/[locale]/(logged-out)/tool/[toolId]/page.tsx
+++ b/src/app/[locale]/(logged-out)/tool/[toolId]/page.tsx
@@ -64,7 +64,7 @@ export default async function ToolPage({
                             populatedSections={populatedSections}
                         />
                         <DatasetsContent
-                            dataset_versions={data.dataset_versions}
+                            dataset_versions={data.versions}
                             anchorIndex={populatedSections.length + 1}
                         />
                         <DataUsesContent

--- a/src/utils/api.ts
+++ b/src/utils/api.ts
@@ -459,6 +459,20 @@ async function getTool(
     return tool;
 }
 
+async function getReducedTool(
+    cookieStore: ReadonlyRequestCookies,
+    toolId: string,
+    options?: GetOptions
+): Promise<Tool> {
+    const collection = await get<Tool>(
+        cookieStore,
+        `${apis.toolsV1UrlIP}/${toolId}?view_type=mini`,
+        options
+    );
+
+    return collection;
+}
+
 async function getReducedCollection(
     cookieStore: ReadonlyRequestCookies,
     collectionId: string,
@@ -739,6 +753,7 @@ async function getDarTemplatesCount(
 export {
     getApplication,
     getCohort,
+    getReducedTool,
     getReducedCollection,
     getDataCustodianNetworks,
     getDataset,


### PR DESCRIPTION
## Screenshots (if relevant)
![image](https://github.com/user-attachments/assets/42aef689-e389-4c09-a08d-a06a497774e6)

## Describe your changes
Correctly pass through and use dataset version info on tool landing page.
Must be merged in parallel with https://github.com/HDRUK/gateway-api/pull/1307

## Issue ticket link
https://hdruk.atlassian.net/browse/GAT-7264

## Checklist before requesting a review

-   [ ] I have performed a self-review of my code
-   [ ] I have added appropriate unit tests
-   [ ] I have created mocks for unit tests (where appropriate)
-   [ ] The interface is responsive (where appropriate)
-   [ ] The interface is at least AA (where appropriate)
