### PR TITLE
chore(GAT-1234): Move error pages to serverside, and tidy up two translations' grammar.

### DIFF
--- a/src/components/ErrorDisplay/ErrorDisplay.tsx
+++ b/src/components/ErrorDisplay/ErrorDisplay.tsx
@@ -1,5 +1,3 @@
-"use client";
-
 import { Box, Typography, useTheme } from "@mui/material";
 import { AllowedErrors, errors } from "@/config/errors";
 import { RemoveCircleIcon } from "@/consts/icons";
@@ -9,7 +7,6 @@ interface ErrorDisplayProps {
 }
 
 const ErrorDisplay = ({ variant }: ErrorDisplayProps) => {
-    const theme = useTheme();
     const errorStatusCode = variant;
 
     const { message, imageSrc, imageAlt, icon } = errors[errorStatusCode];
@@ -26,9 +23,6 @@ const ErrorDisplay = ({ variant }: ErrorDisplayProps) => {
                 alignItems: "center",
                 justifyContent: "center",
                 width: "100%",
-                [theme.breakpoints.down("laptop")]: {
-                    my: "auto",
-                },
             }}>
             <Box sx={{ maxWidth: "550px" }}>
                 {imageSrc ? (

--- a/src/components/ErrorDisplay/ErrorDisplay.tsx
+++ b/src/components/ErrorDisplay/ErrorDisplay.tsx
@@ -1,4 +1,4 @@
-import { Box, Typography, useTheme } from "@mui/material";
+import { Box, Typography } from "@mui/material";
 import { AllowedErrors, errors } from "@/config/errors";
 import { RemoveCircleIcon } from "@/consts/icons";
 

--- a/src/config/messages/en.json
+++ b/src/config/messages/en.json
@@ -626,8 +626,8 @@
                             "successMessage": "Dataset successfully created",
                             "upload": "Upload",
                             "returnButtonText": "View dataset in 'Drafts' tab",
-                            "errorNoMatchingPid": "The summary.dataCustodian.identifier is: {dataCustodianId} which does not match your teams identifier: {teamPid}.",
-                            "errorNoPid": "Missing summary.dataCustodian.identifier your teams identifier is: {teamPid} please add in, this identifier before uploading."
+                            "errorNoMatchingPid": "The summary.dataCustodian.identifier is: {dataCustodianId} which does not match your team's identifier: {teamPid}.",
+                            "errorNoPid": "Missing summary.dataCustodian.identifier. Your team's identifier is: {teamPid}. Please add in this identifier before uploading."
                         }
                     }
                 },


### PR DESCRIPTION
## Screenshots (if relevant)

## Describe your changes
Move error pages to serverside (the breakpoint behaviour is noticeable to the user), and tidy up two translations' grammar.

## Issue ticket link

## Checklist before requesting a review

-   [ ] I have performed a self-review of my code
-   [ ] I have added appropriate unit tests
-   [ ] I have created mocks for unit tests (where appropriate)
-   [ ] The interface is responsive (where appropriate)
-   [ ] The interface is at least AA (where appropriate)
