### PR TITLE
fix(GAT-7550): Data Access Request application loading even though team doesn't have an active template

### DIFF
--- a/src/app/[locale]/(logged-out)/dataset/[datasetId]/components/ActionBar/ActionBar.tsx
+++ b/src/app/[locale]/(logged-out)/dataset/[datasetId]/components/ActionBar/ActionBar.tsx
@@ -122,6 +122,7 @@ const ActionBar = ({ dataset }: ActionBarProps) => {
             onGeneralEnquiryClick: handleGeneralEnquiryClick,
             onFeasibilityEnquiryClick: handleFeasibilityEnquiryClick,
             isDarEnabled: team.is_question_bank,
+            hasPublishedDarTemplate: team.has_published_dar_template,
             modalHeader: team.dar_modal_header,
             modalContent: team.dar_modal_content,
             url: `/${RouteName.DATASET_ITEM}/${datasetId}`,

--- a/src/app/[locale]/(logged-out)/search/components/ActionDropdown/ActionDropdown.tsx
+++ b/src/app/[locale]/(logged-out)/search/components/ActionDropdown/ActionDropdown.tsx
@@ -102,6 +102,7 @@ const ActionDropdown = ({
             onGeneralEnquiryClick: handleGeneralEnquiryClick,
             onFeasibilityEnquiryClick: handleFeasibilityEnquiryClick,
             isDarEnabled: team.is_question_bank,
+            hasPublishedDarTemplate: team.has_dar_template_published,
             url: `/${RouteName.DATASET_ITEM}/${datasetId}`,
             modalHeader: team.dar_modal_header,
             modalContent: team.dar_modal_content,

--- a/src/app/[locale]/(logged-out)/search/components/ActionDropdown/ActionDropdown.tsx
+++ b/src/app/[locale]/(logged-out)/search/components/ActionDropdown/ActionDropdown.tsx
@@ -102,7 +102,7 @@ const ActionDropdown = ({
             onGeneralEnquiryClick: handleGeneralEnquiryClick,
             onFeasibilityEnquiryClick: handleFeasibilityEnquiryClick,
             isDarEnabled: team.is_question_bank,
-            hasPublishedDarTemplate: team.has_dar_template_published,
+            hasPublishedDarTemplate: team.has_published_dar_template,
             url: `/${RouteName.DATASET_ITEM}/${datasetId}`,
             modalHeader: team.dar_modal_header,
             modalContent: team.dar_modal_content,

--- a/src/app/[locale]/(logged-out)/search/components/ResultCard/ResultCard.tsx
+++ b/src/app/[locale]/(logged-out)/search/components/ResultCard/ResultCard.tsx
@@ -135,7 +135,7 @@ const ResultCard = ({
             onGeneralEnquiryClick: handleGeneralEnquiryClick,
             onFeasibilityEnquiryClick: handleFeasibilityEnquiryClick,
             isDarEnabled: team.is_question_bank,
-            hasPublishedDarTemplate: team.has_dar_template_published,
+            hasPublishedDarTemplate: team.has_published_dar_template,
             url: `/${RouteName.DATASET_ITEM}/${datasetId}`,
             modalHeader: team.dar_modal_header,
             modalContent: team.dar_modal_content,

--- a/src/app/[locale]/(logged-out)/search/components/ResultCard/ResultCard.tsx
+++ b/src/app/[locale]/(logged-out)/search/components/ResultCard/ResultCard.tsx
@@ -135,6 +135,7 @@ const ResultCard = ({
             onGeneralEnquiryClick: handleGeneralEnquiryClick,
             onFeasibilityEnquiryClick: handleFeasibilityEnquiryClick,
             isDarEnabled: team.is_question_bank,
+            hasPublishedDarTemplate: team.has_dar_template_published,
             url: `/${RouteName.DATASET_ITEM}/${datasetId}`,
             modalHeader: team.dar_modal_header,
             modalContent: team.dar_modal_content,

--- a/src/app/[locale]/account/profile/library/components/LibraryTable.tsx
+++ b/src/app/[locale]/account/profile/library/components/LibraryTable.tsx
@@ -31,6 +31,7 @@ const LibraryTable = ({
         datasetId: item.dataset_id,
         name: item.dataset_name,
         darEnabled: item.data_provider_dar_enabled,
+        darTemplatePublished: item.data_provider_published_dar_template,
         cohortEnabled: item.dataset_is_cohort_discovery,
         dataCustodian: item.data_provider_name,
         entityType: "Dataset", // will we update in the future with other entities?

--- a/src/app/[locale]/account/profile/library/components/RightPanel.tsx
+++ b/src/app/[locale]/account/profile/library/components/RightPanel.tsx
@@ -48,6 +48,7 @@ const RightPanel = ({
                     teamId: Number(item.teamId),
                     teamName: item.teamName,
                     darEnabled: item.darEnabled,
+                    darTemplatePublished: item.darTemplatePublished,
                     cohortEnabled: item.cohortEnabled,
                 };
             });
@@ -152,7 +153,9 @@ const RightPanel = ({
                     <Tooltip
                         title={
                             !selectedDatasets.every(
-                                dataset => dataset.darEnabled
+                                dataset =>
+                                    dataset.darEnabled &&
+                                    dataset.darTemplatePublished
                             )
                                 ? t("dataAccessRequest.buttonTooltipDar")
                                 : selectedDatasets.length > 0
@@ -166,7 +169,9 @@ const RightPanel = ({
                                 disabled={
                                     !(selectedDatasets.length > 0) ||
                                     !selectedDatasets.every(
-                                        dataset => dataset.darEnabled
+                                        dataset =>
+                                            dataset.darEnabled &&
+                                            dataset.darTemplatePublished
                                     )
                                 }>
                                 <FileUploadOutlined sx={{ pr: 1 }} />

--- a/src/app/[locale]/account/profile/library/utils/index.tsx
+++ b/src/app/[locale]/account/profile/library/utils/index.tsx
@@ -31,6 +31,7 @@ const getColumns = ({
                 dataCustodianId,
                 dataCustodian,
                 darEnabled,
+                darTemplatePublished,
                 cohortEnabled,
             } = row.original;
             return (
@@ -46,6 +47,7 @@ const getColumns = ({
                                     teamId: dataCustodianId,
                                     teamName: dataCustodian,
                                     darEnabled,
+                                    darTemplatePublished,
                                     cohortEnabled,
                                 },
                             })

--- a/src/hooks/useDataAccessRequest/useDataAccessRequest.tsx
+++ b/src/hooks/useDataAccessRequest/useDataAccessRequest.tsx
@@ -24,6 +24,7 @@ interface ShowDARApplicationModalProps {
     onGeneralEnquiryClick(event: React.MouseEvent<HTMLButtonElement>): void;
     onFeasibilityEnquiryClick(event: React.MouseEvent<HTMLButtonElement>): void;
     isDarEnabled: boolean;
+    hasPublishedDarTemplate: boolean;
     url: string;
     modalHeader: string | null;
     modalContent: string | null;
@@ -90,6 +91,7 @@ const useDataAccessRequest = () => {
             onGeneralEnquiryClick,
             onFeasibilityEnquiryClick,
             isDarEnabled,
+            hasPublishedDarTemplate,
             modalHeader,
             modalContent,
             url,
@@ -102,6 +104,7 @@ const useDataAccessRequest = () => {
                     onGeneralEnquiryClick,
                     onFeasibilityEnquiryClick,
                     isDarEnabled,
+                    hasPublishedDarTemplate,
                     modalHeader,
                     modalContent,
                     url,
@@ -115,7 +118,7 @@ const useDataAccessRequest = () => {
                 });
             }
 
-            if (isDarEnabled && !modalContent) {
+            if (isDarEnabled && !modalContent && hasPublishedDarTemplate) {
                 return createDARApplication({
                     datasetIds,
                     teamIds,
@@ -127,6 +130,7 @@ const useDataAccessRequest = () => {
                 onGeneralEnquiryClick,
                 onFeasibilityEnquiryClick,
                 isDarEnabled,
+                hasPublishedDarTemplate,
                 modalHeader,
                 modalContent,
                 url,

--- a/src/interfaces/Library.ts
+++ b/src/interfaces/Library.ts
@@ -7,6 +7,7 @@ interface Library {
     dataset_name: string;
     data_provider_id: number;
     data_provider_dar_enabled: boolean;
+    data_provider_published_dar_template: boolean;
     data_provider_name: string;
     data_provider_member_of: string;
     dataset_is_cohort_discovery: boolean;
@@ -20,6 +21,7 @@ interface SelectedLibrary {
         teamId: number;
         teamName: string;
         darEnabled: boolean;
+        darTemplatePublished: boolean;
         cohortEnabled: boolean;
     };
 }
@@ -29,6 +31,7 @@ interface LibraryListItem {
     datasetId: number;
     name: string;
     darEnabled: boolean;
+    darTemplatePublished: boolean;
     cohortEnabled: boolean;
     dataCustodian: string;
     entityType: string;

--- a/src/interfaces/Search.ts
+++ b/src/interfaces/Search.ts
@@ -97,6 +97,7 @@ export interface SearchResultDataset extends SearchResultBase {
         member_of: string;
         name: string;
         is_question_bank: boolean;
+        has_dar_template_published: boolean;
         is_dar: boolean;
         dar_modal_header: string | null;
         dar_modal_content: string | null;

--- a/src/interfaces/Search.ts
+++ b/src/interfaces/Search.ts
@@ -97,7 +97,7 @@ export interface SearchResultDataset extends SearchResultBase {
         member_of: string;
         name: string;
         is_question_bank: boolean;
-        has_dar_template_published: boolean;
+        has_published_dar_template: boolean;
         is_dar: boolean;
         dar_modal_header: string | null;
         dar_modal_content: string | null;

--- a/src/interfaces/Team.ts
+++ b/src/interfaces/Team.ts
@@ -13,6 +13,7 @@ interface Team {
     uses_5_safes: boolean;
     is_admin: boolean;
     is_question_bank: boolean;
+    has_published_dar_template: boolean;
     member_of: string;
     is_dar: boolean;
     dar_modal_header: string | null;

--- a/src/modules/DarEnquiryDialog/DarEnquiryDialog.tsx
+++ b/src/modules/DarEnquiryDialog/DarEnquiryDialog.tsx
@@ -23,6 +23,7 @@ export interface DarEnquiryDialogProps {
         redirectPath?: string;
     }): void;
     isDarEnabled: boolean;
+    hasPublishedDarTemplate: boolean;
     url: string;
     modalHeader?: string;
     modalContent?: string;
@@ -38,6 +39,7 @@ const DarEnquiryDialog = ({
     onFeasibilityEnquiryClick,
     createDARApplication,
     isDarEnabled,
+    hasPublishedDarTemplate,
     modalHeader,
     modalContent,
     url,
@@ -99,7 +101,7 @@ const DarEnquiryDialog = ({
                 )}
             </MuiDialogContent>
             <MuiDialogActions>
-                {isDarEnabled ? (
+                {isDarEnabled && hasPublishedDarTemplate ? (
                     <Button
                         variant="contained"
                         onClick={() => {


### PR DESCRIPTION
## Screenshots (if relevant)

## Describe your changes
In the 4 places where the "Start DAR Application" buttons are present, the FE now checks the response for whether the owning team has any published DAR templates, and then disables the button as appropriate.

Dependent upon https://github.com/HDRUK/gateway-api/pull/1378

## Issue ticket link
https://hdruk.atlassian.net/browse/GAT-7550

## Checklist before requesting a review

-   [ ] I have performed a self-review of my code
-   [ ] I have added appropriate unit tests
-   [ ] I have created mocks for unit tests (where appropriate)
-   [ ] The interface is responsive (where appropriate)
-   [ ] The interface is at least AA (where appropriate)
