### PR TITLE
fix(GAT-7692): Format filter text when too long

### DIFF
--- a/src/app/[locale]/(logged-out)/search/components/FilterPanel/FilterPanel.tsx
+++ b/src/app/[locale]/(logged-out)/search/components/FilterPanel/FilterPanel.tsx
@@ -853,7 +853,10 @@ const FilterPanel = ({
                                     width: "100%",
                                     pr: 3.25,
                                 }}>
-                                <Typography fontWeight="400" fontSize={20}>
+                                <Typography
+                                    fontWeight="400"
+                                    fontSize={20}
+                                    sx={{ textWrap: "auto" }}>
                                     {t(label)}
                                 </Typography>
                                 {filterCount}


### PR DESCRIPTION
## Screenshots (if relevant)
<img width="355" height="775" alt="image" src="https://github.com/user-attachments/assets/75306d62-9a27-461e-9cb1-4629b287a9b4" />

## Describe your changes
Format filter text when too long

## Issue ticket link
https://hdruk.atlassian.net/browse/GAT-7692

## Checklist before requesting a review

-   [ ] I have performed a self-review of my code
-   [ ] I have added appropriate unit tests
-   [ ] I have created mocks for unit tests (where appropriate)
-   [ ] The interface is responsive (where appropriate)
-   [ ] The interface is at least AA (where appropriate)
