### PR TITLE
fix!(GAT-7896): Updated focus to use orange outline

### DIFF
--- a/src/app/[locale]/account/team/[teamId]/(withLeftNav)/team-management/components/EmailNotificationDescriptions/__snapshots__/EmailNotificationDescriptions.test.tsx.snap
+++ b/src/app/[locale]/account/team/[teamId]/(withLeftNav)/team-management/components/EmailNotificationDescriptions/__snapshots__/EmailNotificationDescriptions.test.tsx.snap
@@ -55,7 +55,7 @@ exports[`EmailNotificationDescriptions should render component 1`] = `
         </li>
       </ul>
       <button
-        class="MuiButtonBase-root MuiButton-root MuiButton-link MuiButton-linkPrimary MuiButton-sizeMedium MuiButton-linkSizeMedium MuiButton-colorPrimary MuiButton-root MuiButton-link MuiButton-linkPrimary MuiButton-sizeMedium MuiButton-linkSizeMedium MuiButton-colorPrimary mui-style-139u6bb-MuiButtonBase-root-MuiButton-root"
+        class="MuiButtonBase-root MuiButton-root MuiButton-link MuiButton-linkPrimary MuiButton-sizeMedium MuiButton-linkSizeMedium MuiButton-colorPrimary MuiButton-root MuiButton-link MuiButton-linkPrimary MuiButton-sizeMedium MuiButton-linkSizeMedium MuiButton-colorPrimary mui-style-hwac07-MuiButtonBase-root-MuiButton-root"
         tabindex="0"
         type="button"
       >

--- a/src/components/CMSPromoTemplate/__snapshots__/CMSPromoTemplate.test.tsx.snap
+++ b/src/components/CMSPromoTemplate/__snapshots__/CMSPromoTemplate.test.tsx.snap
@@ -78,7 +78,7 @@ exports[`CMSPromoTemplate should render content 1`] = `
         href="button/url"
       >
         <button
-          class="MuiButtonBase-root MuiButton-root MuiButton-contained MuiButton-containedPrimary MuiButton-sizeMedium MuiButton-containedSizeMedium MuiButton-colorPrimary MuiButton-root MuiButton-contained MuiButton-containedPrimary MuiButton-sizeMedium MuiButton-containedSizeMedium MuiButton-colorPrimary mui-style-1yfghat-MuiButtonBase-root-MuiButton-root"
+          class="MuiButtonBase-root MuiButton-root MuiButton-contained MuiButton-containedPrimary MuiButton-sizeMedium MuiButton-containedSizeMedium MuiButton-colorPrimary MuiButton-root MuiButton-contained MuiButton-containedPrimary MuiButton-sizeMedium MuiButton-containedSizeMedium MuiButton-colorPrimary mui-style-1mfbltw-MuiButtonBase-root-MuiButton-root"
           tabindex="0"
           type="button"
         >
@@ -122,7 +122,7 @@ exports[`CMSPromoTemplate should render content 1`] = `
         href="button/url"
       >
         <button
-          class="MuiButtonBase-root MuiButton-root MuiButton-contained MuiButton-containedPrimary MuiButton-sizeMedium MuiButton-containedSizeMedium MuiButton-colorPrimary MuiButton-root MuiButton-contained MuiButton-containedPrimary MuiButton-sizeMedium MuiButton-containedSizeMedium MuiButton-colorPrimary mui-style-1yfghat-MuiButtonBase-root-MuiButton-root"
+          class="MuiButtonBase-root MuiButton-root MuiButton-contained MuiButton-containedPrimary MuiButton-sizeMedium MuiButton-containedSizeMedium MuiButton-colorPrimary MuiButton-root MuiButton-contained MuiButton-containedPrimary MuiButton-sizeMedium MuiButton-containedSizeMedium MuiButton-colorPrimary mui-style-1mfbltw-MuiButtonBase-root-MuiButton-root"
           tabindex="0"
           type="button"
         >
@@ -159,7 +159,7 @@ exports[`CMSPromoTemplate should render content 1`] = `
         href="button/url"
       >
         <button
