### PR TITLE
fix(GAT-8073): Cohort hand over

### DIFF
--- a/.github/workflows/dev_deployment.yaml
+++ b/.github/workflows/dev_deployment.yaml
@@ -4,7 +4,7 @@ run-name: ${{ github.actor }} triggered deploy to DEV pipeline
 on:
   push:
     branches:
-      - "fix/GAT-8073-2"
+      - "dev"
 
 env:
   PROJECT_ID: "${{ secrets.PROJECT_ID }}"
@@ -24,7 +24,7 @@ jobs:
       - name: Checkout
         uses: actions/checkout@v4
         with:
-          ref: "fix/GAT-8073-2"
+          ref: "dev"
 
       - name: Read VERSION file
         id: getversion
@@ -73,7 +73,7 @@ jobs:
         id: checkout
         uses: actions/checkout@v4
         with:
-          ref: "fix/GAT-8073-2"
+          ref: "dev"
 
       - name: Google Auth
         id: auth

--- a/.github/workflows/dev_deployment.yaml
+++ b/.github/workflows/dev_deployment.yaml
@@ -4,7 +4,7 @@ run-name: ${{ github.actor }} triggered deploy to DEV pipeline
 on:
   push:
     branches:
-      - "dev"
+      - "fix/GAT-8073-2"
 
 env:
   PROJECT_ID: "${{ secrets.PROJECT_ID }}"
@@ -24,7 +24,7 @@ jobs:
       - name: Checkout
         uses: actions/checkout@v4
         with:
-          ref: "dev"
+          ref: "fix/GAT-8073-2"
 
       - name: Read VERSION file
         id: getversion
@@ -73,7 +73,7 @@ jobs:
         id: checkout
         uses: actions/checkout@v4
         with:
-          ref: "dev"
+          ref: "fix/GAT-8073-2"
 
       - name: Google Auth
         id: auth

