### PR TITLE
fix(GAT-7770): Change filter split character to |

### DIFF
--- a/src/app/[locale]/(logged-out)/search/components/Search/Search.tsx
+++ b/src/app/[locale]/(logged-out)/search/components/Search/Search.tsx
@@ -203,7 +203,7 @@ const Search = ({ filters, cohortDiscovery }: SearchProps) => {
     };
 
     const getParamArray = (paramName: string, allowEmptyStrings?: boolean) => {
-        const param = searchParams?.get(paramName)?.split(",");
+        const param = searchParams?.get(paramName)?.split("|");
         return allowEmptyStrings ? param : param?.filter(filter => !!filter);
     };
 
@@ -830,7 +830,7 @@ const Search = ({ filters, cohortDiscovery }: SearchProps) => {
                 ) => {
                     // url requires string format, ie "one, two, three"
                     updatePathMultiple({
-                        [filterName]: filterValues.join(","),
+                        [filterName]: filterValues.join("|"),
                         [PAGE_FIELD]: "1",
                     });
 

--- a/src/utils/search.ts
+++ b/src/utils/search.ts
@@ -90,7 +90,7 @@ const getUrlFromSearchParams = (
     }
 
     Object.keys(filters).forEach((key: string) => {
-        params.set(key, filters[key].join(","));
+        params.set(key, filters[key].join("|"));
     });
 
     params.set("sort", sort);


### PR DESCRIPTION
## Screenshots (if relevant)

## Describe your changes
- Change filter split character to `|`, was previously `,` which doesn't work if filter value contained a `,`
- Also ensure saved search joins filter values correctly 

## Issue ticket link
https://hdruk.atlassian.net/browse/GAT-7770

## Checklist before requesting a review

-   [ ] I have performed a self-review of my code
-   [ ] I have added appropriate unit tests
-   [ ] I have created mocks for unit tests (where appropriate)
-   [ ] The interface is responsive (where appropriate)
-   [ ] The interface is at least AA (where appropriate)
