### PR TITLE
feat(GAT-7895): Filter chips now have orange background when selected

### DIFF
--- a/src/app/[locale]/(logged-out)/search/components/FilterChips/FilterChips.tsx
+++ b/src/app/[locale]/(logged-out)/search/components/FilterChips/FilterChips.tsx
@@ -72,7 +72,7 @@ const FilterChips = ({
                                                     marginBottom: "4px",
                                                     "&:focus-visible": {
                                                         borderColor:
-                                                            colors.orange200,
+                                                            colors.orange,
                                                         borderWidth: 2,
                                                         backgroundColor:
                                                             colors.green400,

--- a/src/app/[locale]/(logged-out)/search/components/FilterChips/FilterChips.tsx
+++ b/src/app/[locale]/(logged-out)/search/components/FilterChips/FilterChips.tsx
@@ -58,12 +58,25 @@ const FilterChips = ({
                                             )}`}
                                             placement="top">
                                             <Chip
+                                                variant="outlined"
                                                 sx={{
                                                     textOverflow: "ellipsis",
                                                     maxWidth: 200,
                                                     overflow: "hidden",
                                                     whiteSpace: "nowrap",
+                                                    color: colors.white,
+                                                    backgroundColor:
+                                                        colors.green400,
+                                                    borderColor:
+                                                        colors.green400,
                                                     marginBottom: "4px",
+                                                    "&:focus-visible": {
+                                                        borderColor:
+                                                            colors.orange200,
+                                                        borderWidth: 2,
+                                                        backgroundColor:
+                                                            colors.green400,
+                                                    },
                                                 }}
                                                 color={color}
                                                 size={size}


### PR DESCRIPTION
## Screenshots (if relevant)
<img width="599" height="198" alt="Screenshot 2026-01-26 at 11 07 10" src="https://github.com/user-attachments/assets/4b491a9b-625d-4ec5-963d-26ccb5b4b187" />


## Describe your changes

## Issue ticket link
https://hdruk.atlassian.net/browse/GAT-6783
https://hdruk.atlassian.net/browse/GAT-7895

## Checklist before requesting a review

-   [ ] I have performed a self-review of my code
-   [ ] I have added appropriate unit tests
-   [ ] I have created mocks for unit tests (where appropriate)
-   [ ] The interface is responsive (where appropriate)
-   [ ] The interface is at least AA (where appropriate)
