### PR TITLE
fix(GAT-8016): Place name of Custodian / Network above logo on Custodian / Network pages

### DIFF
--- a/src/app/[locale]/(logged-out)/collection/[collectionId]/page.tsx
+++ b/src/app/[locale]/(logged-out)/collection/[collectionId]/page.tsx
@@ -62,52 +62,50 @@ export default async function CollectionItemPage({
             navigation={<ActiveListSidebar items={activeLinkList} />}
             body={
                 <>
-                    <Box sx={{ display: "flex", alignItems: "center" }}>
+                    <Typography variant="h1" sx={{ ml: 2, mt: 2 }}>
+                        <HTMLContent content={name} />
+                    </Typography>
+                    <Box sx={{ display: "flex", alignItems: "center", pt: 0 }}>
                         <AspectRatioImage
                             width={554}
                             height={250}
                             alt={toTitleCase(name)}
                             src={image_link || StaticImages.BASE.placeholder}
                         />
-                        <Typography variant="h1" sx={{ ml: 2 }}>
-                            <HTMLContent content={name} />
-                        </Typography>
                     </Box>
 
-                    <Box sx={{ px: 6, py: 3 }}>
-                        <Box sx={{ mb: 3 }}>
-                            <ActionBar />
-                        </Box>
-                        <Box sx={{ mb: 3 }}>
-                            <Typography variant="h3" sx={{ mb: 1 }}>
-                                {t("introTitle")}
-                            </Typography>
-                            <MarkDownSanitizedWithHtml content={description} />
-                        </Box>
-                        <Box>
-                            <DatasetsContent
-                                datasets={dataset_versions}
-                                anchorIndex={1}
-                            />
+                    <Box>
+                        <ActionBar />
+                    </Box>
+                    <Box sx={{ mb: 3 }}>
+                        <Typography variant="h3" sx={{ mb: 1 }}>
+                            {t("introTitle")}
+                        </Typography>
+                        <MarkDownSanitizedWithHtml content={description} />
+                    </Box>
+                    <Box>
+                        <DatasetsContent
+                            datasets={dataset_versions}
+                            anchorIndex={1}
+                        />
 
-                            <ToolsContent
-                                tools={tools}
-                                anchorIndex={2}
-                                translationPath={TRANSLATION_PATH}
-                            />
+                        <ToolsContent
+                            tools={tools}
+                            anchorIndex={2}
+                            translationPath={TRANSLATION_PATH}
+                        />
 
-                            <DataUsesContent
-                                datauses={dur}
-                                anchorIndex={3}
-                                translationPath={TRANSLATION_PATH}
-                            />
+                        <DataUsesContent
+                            datauses={dur}
+                            anchorIndex={3}
+                            translationPath={TRANSLATION_PATH}
+                        />
 
-                            <PublicationsContent
-                                publications={publications}
-                                anchorIndex={4}
-                                translationPath={TRANSLATION_PATH}
-                            />
-                        </Box>
+                        <PublicationsContent
+                            publications={publications}
+                            anchorIndex={4}
+                            translationPath={TRANSLATION_PATH}
+                        />
                     </Box>
                 </>
             }

--- a/src/app/[locale]/(logged-out)/data-custodian-network/[dataCustodianNetworkId]/page.tsx
+++ b/src/app/[locale]/(logged-out)/data-custodian-network/[dataCustodianNetworkId]/page.tsx
@@ -62,7 +62,10 @@ export default async function DataCustodianNetworkPage({
             navigation={<ActiveListSidebar items={activeLinkList} />}
             body={
                 <>
-                    <Box sx={{ display: "flex", alignItems: "center" }}>
+                    <Typography variant="h1" sx={{ ml: 2, mt: 2 }}>
+                        {summaryData.name}
+                    </Typography>
+                    <Box sx={{ display: "flex", alignItems: "center", pt: 0 }}>
                         <AspectRatioImage
                             width={554}
                             height={250}
@@ -72,9 +75,6 @@ export default async function DataCustodianNetworkPage({
                                 StaticImages.BASE.placeholder
                             }
                         />
-                        <Typography variant="h1" sx={{ ml: 2 }}>
-                            {summaryData.name}
-                        </Typography>
                     </Box>
                     <ActionBar />
                     <Box

--- a/src/app/[locale]/(logged-out)/data-custodian/[dataCustodianId]/page.tsx
+++ b/src/app/[locale]/(logged-out)/data-custodian/[dataCustodianId]/page.tsx
@@ -69,7 +69,10 @@ export default async function DataCustodianItemPage({
             navigation={<ActiveListSidebar items={activeLinkList} />}
             body={
                 <>
-                    <Box sx={{ display: "flex", alignItems: "center" }}>
+                    <Typography variant="h1" sx={{ ml: 2, mt: 2 }}>
+                        {data.name}
+                    </Typography>
+                    <Box sx={{ display: "flex", alignItems: "center", pt: 0 }}>
                         <AspectRatioImage
                             width={554}
                             height={250}
@@ -78,9 +81,6 @@ export default async function DataCustodianItemPage({
                                 data?.team_logo || StaticImages.BASE.placeholder
                             }
                         />
-                        <Typography variant="h1" sx={{ ml: 2 }}>
-                            {data.name}
-                        </Typography>
                     </Box>
                     <ActionBar
                         team={{


### PR DESCRIPTION
## Screenshots (if relevant)
<img width="1746" height="736" alt="image" src="https://github.com/user-attachments/assets/3d3eb0b8-a590-4398-af8a-edecca739bf0" />

## Describe your changes
Place name of Custodian / Network above logo on Custodian / Network pages

## Issue ticket link
https://hdruk.atlassian.net/browse/GAT-8016

## Checklist before requesting a review

-   [ ] I have performed a self-review of my code
-   [ ] I have added appropriate unit tests
-   [ ] I have created mocks for unit tests (where appropriate)
-   [ ] The interface is responsive (where appropriate)
-   [ ] The interface is at least AA (where appropriate)