-          class="MuiButtonBase-root MuiButton-root MuiButton-contained MuiButton-containedPrimary MuiButton-sizeMedium MuiButton-containedSizeMedium MuiButton-colorPrimary MuiButton-root MuiButton-contained MuiButton-containedPrimary MuiButton-sizeMedium MuiButton-containedSizeMedium MuiButton-colorPrimary mui-style-1yfghat-MuiButtonBase-root-MuiButton-root"
+          class="MuiButtonBase-root MuiButton-root MuiButton-contained MuiButton-containedPrimary MuiButton-sizeMedium MuiButton-containedSizeMedium MuiButton-colorPrimary MuiButton-root MuiButton-contained MuiButton-containedPrimary MuiButton-sizeMedium MuiButton-containedSizeMedium MuiButton-colorPrimary mui-style-1mfbltw-MuiButtonBase-root-MuiButton-root"
           tabindex="0"
           type="button"
         >

--- a/src/components/DatasetStatCard/__snapshots__/DatasetStatCard.test.tsx.snap
+++ b/src/components/DatasetStatCard/__snapshots__/DatasetStatCard.test.tsx.snap
@@ -25,7 +25,7 @@ exports[`DatasetStatCard should match snapshot 1`] = `
         <button
           aria-label="helper"
           aria-labelledby=":r0:"
-          class="MuiButtonBase-root MuiIconButton-root MuiIconButton-sizeMedium mui-style-1lsi98i-MuiButtonBase-root-MuiIconButton-root"
+          class="MuiButtonBase-root MuiIconButton-root MuiIconButton-sizeMedium mui-style-mk8whb-MuiButtonBase-root-MuiIconButton-root"
           data-mui-internal-clone-element="true"
           tabindex="0"
           type="button"

--- a/src/components/LogoSlider/__snapshots__/LogoSlider.test.tsx.snap
+++ b/src/components/LogoSlider/__snapshots__/LogoSlider.test.tsx.snap
@@ -9,7 +9,7 @@ exports[`LogoSlider should render component 1`] = `
       class="MuiBox-root mui-style-1gx4n9j"
     >
       <a
-        class="MuiButtonBase-root MuiButton-root MuiButton-text MuiButton-textPrimary MuiButton-sizeMedium MuiButton-textSizeMedium MuiButton-colorPrimary MuiButton-root MuiButton-text MuiButton-textPrimary MuiButton-sizeMedium MuiButton-textSizeMedium MuiButton-colorPrimary mui-style-bjjpfn-MuiButtonBase-root-MuiButton-root"
+        class="MuiButtonBase-root MuiButton-root MuiButton-text MuiButton-textPrimary MuiButton-sizeMedium MuiButton-textSizeMedium MuiButton-colorPrimary MuiButton-root MuiButton-text MuiButton-textPrimary MuiButton-sizeMedium MuiButton-textSizeMedium MuiButton-colorPrimary mui-style-6fkdav-MuiButtonBase-root-MuiButton-root"
         href="http://www.google.com"
         rel="noreferrer"
         tabindex="0"
@@ -27,7 +27,7 @@ exports[`LogoSlider should render component 1`] = `
         />
       </a>
       <a
-        class="MuiButtonBase-root MuiButton-root MuiButton-text MuiButton-textPrimary MuiButton-sizeMedium MuiButton-textSizeMedium MuiButton-colorPrimary MuiButton-root MuiButton-text MuiButton-textPrimary MuiButton-sizeMedium MuiButton-textSizeMedium MuiButton-colorPrimary mui-style-bjjpfn-MuiButtonBase-root-MuiButton-root"
+        class="MuiButtonBase-root MuiButton-root MuiButton-text MuiButton-textPrimary MuiButton-sizeMedium MuiButton-textSizeMedium MuiButton-colorPrimary MuiButton-root MuiButton-text MuiButton-textPrimary MuiButton-sizeMedium MuiButton-textSizeMedium MuiButton-colorPrimary mui-style-6fkdav-MuiButtonBase-root-MuiButton-root"
         href="http://www.google.com"
         rel="noreferrer"
         tabindex="0"
@@ -45,7 +45,7 @@ exports[`LogoSlider should render component 1`] = `
         />
       </a>
       <a
