### PR TITLE
fix(GAT-7911): Dom parser error

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "gateway-web-2",
-  "version": "2.23.0",
+  "version": "2.24.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "gateway-web-2",
-      "version": "2.23.0",
+      "version": "2.24.0",
       "dependencies": {
         "@dnd-kit/core": "^6.1.0",
         "@dnd-kit/sortable": "^8.0.0",
@@ -55,6 +55,7 @@
         "eslint": "^8.37.0",
         "eslint-config-next": "^14.1.0",
         "get-node-dimensions": "^1.2.1",
+        "he": "^1.2.0",
         "html-react-parser": "^5.1.16",
         "i18next": "^22.5.1",
         "i18next-browser-languagedetector": "^7.1.0",
@@ -110,6 +111,7 @@
         "@testing-library/user-event": "^14.4.3",
         "@trivago/prettier-plugin-sort-imports": "^4.3.0",
         "@types/get-node-dimensions": "^1.2.4",
+        "@types/he": "^1.2.3",
         "@types/react-lines-ellipsis": "^0.15.6",
         "@types/react-virtualized": "^9.21.29",
         "@typescript-eslint/eslint-plugin": "^5.57.1",
@@ -9270,6 +9272,13 @@
         "@types/node": "*"
       }
     },
+    "node_modules/@types/he": {
+      "version": "1.2.3",
+      "resolved": "https://registry.npmjs.org/@types/he/-/he-1.2.3.tgz",
+      "integrity": "sha512-q67/qwlxblDzEDvzHhVkwc1gzVWxaNxeyHUBF4xElrvjL11O+Ytze+1fGpBHlr/H9myiBUaUXNnNPmBHxxfAcA==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/@types/html-minifier-terser": {
       "version": "6.1.0",
       "resolved": "https://registry.npmjs.org/@types/html-minifier-terser/-/html-minifier-terser-6.1.0.tgz",
@@ -16403,7 +16412,7 @@
       "version": "1.2.0",
       "resolved": "https://registry.npmjs.org/he/-/he-1.2.0.tgz",
       "integrity": "sha512-F/1DnUGPopORZi0ni+CvrCgHQ5FyEAHRLSApuYWMmrbSwoN2Mn/7k+Gl38gJnR7yyDZk6WLXwiGod1JOWNDKGw==",
-      "dev": true,
+      "license": "MIT",
       "bin": {
         "he": "bin/he"
       }

--- a/package-lock.json
+++ b/package-lock.json
@@ -55,6 +55,7 @@
         "eslint": "^8.37.0",
         "eslint-config-next": "^14.1.0",
         "get-node-dimensions": "^1.2.1",
+        "he": "^1.2.0",
         "html-react-parser": "^5.1.16",
         "i18next": "^22.5.1",
         "i18next-browser-languagedetector": "^7.1.0",
@@ -110,6 +111,7 @@
         "@testing-library/user-event": "^14.4.3",
         "@trivago/prettier-plugin-sort-imports": "^4.3.0",
         "@types/get-node-dimensions": "^1.2.4",
+        "@types/he": "^1.2.3",
         "@types/react-lines-ellipsis": "^0.15.6",
         "@types/react-virtualized": "^9.21.29",
         "@typescript-eslint/eslint-plugin": "^5.57.1",
@@ -9270,6 +9272,13 @@
         "@types/node": "*"
       }
     },
