### PR TITLE
fix(GAT-8070): Break action bar to grid earlier

### DIFF
--- a/src/app/[locale]/(logged-out)/dataset/[datasetId]/components/ActionBar/ActionBar.styles.ts
+++ b/src/app/[locale]/(logged-out)/dataset/[datasetId]/components/ActionBar/ActionBar.styles.ts
@@ -7,7 +7,7 @@ export const ActionBarWrapper = styled(Box)(() => ({
     width: "100%",
     boxShadow: "1px 1px 3px 0px #00000017",
 
-    [theme.breakpoints.up("tablet")]: {
+    [theme.breakpoints.up("desktop")]: {
         display: "flex",
         justifyContent: "space-between",
         alignItems: "center",

--- a/src/app/[locale]/(logged-out)/dataset/[datasetId]/components/ActionBar/ActionBar.tsx
+++ b/src/app/[locale]/(logged-out)/dataset/[datasetId]/components/ActionBar/ActionBar.tsx
@@ -210,8 +210,8 @@ const ActionBar = ({ dataset }: ActionBarProps) => {
     return (
         <ActionBarWrapper
             sx={{
-                display: { mobile: "grid", tablet: "flex" },
-                gap: { mobile: 1, tablet: 0 },
+                display: { mobile: "grid", desktop: "flex" },
+                gap: { mobile: 1, desktop: 0 },
             }}>
             <BackButton
                 label={t("label")}
@@ -225,12 +225,12 @@ const ActionBar = ({ dataset }: ActionBarProps) => {
 
             <Box
                 sx={{
-                    display: { mobile: "grid", tablet: "flex" },
+                    display: { mobile: "grid", desktop: "flex" },
                     gap: 1,
                     p: 0,
                     gridTemplateColumns: {
                         mobile: "repeat(2, minmax(0, 1fr))",
-                        tablet: "none",
+                        desktop: "none",
                     },
                 }}>
                 <Button onClick={handleGeneralEnquiryClick}>
@@ -282,7 +282,7 @@ const ActionBar = ({ dataset }: ActionBarProps) => {
                     }
                     sx={{
                         bgcolor: colors.grey200,
-                        ml: { mobile: 0, tablet: 2 },
+                        ml: { mobile: 0, desktop: 2 },
                     }}
                     onClick={handleOpenDropdownMenu}>
                     {t("downloadMetadata")}


### PR DESCRIPTION
## Screenshots (if relevant)
<img width="887" height="700" alt="image" src="https://github.com/user-attachments/assets/84551a60-f3b9-407e-b44e-6dc34f1b0ed1" />

## Describe your changes
Break action bar to grid earlier

## Issue ticket link
https://hdruk.atlassian.net/browse/GAT-8070

## Checklist before requesting a review

-   [ ] I have performed a self-review of my code
-   [ ] I have added appropriate unit tests
-   [ ] I have created mocks for unit tests (where appropriate)
-   [ ] The interface is responsive (where appropriate)
-   [ ] The interface is at least AA (where appropriate)