--- a/src/app/[locale]/(logged-out)/about/cohort-discovery-request/components/CohortDiscoveryRequestForm/CohortDiscoveryRequestForm.tsx
+++ b/src/app/[locale]/(logged-out)/about/cohort-discovery-request/components/CohortDiscoveryRequestForm/CohortDiscoveryRequestForm.tsx
@@ -58,15 +58,15 @@ const CohortDiscoveryRequestForm = ({
 
     const [termsAccepted, setTermsAccepted] = useState<boolean>(false);
 
-   useEffect(() => {
-    if (!isUserLoading && !isAccessLoading) {
-        if (accessData?.redirect_url) {
-            push(accessData.redirect_url);
-        } else if (userData?.request_status === "APPROVED") {
-            push(`/${RouteName.ABOUT}/${RouteName.COHORT_DISCOVERY}`);
+    useEffect(() => {
+        if (!isUserLoading && !isAccessLoading) {
+            if (accessData?.redirect_url) {
+                push(accessData.redirect_url);
+            } else if (userData?.request_status === "APPROVED") {
+                push(`/${RouteName.ABOUT}/${RouteName.COHORT_DISCOVERY}`);
+            }
         }
-    }
-}, [isUserLoading, isAccessLoading, accessData, userData, push]);
+    }, [isUserLoading, isAccessLoading, accessData, userData, push]);
 
     return !isUserLoading && !isAccessLoading ? (
         <BoxContainer

--- a/src/app/[locale]/(logged-out)/about/cohort-discovery-request/components/CohortDiscoveryRequestForm/CohortDiscoveryRequestForm.tsx
+++ b/src/app/[locale]/(logged-out)/about/cohort-discovery-request/components/CohortDiscoveryRequestForm/CohortDiscoveryRequestForm.tsx
@@ -1,9 +1,9 @@
 "use client";
 
-import { useState } from "react";
+import { useEffect, useState } from "react";
 import { Box, Divider, Paper, Typography } from "@mui/material";
 import { useTranslations } from "next-intl";
-import { redirect, useRouter } from "next/navigation";
+import { useRouter } from "next/navigation";
 import { templateRepeatFields } from "@/interfaces/Cms";
 import { CohortRequest } from "@/interfaces/CohortRequest";
 import BoxContainer from "@/components/BoxContainer";
@@ -28,7 +28,7 @@ interface accessRequestType {
     redirect_url: string;
 }
 
-const CohortDisoveryRequestForm = ({
+const CohortDiscoveryRequestForm = ({
     cmsContent,
     userId,
 }: CohortDisoveryRequestFormProps) => {
@@ -58,16 +58,15 @@ const CohortDisoveryRequestForm = ({
 
     const [termsAccepted, setTermsAccepted] = useState<boolean>(false);
 
+   useEffect(() => {
     if (!isUserLoading && !isAccessLoading) {
         if (accessData?.redirect_url) {
-            redirect(accessData?.redirect_url);
-        } else if (
-            userData?.request_status &&
-            userData.request_status === "APPROVED"
-        ) {
-            redirect(`/${RouteName.ABOUT}/${RouteName.COHORT_DISCOVERY}`);
+            push(accessData.redirect_url);
+        } else if (userData?.request_status === "APPROVED") {
+            push(`/${RouteName.ABOUT}/${RouteName.COHORT_DISCOVERY}`);
         }
     }
+}, [isUserLoading, isAccessLoading, accessData, userData, push]);
 
     return !isUserLoading && !isAccessLoading ? (
         <BoxContainer

--- a/src/app/[locale]/(logged-out)/about/cohort-discovery-request/components/CohortDiscoveryRequestForm/CohortDiscoveryRequestForm.tsx
+++ b/src/app/[locale]/(logged-out)/about/cohort-discovery-request/components/CohortDiscoveryRequestForm/CohortDiscoveryRequestForm.tsx
@@ -62,9 +62,10 @@ const CohortDiscoveryRequestForm = ({
         if (!isUserLoading && !isAccessLoading) {
             if (accessData?.redirect_url) {
                 push(accessData.redirect_url);
-            } else if (userData?.request_status === "APPROVED") {
-                push(`/${RouteName.ABOUT}/${RouteName.COHORT_DISCOVERY}`);
-            }
+           } else if (
+            userData?.request_status &&
+            userData.request_status === "APPROVED"
+        ) {
         }
     }, [isUserLoading, isAccessLoading, accessData, userData, push]);
 

--- a/src/app/[locale]/(logged-out)/about/cohort-discovery-request/components/CohortDiscoveryRequestForm/CohortDiscoveryRequestForm.tsx
+++ b/src/app/[locale]/(logged-out)/about/cohort-discovery-request/components/CohortDiscoveryRequestForm/CohortDiscoveryRequestForm.tsx
@@ -62,10 +62,12 @@ const CohortDiscoveryRequestForm = ({
         if (!isUserLoading && !isAccessLoading) {
             if (accessData?.redirect_url) {
                 push(accessData.redirect_url);
-           } else if (
-            userData?.request_status &&
-            userData.request_status === "APPROVED"
-        ) {
+            } else if (
+                userData?.request_status &&
+                userData.request_status === "APPROVED"
+            ) {
+                push(`/${RouteName.ABOUT}/${RouteName.COHORT_DISCOVERY}`);
+            }
         }
     }, [isUserLoading, isAccessLoading, accessData, userData, push]);
 

--- a/src/app/[locale]/(logged-out)/about/cohort-discovery-request/components/CohortDiscoveryRequestForm/CohortDiscoveryRequestForm.tsx
+++ b/src/app/[locale]/(logged-out)/about/cohort-discovery-request/components/CohortDiscoveryRequestForm/CohortDiscoveryRequestForm.tsx
@@ -19,7 +19,7 @@ import CohortRequestTermsDialog from "../CohortRequestTermsDialog";
 
 const COHORT_TRANSLATION_PATH = "pages.about.cohortDiscoveryRequest";
 
-interface CohortDisoveryRequestFormProps {
+interface CohortDiscoveryRequestFormProps {
     cmsContent: templateRepeatFields;
     userId: number;
 }
@@ -31,7 +31,7 @@ interface accessRequestType {
 const CohortDiscoveryRequestForm = ({
     cmsContent,
     userId,
-}: CohortDisoveryRequestFormProps) => {
+}: CohortDiscoveryRequestFormProps) => {
     const { push } = useRouter();
     const { showDialog } = useDialog();
     const t = useTranslations();
@@ -152,4 +152,4 @@ const CohortDiscoveryRequestForm = ({
     ) : null;
 };
 
-export default CohortDisoveryRequestForm;
+export default CohortDiscoveryRequestForm;

--- a/src/app/[locale]/(logged-out)/about/cohort-discovery-request/components/CohortDiscoveryRequestForm/index.ts
+++ b/src/app/[locale]/(logged-out)/about/cohort-discovery-request/components/CohortDiscoveryRequestForm/index.ts
@@ -1,3 +1,3 @@
-import CohortDisoveryRequestForm from "./CohortDiscoveryRequestForm";
+import CohortDiscoveryRequestForm from "./CohortDiscoveryRequestForm";
 
-export default CohortDisoveryRequestForm;
+export default CohortDiscoveryRequestForm;

--- a/src/app/[locale]/(logged-out)/about/cohort-discovery-request/components/CohortDiscoveryRequestForm/index.ts
+++ b/src/app/[locale]/(logged-out)/about/cohort-discovery-request/components/CohortDiscoveryRequestForm/index.ts
@@ -1,0 +1,3 @@
+import CohortDisoveryRequestForm from "./CohortDiscoveryRequestForm";
+
+export default CohortDisoveryRequestForm;

--- a/src/app/[locale]/(logged-out)/about/cohort-discovery-request/components/CohortDisoveryRequestForm/index.ts
+++ b/src/app/[locale]/(logged-out)/about/cohort-discovery-request/components/CohortDisoveryRequestForm/index.ts
@@ -1,3 +1,0 @@
-import CohortDisoveryRequestForm from "./CohortDisoveryRequestForm";
-
-export default CohortDisoveryRequestForm;

--- a/src/app/[locale]/(logged-out)/about/cohort-discovery-request/page.tsx
+++ b/src/app/[locale]/(logged-out)/about/cohort-discovery-request/page.tsx
@@ -4,7 +4,7 @@ import ProtectedAccountRoute from "@/components/ProtectedAccountRoute";
 import { getUserFromCookie } from "@/utils/api";
 import { getCohortTermsAndConditions } from "@/utils/cms";
 import metaData from "@/utils/metadata";
-import CohortDisoveryRequestForm from "./components/CohortDisoveryRequestForm";
+import CohortDiscoveryRequestForm from "./components/CohortDiscoveryRequestForm";
 
 export const metadata = metaData({
     title: "Cohort Discovery Request - About",
@@ -23,7 +23,7 @@ export default async function CohortDiscoryRequestPage() {
     return (
         <ProtectedAccountRoute loggedInOnly={!!user?.id}>
             <Container>
-                <CohortDisoveryRequestForm
+                <CohortDiscoveryRequestForm
                     userId={user?.id}
                     cmsContent={repeatfields}
                 />


### PR DESCRIPTION
## Screenshots (if relevant)

## Describe your changes
redirect is a server side function, this is a client component. 

Next will prefetch under 2 conditions

- Production mode
- internal url

Cohort sits under the same domain so it thinks its the same app so it will try to prefetch on occasion, This happens with redirect and next link components.

As its client we should really be using push not redirect.

## Issue ticket link

## Checklist before requesting a review

-   [ ] I have performed a self-review of my code
-   [ ] I have added appropriate unit tests
-   [ ] I have created mocks for unit tests (where appropriate)
-   [ ] The interface is responsive (where appropriate)
-   [ ] The interface is at least AA (where appropriate)