-        class="MuiButtonBase-root MuiButton-root MuiButton-text MuiButton-textPrimary MuiButton-sizeMedium MuiButton-textSizeMedium MuiButton-colorPrimary MuiButton-root MuiButton-text MuiButton-textPrimary MuiButton-sizeMedium MuiButton-textSizeMedium MuiButton-colorPrimary mui-style-bjjpfn-MuiButtonBase-root-MuiButton-root"
+        class="MuiButtonBase-root MuiButton-root MuiButton-text MuiButton-textPrimary MuiButton-sizeMedium MuiButton-textSizeMedium MuiButton-colorPrimary MuiButton-root MuiButton-text MuiButton-textPrimary MuiButton-sizeMedium MuiButton-textSizeMedium MuiButton-colorPrimary mui-style-6fkdav-MuiButtonBase-root-MuiButton-root"
         href="http://www.google.com"
         rel="noreferrer"
         tabindex="0"
@@ -63,7 +63,7 @@ exports[`LogoSlider should render component 1`] = `
         />
       </a>
       <a
-        class="MuiButtonBase-root MuiButton-root MuiButton-text MuiButton-textPrimary MuiButton-sizeMedium MuiButton-textSizeMedium MuiButton-colorPrimary MuiButton-root MuiButton-text MuiButton-textPrimary MuiButton-sizeMedium MuiButton-textSizeMedium MuiButton-colorPrimary mui-style-bjjpfn-MuiButtonBase-root-MuiButton-root"
+        class="MuiButtonBase-root MuiButton-root MuiButton-text MuiButton-textPrimary MuiButton-sizeMedium MuiButton-textSizeMedium MuiButton-colorPrimary MuiButton-root MuiButton-text MuiButton-textPrimary MuiButton-sizeMedium MuiButton-textSizeMedium MuiButton-colorPrimary mui-style-6fkdav-MuiButtonBase-root-MuiButton-root"
         href="http://www.google.com"
         rel="noreferrer"
         tabindex="-1"
@@ -81,7 +81,7 @@ exports[`LogoSlider should render component 1`] = `
         />
       </a>
       <a
-        class="MuiButtonBase-root MuiButton-root MuiButton-text MuiButton-textPrimary MuiButton-sizeMedium MuiButton-textSizeMedium MuiButton-colorPrimary MuiButton-root MuiButton-text MuiButton-textPrimary MuiButton-sizeMedium MuiButton-textSizeMedium MuiButton-colorPrimary mui-style-bjjpfn-MuiButtonBase-root-MuiButton-root"
+        class="MuiButtonBase-root MuiButton-root MuiButton-text MuiButton-textPrimary MuiButton-sizeMedium MuiButton-textSizeMedium MuiButton-colorPrimary MuiButton-root MuiButton-text MuiButton-textPrimary MuiButton-sizeMedium MuiButton-textSizeMedium MuiButton-colorPrimary mui-style-6fkdav-MuiButtonBase-root-MuiButton-root"
         href="http://www.google.com"
         rel="noreferrer"
         tabindex="-1"
@@ -99,7 +99,7 @@ exports[`LogoSlider should render component 1`] = `
         />
       </a>
       <a
-        class="MuiButtonBase-root MuiButton-root MuiButton-text MuiButton-textPrimary MuiButton-sizeMedium MuiButton-textSizeMedium MuiButton-colorPrimary MuiButton-root MuiButton-text MuiButton-textPrimary MuiButton-sizeMedium MuiButton-textSizeMedium MuiButton-colorPrimary mui-style-bjjpfn-MuiButtonBase-root-MuiButton-root"
+        class="MuiButtonBase-root MuiButton-root MuiButton-text MuiButton-textPrimary MuiButton-sizeMedium MuiButton-textSizeMedium MuiButton-colorPrimary MuiButton-root MuiButton-text MuiButton-textPrimary MuiButton-sizeMedium MuiButton-textSizeMedium MuiButton-colorPrimary mui-style-6fkdav-MuiButtonBase-root-MuiButton-root"
         href="http://www.google.com"
         rel="noreferrer"
         tabindex="-1"

--- a/src/components/ModalButtons/__snapshots__/ModalButtons.test.tsx.snap
+++ b/src/components/ModalButtons/__snapshots__/ModalButtons.test.tsx.snap
@@ -6,14 +6,14 @@ exports[`ModalButtons should render basic modal buttons 1`] = `
     class="MuiBox-root mui-style-f2lpgk"
   >
     <button
