### PR TITLE
feat(GAT-7879): Add additional wordpress support pages

### DIFF
--- a/src/app/[locale]/(logged-out)/data-custodian/support/components/SupportCentreLinks/SupportCentreLinks.tsx
+++ b/src/app/[locale]/(logged-out)/data-custodian/support/components/SupportCentreLinks/SupportCentreLinks.tsx
@@ -1,5 +1,6 @@
 "use client";
 
+import QuizOutlinedIcon from "@mui/icons-material/QuizOutlined";
 import { Box, Grid } from "@mui/material";
 import { useTranslations } from "next-intl";
 import Banner from "@/components/Banner";
@@ -73,6 +74,11 @@ export default function MeetTheTeam() {
             heading: t("theAllianceTitle"),
             link: RouteName.DATA_CUSTODIAN_THE_ALLIANCE,
             icon: <TheAllianceIcon aria-hidden="true" focusable="false" />,
+        },
+        {
+            heading: t("faqsTitle"),
+            link: RouteName.DATA_CUSTODIAN_FAQS,
+            icon: <QuizOutlinedIcon aria-hidden="true" focusable="false" />,
         },
     ];
 

--- a/src/app/[locale]/(logged-out)/data-custodian/support/faqs/page.tsx
+++ b/src/app/[locale]/(logged-out)/data-custodian/support/faqs/page.tsx
@@ -1,0 +1,26 @@
+import { notFound } from "next/navigation";
+import { getContentPageByParentQuery } from "@/utils/cms";
+import metaData from "@/utils/metadata";
+import "@/styles/wpStyles.css";
+import SupportPage from "../components/SupportPage";
+
+export const metadata = metaData({
+    title: "The Alliance - Data Custodians",
+    description: "",
+});
+
+const FAQsPage = async () => {
+    const cmsPage = await getContentPageByParentQuery("DataCustodianFAQs", {
+        id: "data-custodian-faqs",
+        idType: "URI",
+        parentId: "/data-custodian-support",
+    });
+
+    if (!cmsPage) {
+        notFound();
+    }
+
+    return <SupportPage title={cmsPage?.title} content={cmsPage?.content} />;
+};
+
+export default FAQsPage;

--- a/src/app/[locale]/(logged-out)/support/components/SupportCentreLinks/SupportCentreLinks.tsx
+++ b/src/app/[locale]/(logged-out)/support/components/SupportCentreLinks/SupportCentreLinks.tsx
@@ -1,5 +1,6 @@
 "use client";
 
+import QuizOutlinedIcon from "@mui/icons-material/QuizOutlined";
 import SearchIcon from "@mui/icons-material/Search";
 import { Box, Grid } from "@mui/material";
 import { useTranslations } from "next-intl";
@@ -59,6 +60,11 @@ export default function MeetTheTeam() {
             icon: (
                 <DataAccessRequestIcon aria-hidden="true" focusable="false" />
             ),
+        },
+        {
+            heading: t("researcherTitle"),
+            link: RouteName.SUPPORT_RESEARCHER_FAQS,
+            icon: <QuizOutlinedIcon aria-hidden="true" focusable="false" />,
         },
     ];
 

--- a/src/app/[locale]/(logged-out)/support/researcher-faqs/page.tsx
+++ b/src/app/[locale]/(logged-out)/support/researcher-faqs/page.tsx
@@ -1,0 +1,23 @@
+import { notFound } from "next/navigation";
+import { getContentPageByParentQuery } from "@/utils/cms";
+import metaData from "@/utils/metadata";
+import SupportPage from "../components/SupportPage";
+
+export const metadata = metaData({
+    title: "Researcher FAQs - Support",
+    description: "",
+});
+
+export default async function ResearcherFAQs() {
+    const cmsPage = await getContentPageByParentQuery("GetContentPageQuery", {
+        id: "researcher-faqs",
+        idType: "URI",
+        parentId: "/support",
+    });
+
+    if (!cmsPage) {
+        notFound();
+    }
+
+    return <SupportPage title={cmsPage?.title} content={cmsPage?.content} />;
+}

--- a/src/config/messages/en.json
+++ b/src/config/messages/en.json
@@ -170,6 +170,7 @@
             "managingEnquiryDarTitle": "Using the Gateway Enquiry & Data Access Request Module",
             "gettingStartedTitle": "Getting started on the Gateway and managing your Team",
             "theAllianceTitle": "The Alliance",
+            "faqsTitle": "FAQs",
             "onboardingCohortDiscoveryTitle": "Onboarding to Cohort Discovery",
             "documentation": {
                 "title": "Documentation"
@@ -192,6 +193,7 @@
             "metadataOnboardingTitle": "Metadata Onboarding and Integrations",
             "durTitle": "Exploring Data Uses / Research Projects",
             "darTitle": "Submitting Enquiries and Data Access Requests",
+            "researcherTitle": "Researcher FAQs",
             "uploadingPublicationsTitle": "Uploading Publications ",
             "cohortDiscoveryTitle": "Using Cohort Discovery",
             "exploringCollectionsTitle": "Exploring Collections, Data Custodians and Data Custodian Networks",

--- a/src/consts/routeName.ts
+++ b/src/consts/routeName.ts
@@ -51,6 +51,7 @@ export enum RouteName {
     SUPPORT_COLLECTIONS = "/support/collections",
     SUPPORT_DUR = "/support/data-use-register",
     SUPPORT_DAR = "/support/data-access-request",
+    SUPPORT_RESEARCHER_FAQS = "/support/researcher-faqs",
     SUPPORT_TOOLS = "/support/tools",
     NEWS_EVENTS = "news/events",
     UPLOAD = "upload",
@@ -74,6 +75,7 @@ export enum RouteName {
     DATA_CUSTODIAN_THE_ALLIANCE = "/data-custodian/support/the-alliance",
     DATA_CUSTODIAN_TOOLS = "/data-custodian/support/tools",
     DATA_CUSTODIAN_PUBLICATIONS = "/data-custodian/support/publications",
+    DATA_CUSTODIAN_FAQS = "/data-custodian/support/faqs",
     MISSION_AND_PURPOSE = "/about/our-mission-and-purpose",
     RESEARCHERS = "/about/researchers-innovators",
 }


### PR DESCRIPTION
## Screenshots (if relevant)
<img width="1205" height="704" alt="image" src="https://github.com/user-attachments/assets/7be0ad16-a8bd-4c4b-b506-a7aaec2bc82d" />

## Describe your changes
 Add additional wordpress support pages

## Issue ticket link
https://hdruk.atlassian.net/browse/GAT-7879

## Checklist before requesting a review

-   [ ] I have performed a self-review of my code
-   [ ] I have added appropriate unit tests
-   [ ] I have created mocks for unit tests (where appropriate)
-   [ ] The interface is responsive (where appropriate)
-   [ ] The interface is at least AA (where appropriate)
