### PR TITLE
fix(GAT-1234): Show user.name if user.firstname is null, to avoid showing 'null null'

### DIFF
--- a/src/config/tables/teamMemberManagement.tsx
+++ b/src/config/tables/teamMemberManagement.tsx
@@ -117,7 +117,11 @@ const getColumns = ({
     columnHelper.display({
         id: "name",
         header: () => <Box textAlign="left">{translations.nameHeader}</Box>,
-        cell: ({ row }) => `${row.original.firstname} ${row.original.lastname}`,
+        cell: ({ row }) => {
+            return row.original.firstname
+                ? `${row.original.firstname} ${row.original.lastname}`
+                : row.original.name;
+        },
     }),
     columnHelper.display({
         id: "team",


### PR DESCRIPTION
## Screenshots (if relevant)
<img width="444" height="402" alt="image" src="https://github.com/user-attachments/assets/4048ab31-0716-4f09-83bf-1b214787aee8" />

rather than 

<img width="444" height="402" alt="image" src="https://github.com/user-attachments/assets/62754c75-5837-4e74-abf2-1f8b072617bd" />


## Describe your changes
Show user.name if user.firstname is null, to avoid showing 'null null'

## Issue ticket link

## Checklist before requesting a review

-   [ ] I have performed a self-review of my code
-   [ ] I have added appropriate unit tests
-   [ ] I have created mocks for unit tests (where appropriate)
-   [ ] The interface is responsive (where appropriate)
-   [ ] The interface is at least AA (where appropriate)
