### PR TITLE
fix(GAT-8409): Resolve issues around searching publications

### DIFF
--- a/src/app/[locale]/account/profile/publications/components/DatasetRelationshipFields/DatasetRelationshipFields.tsx
+++ b/src/app/[locale]/account/profile/publications/components/DatasetRelationshipFields/DatasetRelationshipFields.tsx
@@ -144,10 +144,11 @@ const DatasetRelationshipFields = <TFieldValues extends FieldValues>({
                     <Box
                         sx={{
                             p: 0,
+                            mt: "5px",
                             gridColumn: "span 1",
                             display: "flex",
                             justifyContent: "flex-end",
-                            alignItems: "flex-end",
+                            alignItems: "flex-start",
                         }}>
                         {fields.length > 1 && (
                             <IconButton

--- a/src/components/Autocomplete/Autocomplete.tsx
+++ b/src/components/Autocomplete/Autocomplete.tsx
@@ -132,7 +132,6 @@ const Autocomplete = <T extends FieldValues>(props: AutocompleteProps<T>) => {
             <MuiAutocomplete
                 id={id || name}
                 {...field}
-                value={field.value ?? []}
                 {...restProps}
                 freeSolo={freeSolo}
                 multiple={multiple}
@@ -273,7 +272,9 @@ const Autocomplete = <T extends FieldValues>(props: AutocompleteProps<T>) => {
                 noOptionsText={
                     isLoadingOptions ? <Loading size={30} /> : noOptionsText
                 }
-                ListboxProps={{ style: { maxHeight: "35vh" } }}
+                slotProps={{
+                    listbox: { style: { maxHeight: "35vh" } },
+                }}
             />
         </FormInputWrapper>
     );

--- a/src/config/forms/publication.tsx
+++ b/src/config/forms/publication.tsx
@@ -99,7 +99,6 @@ const formArrayFields = [
         component: inputComponents.Autocomplete,
         name: "id",
         placeholder: "Type to search dataset titles",
-        showClearButton: true,
         required: true,
     },
 ];


### PR DESCRIPTION
## Screenshots (if relevant)
<img width="1114" height="137" alt="image" src="https://github.com/user-attachments/assets/b3755f77-4d57-48d6-975e-da27f7b6ae86" />

## Describe your changes
Autocomplete value was being wiped when typing
Improved styling around publications creation page

## Issue ticket link
https://hdruk.atlassian.net/browse/GAT-8409

## Checklist before requesting a review

-   [ ] I have performed a self-review of my code
-   [ ] I have added appropriate unit tests
-   [ ] I have created mocks for unit tests (where appropriate)
-   [ ] The interface is responsive (where appropriate)
-   [ ] The interface is at least AA (where appropriate)
