### PR TITLE
fix(GAT-8070): Make publication search card title more readable on mobile and tablet

### DIFF
--- a/src/app/[locale]/(logged-out)/search/components/ResultCardPublication/ResultCardPublication.styles.ts
+++ b/src/app/[locale]/(logged-out)/search/components/ResultCardPublication/ResultCardPublication.styles.ts
@@ -4,14 +4,6 @@ import Link from "@/components/Link";
 import Typography from "@/components/Typography";
 import { colors } from "@/config/theme";
 
-export const PublicationTitleWrapper = styled("div")(({ theme }) => ({
-    display: "flex",
-    flexDirection: "row",
-    justifyContent: "space-between",
-    alignItems: "center",
-    marginBottom: theme.spacing(1),
-}));
-
 export const PublicationTitle = styled(Link)(() => ({
     width: "100%",
     fontWeight: 600,

--- a/src/app/[locale]/(logged-out)/search/components/ResultCardPublication/ResultCardPublication.tsx
+++ b/src/app/[locale]/(logged-out)/search/components/ResultCardPublication/ResultCardPublication.tsx
@@ -10,7 +10,6 @@ import {
     PublicationAbstract,
     PublicationText,
     PublicationTitle,
-    PublicationTitleWrapper,
     PublicationWrapper,
     PublicationYear,
 } from "./ResultCardPublication.styles";

--- a/src/app/[locale]/(logged-out)/search/components/ResultCardPublication/ResultCardPublication.tsx
+++ b/src/app/[locale]/(logged-out)/search/components/ResultCardPublication/ResultCardPublication.tsx
@@ -3,6 +3,7 @@ import { useTranslations } from "next-intl";
 import { SearchResultPublication } from "@/interfaces/Search";
 import EllipsisLineLimit from "@/components/EllipsisLineLimit";
 import ShowMore from "@/components/ShowMore";
+import Typography from "@/components/Typography";
 import { colors } from "@/config/theme";
 import { OpenInNewIcon } from "@/consts/icons";
 import {
@@ -44,7 +45,18 @@ const ResultCardPublication = ({ result }: ResultCardPublicationProps) => {
                 <PublicationWrapper
                     disableTypography
                     primary={
-                        <PublicationTitleWrapper>
+                        <Typography
+                            sx={{
+                                display: "flex",
+                                flexDirection: {
+                                    laptop: "row",
+                                    tablet: "column",
+                                    mobile: "column",
+                                },
+                                justifyContent: "space-between",
+                                alignItems: "flex-end",
+                                marginBottom: theme.spacing(1),
+                            }}>
                             <PublicationTitle
                                 href={full_text_url || url || ""}
                                 target="_blank">
@@ -57,22 +69,14 @@ const ResultCardPublication = ({ result }: ResultCardPublicationProps) => {
                                     sx={{ ml: isMobileOrTablet ? 1 : 2 }}
                                 />
                             </PublicationTitle>
-                            {!isMobileOrTablet && (
-                                <PublicationYear>
-                                    {t("published")}:{" "}
-                                    {year_of_publication || t("notAvailable")}
-                                </PublicationYear>
-                            )}
-                        </PublicationTitleWrapper>
+                            <PublicationYear>
+                                {t("published")}:{" "}
+                                {year_of_publication || t("notAvailable")}
+                            </PublicationYear>
+                        </Typography>
                     }
                     secondary={
                         <>
-                            {isMobileOrTablet && (
-                                <PublicationYear alignSelf="end">
-                                    {t("published")}:{" "}
-                                    {year_of_publication || t("notAvailable")}
-                                </PublicationYear>
-                            )}
                             <div>
                                 <ShowMore maxHeight={21}>
                                     <PublicationText sx={{ m: 0 }}>

--- a/src/app/[locale]/(logged-out)/search/components/ResultCardPublication/ResultCardPublication.tsx
+++ b/src/app/[locale]/(logged-out)/search/components/ResultCardPublication/ResultCardPublication.tsx
@@ -51,9 +51,11 @@ const ResultCardPublication = ({ result }: ResultCardPublicationProps) => {
                                 <EllipsisLineLimit
                                     text={paper_title || ""}
                                     showToolTip
-                                    maxLine={1}
+                                    maxLine={isMobileOrTablet ? 2 : 1}
                                 />
-                                <OpenInNewIcon sx={{ ml: 2 }} />
+                                <OpenInNewIcon
+                                    sx={{ ml: isMobileOrTablet ? 1 : 2 }}
+                                />
                             </PublicationTitle>
                             {!isMobileOrTablet && (
                                 <PublicationYear>

--- a/src/app/[locale]/(logged-out)/search/components/ResultCardPublication/ResultCardPublication.tsx
+++ b/src/app/[locale]/(logged-out)/search/components/ResultCardPublication/ResultCardPublication.tsx
@@ -1,4 +1,4 @@
-import { ListItem } from "@mui/material";
+import { ListItem, useMediaQuery, useTheme } from "@mui/material";
 import { useTranslations } from "next-intl";
 import { SearchResultPublication } from "@/interfaces/Search";
 import EllipsisLineLimit from "@/components/EllipsisLineLimit";
@@ -22,6 +22,9 @@ const TRANSLATION_PATH = "pages.search.components.ResultCardPublication";
 
 const ResultCardPublication = ({ result }: ResultCardPublicationProps) => {
     const t = useTranslations(TRANSLATION_PATH);
+
+    const theme = useTheme();
+    const isMobileOrTablet = useMediaQuery(theme.breakpoints.down("laptop"));
 
     const {
         abstract,
@@ -52,14 +55,22 @@ const ResultCardPublication = ({ result }: ResultCardPublicationProps) => {
                                 />
                                 <OpenInNewIcon sx={{ ml: 2 }} />
                             </PublicationTitle>
-                            <PublicationYear>
-                                {t("published")}:{" "}
-                                {year_of_publication || t("notAvailable")}
-                            </PublicationYear>
+                            {!isMobileOrTablet && (
+                                <PublicationYear>
+                                    {t("published")}:{" "}
+                                    {year_of_publication || t("notAvailable")}
+                                </PublicationYear>
+                            )}
                         </PublicationTitleWrapper>
                     }
                     secondary={
                         <>
+                            {isMobileOrTablet && (
+                                <PublicationYear alignSelf="end">
+                                    {t("published")}:{" "}
+                                    {year_of_publication || t("notAvailable")}
+                                </PublicationYear>
+                            )}
                             <div>
                                 <ShowMore maxHeight={21}>
                                     <PublicationText sx={{ m: 0 }}>


### PR DESCRIPTION
## Screenshots (if relevant)

https://github.com/user-attachments/assets/5bc60d44-29e8-4fd7-bc67-59429566bfd3


## Describe your changes
On tablet and mobile, move to 2 lines for title, and and move publication year down a row

## Issue ticket link
https://hdruk.atlassian.net/browse/GAT-8070

## Checklist before requesting a review

-   [ ] I have performed a self-review of my code
-   [ ] I have added appropriate unit tests
-   [ ] I have created mocks for unit tests (where appropriate)
-   [ ] The interface is responsive (where appropriate)
-   [ ] The interface is at least AA (where appropriate)
