### PR TITLE
feat(GAT-8105): Use team payload to determine cohort support on Custodian landing pages

### DIFF
--- a/src/app/[locale]/(logged-out)/data-custodian/[dataCustodianId]/page.tsx
+++ b/src/app/[locale]/(logged-out)/data-custodian/[dataCustodianId]/page.tsx
@@ -46,13 +46,9 @@ export default async function DataCustodianItemPage({
 
     const cohortDiscovery = await getCohortDiscovery();
 
-    const promises = data.datasets.map(x =>
-        getDataset(cookieStore, x.id.toString())
+    const enableCohortDiscovery = data.datasets.some(
+        x => x.is_cohort_discovery
     );
-
-    const datasets = await Promise.all(promises);
-
-    const enableCohortDiscovery = datasets.some(x => x.is_cohort_discovery);
 
     const populatedSections = dataCustodianFields.filter(section =>
         section.fields.some(field => !isEmpty(get(data, field.path)))

--- a/src/app/[locale]/(logged-out)/data-custodian/[dataCustodianId]/page.tsx
+++ b/src/app/[locale]/(logged-out)/data-custodian/[dataCustodianId]/page.tsx
@@ -15,7 +15,7 @@ import Typography from "@/components/Typography";
 import ActiveListSidebar from "@/modules/ActiveListSidebar";
 import { StaticImages } from "@/config/images";
 import { AspectRatioImage } from "@/config/theme";
-import { getDataset, getTeamSummary } from "@/utils/api";
+import { getTeamSummary } from "@/utils/api";
 import { getCohortDiscovery } from "@/utils/cms";
 import metaData from "@/utils/metadata";
 import ActionBar from "./components/ActionBar";

--- a/src/interfaces/Dataset.ts
+++ b/src/interfaces/Dataset.ts
@@ -214,6 +214,7 @@ interface Dataset {
 
 interface DataCustodianDataset {
     id: number;
+    is_cohort_discovery: boolean;
     populationSize: number;
     title: string;
     datasetType: string;


### PR DESCRIPTION
## Screenshots (if relevant)

## Describe your changes
Relies upon first merging https://github.com/HDRUK/gateway-api/pull/1460.

Speeds up page load of `/data-custodian/{id}` considerably.

## Issue ticket link
https://hdruk.atlassian.net/browse/GAT-8105

## Checklist before requesting a review

-   [ ] I have performed a self-review of my code
-   [ ] I have added appropriate unit tests
-   [ ] I have created mocks for unit tests (where appropriate)
-   [ ] The interface is responsive (where appropriate)
-   [ ] The interface is at least AA (where appropriate)
