### PR TITLE
feat(GAT-7262): Display associated authors on tool search results and landing page

### DIFF
--- a/src/app/[locale]/(logged-out)/tool/[toolId]/config.tsx
+++ b/src/app/[locale]/(logged-out)/tool/[toolId]/config.tsx
@@ -59,6 +59,12 @@ const toolFields: ToolSection[] = [
                 hideTooltip: false,
                 label: "lastUpdated",
             },
+            {
+                path: "associated_authors",
+                type: FieldType.TEXT,
+                hideTooltip: false,
+                label: "authors",
+            },
             // missing - uploaders or use associated authors?
             // missing - tool category, what is that suppose to be? I see category_id returned
             // missing - domain, what is this suppose to be?

--- a/src/config/messages/en.json
+++ b/src/config/messages/en.json
@@ -1460,6 +1460,8 @@
             "dataUses": "Related Data Uses",
             "publications": "Related Publications",
             "collections": "Related Collections",
+            "authors": "Associated Authors",
+            "authorsTooltip": "People who authored this analysis script, tool or software.",
             "components": {
                 "ActionBar": {
                     "label": "Back to Tools search results"

--- a/src/interfaces/Search.ts
+++ b/src/interfaces/Search.ts
@@ -146,6 +146,7 @@ export interface SearchResultTool extends SearchResultBase {
     programming_package?: string[];
     datasets?: string[];
     category?: string;
+    associatedAuthors?: string;
 }
 
 export interface SearchResultCollection extends SearchResultBase {

--- a/src/modules/ToolDetailsDialog/ToolDetailsDialog.tsx
+++ b/src/modules/ToolDetailsDialog/ToolDetailsDialog.tsx
@@ -4,6 +4,7 @@ import { SearchResultTool } from "@/interfaces/Search";
 import Box from "@/components/Box";
 import Dialog from "@/components/Dialog";
 import { MarkDownSanitizedWithHtml } from "@/components/MarkDownSanitizedWithHTML";
+import Typography from "@/components/Typography";
 import { CategoryHeader } from "./ToolDetailsDialog.styles";
 
 interface ToolDetailsDialogProps {
@@ -15,7 +16,7 @@ const TRANSLATION_PATH = "modules.dialogs.ToolDetailsDialog";
 const ToolDetailsDialog = ({ result }: ToolDetailsDialogProps) => {
     const t = useTranslations(TRANSLATION_PATH);
 
-    const { name: title, description } = result;
+    const { name: title, description, associatedAuthors } = result;
 
     return (
         <Dialog title={title}>
@@ -30,6 +31,7 @@ const ToolDetailsDialog = ({ result }: ToolDetailsDialogProps) => {
                 <CategoryHeader variant="h3">{t("keywords")}</CategoryHeader>
 
                 <CategoryHeader variant="h3">{t("team")}</CategoryHeader>
+                <Typography>{associatedAuthors}</Typography>
             </MuiDialogContent>
         </Dialog>
     );


### PR DESCRIPTION
## Screenshots (if relevant)
<img width="678" height="345" alt="Description" src="https://github.com/user-attachments/assets/e20e623e-821a-4fc4-920e-4804c3c5e04b" />
<img width="906" height="337" alt="Last Updated" src="https://github.com/user-attachments/assets/e25bdd51-0d4e-4816-9d9c-2b9f3de6acb0" />

## Describe your changes
Display associated authors on tool search results and landing page

## Issue ticket link
https://hdruk.atlassian.net/browse/GAT-7262

## Checklist before requesting a review

-   [ ] I have performed a self-review of my code
-   [ ] I have added appropriate unit tests
-   [ ] I have created mocks for unit tests (where appropriate)
-   [ ] The interface is responsive (where appropriate)
-   [ ] The interface is at least AA (where appropriate)