-      class="MuiButtonBase-root MuiButton-root MuiButton-contained MuiButton-containedInherit MuiButton-sizeMedium MuiButton-containedSizeMedium MuiButton-colorInherit MuiButton-root MuiButton-contained MuiButton-containedInherit MuiButton-sizeMedium MuiButton-containedSizeMedium MuiButton-colorInherit mui-style-ptunhj-MuiButtonBase-root-MuiButton-root"
+      class="MuiButtonBase-root MuiButton-root MuiButton-contained MuiButton-containedInherit MuiButton-sizeMedium MuiButton-containedSizeMedium MuiButton-colorInherit MuiButton-root MuiButton-contained MuiButton-containedInherit MuiButton-sizeMedium MuiButton-containedSizeMedium MuiButton-colorInherit mui-style-1lba1mx-MuiButtonBase-root-MuiButton-root"
       tabindex="0"
       type="button"
     >
       Cancel
     </button>
     <button
-      class="MuiButtonBase-root MuiButton-root MuiButton-contained MuiButton-containedPrimary MuiButton-sizeMedium MuiButton-containedSizeMedium MuiButton-colorPrimary MuiButton-root MuiButton-contained MuiButton-containedPrimary MuiButton-sizeMedium MuiButton-containedSizeMedium MuiButton-colorPrimary mui-style-1rbdjgx-MuiButtonBase-root-MuiButton-root"
+      class="MuiButtonBase-root MuiButton-root MuiButton-contained MuiButton-containedPrimary MuiButton-sizeMedium MuiButton-containedSizeMedium MuiButton-colorPrimary MuiButton-root MuiButton-contained MuiButton-containedPrimary MuiButton-sizeMedium MuiButton-containedSizeMedium MuiButton-colorPrimary mui-style-1l0lblz-MuiButtonBase-root-MuiButton-root"
       tabindex="0"
       type="button"
     >

--- a/src/config/theme.ts
+++ b/src/config/theme.ts
@@ -215,6 +215,8 @@ const theme = createTheme({
                         "&.Mui-focusVisible": {
                             outline: `2px solid ${colors.orange}`,
                             borderRadius: "50%",
+                            outlineOffset: 0,
+                            background: colors.grey400,
                         },
                     };
                 },