+    "node_modules/@types/he": {
+      "version": "1.2.3",
+      "resolved": "https://registry.npmjs.org/@types/he/-/he-1.2.3.tgz",
+      "integrity": "sha512-q67/qwlxblDzEDvzHhVkwc1gzVWxaNxeyHUBF4xElrvjL11O+Ytze+1fGpBHlr/H9myiBUaUXNnNPmBHxxfAcA==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/@types/html-minifier-terser": {
       "version": "6.1.0",
       "resolved": "https://registry.npmjs.org/@types/html-minifier-terser/-/html-minifier-terser-6.1.0.tgz",
@@ -16403,7 +16412,6 @@
       "version": "1.2.0",
       "resolved": "https://registry.npmjs.org/he/-/he-1.2.0.tgz",
       "integrity": "sha512-F/1DnUGPopORZi0ni+CvrCgHQ5FyEAHRLSApuYWMmrbSwoN2Mn/7k+Gl38gJnR7yyDZk6WLXwiGod1JOWNDKGw==",
-      "dev": true,
       "license": "MIT",
       "bin": {
         "he": "bin/he"

--- a/package-lock.json
+++ b/package-lock.json
@@ -55,7 +55,6 @@
         "eslint": "^8.37.0",
         "eslint-config-next": "^14.1.0",
         "get-node-dimensions": "^1.2.1",
-        "he": "^1.2.0",
         "html-react-parser": "^5.1.16",
         "i18next": "^22.5.1",
         "i18next-browser-languagedetector": "^7.1.0",
@@ -111,7 +110,6 @@
         "@testing-library/user-event": "^14.4.3",
         "@trivago/prettier-plugin-sort-imports": "^4.3.0",
         "@types/get-node-dimensions": "^1.2.4",
-        "@types/he": "^1.2.3",
         "@types/react-lines-ellipsis": "^0.15.6",
         "@types/react-virtualized": "^9.21.29",
         "@typescript-eslint/eslint-plugin": "^5.57.1",
@@ -9272,13 +9270,6 @@
         "@types/node": "*"
       }
     },
-    "node_modules/@types/he": {
-      "version": "1.2.3",
-      "resolved": "https://registry.npmjs.org/@types/he/-/he-1.2.3.tgz",
-      "integrity": "sha512-q67/qwlxblDzEDvzHhVkwc1gzVWxaNxeyHUBF4xElrvjL11O+Ytze+1fGpBHlr/H9myiBUaUXNnNPmBHxxfAcA==",
-      "dev": true,
-      "license": "MIT"
-    },
     "node_modules/@types/html-minifier-terser": {
       "version": "6.1.0",
       "resolved": "https://registry.npmjs.org/@types/html-minifier-terser/-/html-minifier-terser-6.1.0.tgz",
@@ -16412,6 +16403,7 @@
       "version": "1.2.0",
       "resolved": "https://registry.npmjs.org/he/-/he-1.2.0.tgz",
       "integrity": "sha512-F/1DnUGPopORZi0ni+CvrCgHQ5FyEAHRLSApuYWMmrbSwoN2Mn/7k+Gl38gJnR7yyDZk6WLXwiGod1JOWNDKGw==",
+      "dev": true,
       "license": "MIT",
       "bin": {
         "he": "bin/he"

--- a/package.json
+++ b/package.json
@@ -24,7 +24,6 @@
     "pageTester": "tsx ./datasetsPageTester.ts"
   },
   "dependencies": {
-    "@vercel/flags": "3.1.1",
     "@dnd-kit/core": "^6.1.0",
     "@dnd-kit/sortable": "^8.0.0",
     "@dnd-kit/utilities": "^3.2.2",
@@ -60,6 +59,7 @@
     "@types/node": "18.14.4",
     "@types/react": "18.0.28",
     "@types/react-dom": "18.0.11",
+    "@vercel/flags": "3.1.1",
     "@visx/group": "^3.3.0",
     "@visx/responsive": "^3.3.0",
     "@visx/scale": "^3.5.0",
@@ -71,6 +71,7 @@
     "eslint": "^8.37.0",
     "eslint-config-next": "^14.1.0",
     "get-node-dimensions": "^1.2.1",
+    "he": "^1.2.0",
     "html-react-parser": "^5.1.16",
     "i18next": "^22.5.1",
     "i18next-browser-languagedetector": "^7.1.0",
@@ -126,6 +127,7 @@
     "@testing-library/user-event": "^14.4.3",
     "@trivago/prettier-plugin-sort-imports": "^4.3.0",
     "@types/get-node-dimensions": "^1.2.4",
+    "@types/he": "^1.2.3",
     "@types/react-lines-ellipsis": "^0.15.6",
     "@types/react-virtualized": "^9.21.29",
     "@typescript-eslint/eslint-plugin": "^5.57.1",

--- a/package.json
+++ b/package.json
@@ -71,7 +71,6 @@
     "eslint": "^8.37.0",
     "eslint-config-next": "^14.1.0",
     "get-node-dimensions": "^1.2.1",
-    "he": "^1.2.0",
     "html-react-parser": "^5.1.16",
     "i18next": "^22.5.1",
     "i18next-browser-languagedetector": "^7.1.0",
@@ -127,7 +126,7 @@
     "@testing-library/user-event": "^14.4.3",
     "@trivago/prettier-plugin-sort-imports": "^4.3.0",
     "@types/get-node-dimensions": "^1.2.4",
-    "@types/he": "^1.2.3",
+  
     "@types/react-lines-ellipsis": "^0.15.6",
     "@types/react-virtualized": "^9.21.29",
     "@typescript-eslint/eslint-plugin": "^5.57.1",

--- a/package.json
+++ b/package.json
@@ -71,6 +71,7 @@
     "eslint": "^8.37.0",
     "eslint-config-next": "^14.1.0",
     "get-node-dimensions": "^1.2.1",
+    "he": "^1.2.0",
     "html-react-parser": "^5.1.16",
     "i18next": "^22.5.1",
     "i18next-browser-languagedetector": "^7.1.0",
@@ -126,7 +127,7 @@
     "@testing-library/user-event": "^14.4.3",
     "@trivago/prettier-plugin-sort-imports": "^4.3.0",
     "@types/get-node-dimensions": "^1.2.4",
-  
+    "@types/he": "^1.2.3",
     "@types/react-lines-ellipsis": "^0.15.6",
     "@types/react-virtualized": "^9.21.29",
     "@typescript-eslint/eslint-plugin": "^5.57.1",

--- a/src/utils/general.ts
+++ b/src/utils/general.ts
@@ -1,4 +1,4 @@
-import { decode } from "he";
+import DOMPurify from "isomorphic-dompurify";
 
 const capitalise = (str: string) => {
     return str.charAt(0).toUpperCase() + str.slice(1).toLowerCase();
@@ -54,7 +54,7 @@ function parseStaticImagePaths<T>(values: T, prefix?: string) {
 }
 
 function decodeHtmlEntity(input: string): string {
-    return decode(input);
+    return DOMPurify(input);
 }
 
 export {

--- a/src/utils/general.ts
+++ b/src/utils/general.ts
@@ -1,3 +1,6 @@
+import { decode } from "he";
+
+
 const capitalise = (str: string) => {
     return str.charAt(0).toUpperCase() + str.slice(1).toLowerCase();
 };
@@ -52,8 +55,7 @@ function parseStaticImagePaths<T>(values: T, prefix?: string) {
 }
 
 function decodeHtmlEntity(input: string): string {
-    const doc = new DOMParser().parseFromString(input, "text/html");
-    return doc.documentElement.textContent || "";
+  return decode(input);
 }
 
 export {

--- a/src/utils/general.ts
+++ b/src/utils/general.ts
@@ -1,4 +1,4 @@
-import DOMPurify from "isomorphic-dompurify";
+import { decode } from "he";
 
 const capitalise = (str: string) => {
     return str.charAt(0).toUpperCase() + str.slice(1).toLowerCase();
@@ -54,7 +54,7 @@ function parseStaticImagePaths<T>(values: T, prefix?: string) {
 }
 
 function decodeHtmlEntity(input: string): string {
-    return DOMPurify(input);
+    return decode(input);
 }
 
 export {

--- a/src/utils/general.ts
+++ b/src/utils/general.ts
@@ -1,6 +1,5 @@
 import { decode } from "he";
 
-
 const capitalise = (str: string) => {
     return str.charAt(0).toUpperCase() + str.slice(1).toLowerCase();
 };
@@ -55,7 +54,7 @@ function parseStaticImagePaths<T>(values: T, prefix?: string) {
 }
 
 function decodeHtmlEntity(input: string): string {
-  return decode(input);
+    return decode(input);
 }
 
 export {


### PR DESCRIPTION
## Screenshots (if relevant)

## Describe your changes
Error for serverside: ReferenceError: DOMParser is not defined
    at l (/usr/src/.next/server/chunks/9112.js:14:85685)
    at /usr/src/.next/server/app/[locale]/(logged-out)/dataset/[datasetId]/page.js:9:8792
    at Array.map (<anonymous>)
    at l (/usr/src/.next/server/app/[locale]/(logged-out)/dataset/[datasetId]/page.js:9:8777)
    at /usr/src/.next/server/app/[locale]/(logged-out)/dataset/[datasetId]/page.js:9:10959
    at Array.map (<anonymous>)
    at /usr/src/.next/server/app/[locale]/(logged-out)/dataset/[datasetId]/page.js:9:10413
    at Array.map (<anonymous>)
    at X (/usr/src/.next/server/app/[locale]/(logged-out)/dataset/[datasetId]/page.js:9:9409)
    at nM (/usr/src/node_modules/next/dist/compiled/next-server/app-page.runtime.prod.js:12:47419)


DomParser is a browser api not a node api so it wont exist when ran in SSR.
## Issue ticket link

## Checklist before requesting a review

-   [ ] I have performed a self-review of my code
-   [ ] I have added appropriate unit tests
-   [ ] I have created mocks for unit tests (where appropriate)
-   [ ] The interface is responsive (where appropriate)
-   [ ] The interface is at least AA (where appropriate)
