### PR TITLE
fix(GAT-7643): Can't download a metadata template file

### DIFF
--- a/src/components/DownloadExternalFile/DownloadExternalFile.test.tsx
+++ b/src/components/DownloadExternalFile/DownloadExternalFile.test.tsx
@@ -52,9 +52,7 @@ describe("DownloadExternalFile", () => {
         fireEvent.click(screen.getByRole("button"));
 
         await waitFor(() => {
-            expect(fetchMock).toHaveBeenCalledWith(apiPath, {
-                headers: { "x-Request-Session-Id": "web: undefined" },
-            });
+            expect(fetchMock).toHaveBeenCalledWith(apiPath);
 
             expect(mockDownloadExternalFile).toHaveBeenCalledWith(
                 expect.objectContaining({

--- a/src/components/DownloadExternalFile/DownloadExternalFile.tsx
+++ b/src/components/DownloadExternalFile/DownloadExternalFile.tsx
@@ -1,6 +1,6 @@
 import Cookies from "js-cookie";
 import notificationService from "@/services/notification";
-import { sessionCookie, sessionHeader, sessionPrefix } from "@/config/session";
+import { sessionCookie } from "@/config/session";
 import { downloadExternalFile } from "@/utils/download";
 import { logger } from "@/utils/logger";
 import DownloadButton from "../DownloadButton";
@@ -29,9 +29,7 @@ const DownloadExternalFile = ({
             return;
         }
 
-        const response = await fetch(apiPath, {
-            headers: { [sessionHeader]: sessionPrefix + session },
-        });
+        const response = await fetch(apiPath);
 
         if (!response.ok) {
             let errorMessage: string;


### PR DESCRIPTION
## Screenshots (if relevant)

<img width="1897" height="881" alt="metadata_template_download" src="https://github.com/user-attachments/assets/b2667141-eef1-4ea9-b50b-07e32ea2fa4f" />


## Describe your changes

The metadata template is downloaded direct from GitHub and GitHub didn't like the `x-Request-Session-Id` header.  I don't think the header is needed in the request itself so I've removed it.

## Issue ticket link

https://hdruk.atlassian.net/browse/GAT-7643

## Checklist before requesting a review

-   [ ] I have performed a self-review of my code
-   [ ] I have added appropriate unit tests
-   [ ] I have created mocks for unit tests (where appropriate)
-   [ ] The interface is responsive (where appropriate)
-   [ ] The interface is at least AA (where appropriate)