--- a/src/config/theme.ts
+++ b/src/config/theme.ts
@@ -347,6 +347,9 @@ const theme = createTheme({
                         "&:hover": {
                             background: palette.greyCustom.main,
                         },
+                        "&.Mui-focusVisible": {
+                            background: palette.greyCustom.main,
+                        }
                     },
                 },
                 {

--- a/src/config/theme.ts
+++ b/src/config/theme.ts
@@ -212,9 +212,8 @@ const theme = createTheme({
             styleOverrides: {
                 root: ({ theme }) => {
                     return {
-                        "&.Mui-focusVisible > .MuiSvgIcon-root": {
-                            outline: `2px solid ${theme.palette.primary.main}`,
-                            outlineOffset: 2,
+                        "&.Mui-focusVisible": {
+                            outline: `2px solid ${colors.orange}`,
                             borderRadius: "50%",
                         },
                     };
@@ -392,8 +391,8 @@ const theme = createTheme({
                             : _theme.palette[ownerState.color || "primary"]
                                   ?.main,
                     "&.Mui-focusVisible:not(.MuiIconButton-root)": {
-                        outline: `2px solid ${_theme.palette.primary.main}`,
-                        outlineOffset: 2,
+                        outline: `2px solid ${colors.orange}`,
+                        borderWidth: 0,
                     },
                 }),
                 outlined: ({ ownerState, theme: _theme }) => {

--- a/src/modules/ProviderLinks/__snapshots__/ProviderLinks.test.tsx.snap
+++ b/src/modules/ProviderLinks/__snapshots__/ProviderLinks.test.tsx.snap
@@ -6,7 +6,7 @@ exports[`ProviderLinks should match snapshot 1`] = `
     class="MuiBox-root mui-style-1uxy81i"
   >
     <button
-      class="MuiButtonBase-root MuiButton-root MuiButton-text MuiButton-textPrimary MuiButton-sizeMedium MuiButton-textSizeMedium MuiButton-colorPrimary MuiButton-root MuiButton-text MuiButton-textPrimary MuiButton-sizeMedium MuiButton-textSizeMedium MuiButton-colorPrimary mui-style-2782bi-MuiButtonBase-root-MuiButton-root"
+      class="MuiButtonBase-root MuiButton-root MuiButton-text MuiButton-textPrimary MuiButton-sizeMedium MuiButton-textSizeMedium MuiButton-colorPrimary MuiButton-root MuiButton-text MuiButton-textPrimary MuiButton-sizeMedium MuiButton-textSizeMedium MuiButton-colorPrimary mui-style-14ilbmx-MuiButtonBase-root-MuiButton-root"
       tabindex="0"
       type="button"
     >
@@ -29,7 +29,7 @@ exports[`ProviderLinks should match snapshot 1`] = `
       </span>
     </button>
     <button
-      class="MuiButtonBase-root MuiButton-root MuiButton-text MuiButton-textPrimary MuiButton-sizeMedium MuiButton-textSizeMedium MuiButton-colorPrimary MuiButton-root MuiButton-text MuiButton-textPrimary MuiButton-sizeMedium MuiButton-textSizeMedium MuiButton-colorPrimary mui-style-2782bi-MuiButtonBase-root-MuiButton-root"
+      class="MuiButtonBase-root MuiButton-root MuiButton-text MuiButton-textPrimary MuiButton-sizeMedium MuiButton-textSizeMedium MuiButton-colorPrimary MuiButton-root MuiButton-text MuiButton-textPrimary MuiButton-sizeMedium MuiButton-textSizeMedium MuiButton-colorPrimary mui-style-14ilbmx-MuiButtonBase-root-MuiButton-root"
       tabindex="0"
       type="button"
     >
@@ -52,7 +52,7 @@ exports[`ProviderLinks should match snapshot 1`] = `
       </span>
     </button>
     <button
-      class="MuiButtonBase-root MuiButton-root MuiButton-text MuiButton-textPrimary MuiButton-sizeMedium MuiButton-textSizeMedium MuiButton-colorPrimary MuiButton-root MuiButton-text MuiButton-textPrimary MuiButton-sizeMedium MuiButton-textSizeMedium MuiButton-colorPrimary mui-style-2782bi-MuiButtonBase-root-MuiButton-root"
+      class="MuiButtonBase-root MuiButton-root MuiButton-text MuiButton-textPrimary MuiButton-sizeMedium MuiButton-textSizeMedium MuiButton-colorPrimary MuiButton-root MuiButton-text MuiButton-textPrimary MuiButton-sizeMedium MuiButton-textSizeMedium MuiButton-colorPrimary mui-style-14ilbmx-MuiButtonBase-root-MuiButton-root"
       tabindex="0"
       type="button"
     >
@@ -75,7 +75,7 @@ exports[`ProviderLinks should match snapshot 1`] = `
       </span>
     </button>
     <button
-      class="MuiButtonBase-root MuiButton-root MuiButton-text MuiButton-textPrimary MuiButton-sizeMedium MuiButton-textSizeMedium MuiButton-colorPrimary MuiButton-root MuiButton-text MuiButton-textPrimary MuiButton-sizeMedium MuiButton-textSizeMedium MuiButton-colorPrimary mui-style-2782bi-MuiButtonBase-root-MuiButton-root"
+      class="MuiButtonBase-root MuiButton-root MuiButton-text MuiButton-textPrimary MuiButton-sizeMedium MuiButton-textSizeMedium MuiButton-colorPrimary MuiButton-root MuiButton-text MuiButton-textPrimary MuiButton-sizeMedium MuiButton-textSizeMedium MuiButton-colorPrimary mui-style-14ilbmx-MuiButtonBase-root-MuiButton-root"
       tabindex="0"
       type="button"
     >


### PR DESCRIPTION
## Screenshots (if relevant)
<img width="599" height="198" alt="Screenshot 2026-01-26 at 15 54 17" src="https://github.com/user-attachments/assets/ed93abd0-0c20-45ac-bc7e-f274b4709eb8" />
<img width="599" height="198" alt="Screenshot 2026-01-26 at 16 57 01" src="https://github.com/user-attachments/assets/3257ac22-9c6b-482f-8f59-443be3126664" />

## Describe your changes

## Issue ticket link
https://hdruk.atlassian.net/browse/GAT-7896

## Checklist before requesting a review

-   [ ] I have performed a self-review of my code
-   [ ] I have added appropriate unit tests
-   [ ] I have created mocks for unit tests (where appropriate)
-   [ ] The interface is responsive (where appropriate)
-   [ ] The interface is at least AA (where appropriate)
