### PR TITLE
feat(GAT-8480): Updates custodian network page to cater for 4 per row

### DIFF
--- a/src/app/[locale]/(logged-out)/search/components/DataCustodianNetwork/DataCustodianNetwork.tsx
+++ b/src/app/[locale]/(logged-out)/search/components/DataCustodianNetwork/DataCustodianNetwork.tsx
@@ -34,7 +34,7 @@ interface DataCustodianNetworkProps {
 }
 
 const TRANSLATION_PATH = "pages.search";
-const SEARCH_PER_PAGE = 3;
+const SEARCH_PER_PAGE = 4;
 
 const DataCustodianNetwork = ({
     searchParams = {},
@@ -84,9 +84,11 @@ const DataCustodianNetwork = ({
                     <Box sx={{ pb: 2 }}>{t("noResults")}</Box>
                 </Paper>
             )}
-            <ResultsList variant="tiled">
+            <ResultsList variant="tiled" tiledDesktopColumns={SEARCH_PER_PAGE}>
                 {isLoading &&
-                    [1, 2, 3].map(item => <CardStackedSkeleton key={item} />)}
+                    Array.from({ length: SEARCH_PER_PAGE }, (_, index) => (
+                        <CardStackedSkeleton key={index} />
+                    ))}
                 {!isLoading &&
                     data?.map(result => (
                         <CardStacked

--- a/src/app/[locale]/(logged-out)/search/components/DataCustodianNetwork/DataCustodianNetwork.tsx
+++ b/src/app/[locale]/(logged-out)/search/components/DataCustodianNetwork/DataCustodianNetwork.tsx
@@ -84,7 +84,7 @@ const DataCustodianNetwork = ({
                     <Box sx={{ pb: 2 }}>{t("noResults")}</Box>
                 </Paper>
             )}
-            <ResultsList variant="tiled" tiledDesktopColumns={SEARCH_PER_PAGE}>
+            <ResultsList variant="tiled">
                 {isLoading &&
                     Array.from({ length: SEARCH_PER_PAGE }, (_, index) => (
                         <CardStackedSkeleton key={index} />

--- a/src/app/[locale]/(logged-out)/search/components/DataCustodianNetwork/DataCustodianNetwork.tsx
+++ b/src/app/[locale]/(logged-out)/search/components/DataCustodianNetwork/DataCustodianNetwork.tsx
@@ -84,7 +84,7 @@ const DataCustodianNetwork = ({
                     <Box sx={{ pb: 2 }}>{t("noResults")}</Box>
                 </Paper>
             )}
-            <ResultsList variant="tiled">
+            <ResultsList variant="tiled" fillDanglingSingleCard>
                 {isLoading &&
                     Array.from({ length: SEARCH_PER_PAGE }, (_, index) => (
                         <CardStackedSkeleton key={index} />

--- a/src/app/[locale]/(logged-out)/search/components/ResultsList/ResultsList.tsx
+++ b/src/app/[locale]/(logged-out)/search/components/ResultsList/ResultsList.tsx
@@ -5,12 +5,14 @@ import BoxContainer from "@/components/BoxContainer";
 export interface ResultsListProps {
     children: ReactNode;
     variant?: "list" | "tiled";
-    tiledDesktopColumns?: number;
+    minTileWidth?: number;
+    maxDesktopColumns?: number;
 }
 
 export default function ResultsList({
     variant = "list",
-    tiledDesktopColumns = 3,
+    minTileWidth = 250,
+    maxDesktopColumns,
     children,
 }: ResultsListProps) {
     return variant === "list" ? (
@@ -27,8 +29,11 @@ export default function ResultsList({
         <BoxContainer
             sx={{
                 gridTemplateColumns: {
-                    mobile: "repeat(1, 1fr)",
-                    desktop: `repeat(${tiledDesktopColumns}, minmax(0, 1fr))`,
+                    mobile: "repeat(1, minmax(0, 1fr))",
+                    tablet: `repeat(auto-fit, minmax(${minTileWidth}px, 1fr))`,
+                    ...(maxDesktopColumns && {
+                        desktop: `repeat(${maxDesktopColumns}, minmax(0, 1fr))`,
+                    }),
                 },
                 gap: 2,
                 mb: 2,

--- a/src/app/[locale]/(logged-out)/search/components/ResultsList/ResultsList.tsx
+++ b/src/app/[locale]/(logged-out)/search/components/ResultsList/ResultsList.tsx
@@ -5,10 +5,12 @@ import BoxContainer from "@/components/BoxContainer";
 export interface ResultsListProps {
     children: ReactNode;
     variant?: "list" | "tiled";
+    tiledDesktopColumns?: number;
 }
 
 export default function ResultsList({
     variant = "list",
+    tiledDesktopColumns = 3,
     children,
 }: ResultsListProps) {
     return variant === "list" ? (
@@ -26,7 +28,7 @@ export default function ResultsList({
             sx={{
                 gridTemplateColumns: {
                     mobile: "repeat(1, 1fr)",
-                    desktop: "repeat(3, 1fr)",
+                    desktop: `repeat(${tiledDesktopColumns}, minmax(0, 1fr))`,
                 },
                 gap: 2,
                 mb: 2,

--- a/src/app/[locale]/(logged-out)/search/components/ResultsList/ResultsList.tsx
+++ b/src/app/[locale]/(logged-out)/search/components/ResultsList/ResultsList.tsx
@@ -1,5 +1,12 @@
-import { type ReactNode } from "react";
-import { List } from "@mui/material";
+import {
+    type ReactNode,
+    Children,
+    useEffect,
+    useMemo,
+    useRef,
+    useState,
+} from "react";
+import { Box, List, useMediaQuery, useTheme } from "@mui/material";
 import BoxContainer from "@/components/BoxContainer";
 
 export interface ResultsListProps {
@@ -7,14 +14,68 @@ export interface ResultsListProps {
     variant?: "list" | "tiled";
     minTileWidth?: number;
     maxDesktopColumns?: number;
+    fillDanglingSingleCard?: boolean;
 }
 
 export default function ResultsList({
     variant = "list",
     minTileWidth = 250,
     maxDesktopColumns,
+    fillDanglingSingleCard = false,
     children,
 }: ResultsListProps) {
+    const theme = useTheme();
+    const isDesktop = useMediaQuery(theme.breakpoints.up("desktop"));
+    const containerRef = useRef<HTMLDivElement>(null);
+    const [containerWidth, setContainerWidth] = useState(0);
+    const tiledChildren = useMemo(() => Children.toArray(children), [children]);
+
+    useEffect(() => {
+        if (variant !== "tiled" || !fillDanglingSingleCard || !containerRef.current) {
+            return undefined;
+        }
+
+        const observer = new ResizeObserver(entries => {
+            const nextWidth = entries[0]?.contentRect?.width ?? 0;
+            setContainerWidth(nextWidth);
+        });
+
+        observer.observe(containerRef.current);
+        return () => observer.disconnect();
+    }, [variant, fillDanglingSingleCard]);
+
+    const blankTileCount = useMemo(() => {
+        if (variant !== "tiled" || !fillDanglingSingleCard || !tiledChildren.length) {
+            return 0;
+        }
+
+        if (containerWidth <= 0) {
+            return 0;
+        }
+
+        const gapPx = Number(theme.spacing(2).replace("px", ""));
+        const autoFitColumns = Math.max(
+            1,
+            Math.floor((containerWidth + gapPx) / (minTileWidth + gapPx))
+        );
+        const currentColumns =
+            isDesktop && maxDesktopColumns
+                ? maxDesktopColumns
+                : autoFitColumns;
+        const remainder = tiledChildren.length % currentColumns;
+
+        return remainder === 1 && currentColumns > 1 ? currentColumns - 1 : 0;
+    }, [
+        variant,
+        fillDanglingSingleCard,
+        tiledChildren.length,
+        containerWidth,
+        theme,
+        minTileWidth,
+        isDesktop,
+        maxDesktopColumns,
+    ]);
+
     return variant === "list" ? (
         <List
             sx={{
@@ -27,6 +88,7 @@ export default function ResultsList({
         </List>
     ) : (
         <BoxContainer
+            ref={containerRef}
             sx={{
                 gridTemplateColumns: {
                     mobile: "repeat(1, minmax(0, 1fr))",
@@ -38,7 +100,18 @@ export default function ResultsList({
                 gap: 2,
                 mb: 2,
             }}>
-            {children}
+            {tiledChildren}
+            {Array.from({ length: blankTileCount }, (_, index) => (
+                <Box
+                    key={`blank-tile-${index}`}
+                    aria-hidden
+                    sx={{
+                        minHeight: 130,
+                        border: `1px dashed ${theme.palette.grey[400]}`,
+                        bgcolor: "grey.100",
+                    }}
+                />
+            ))}
         </BoxContainer>
     );
 }

--- a/src/app/[locale]/(logged-out)/search/components/Search/Search.tsx
+++ b/src/app/[locale]/(logged-out)/search/components/Search/Search.tsx
@@ -635,8 +635,10 @@ const Search = ({ filters, cohortDiscovery, schema }: SearchProps) => {
                         ? "tiled"
                         : "list"
                 }
-                tiledDesktopColumns={
-                    queryParams.type === SearchCategory.COLLECTIONS ? 4 : 3
+                maxDesktopColumns={
+                    queryParams.type === SearchCategory.COLLECTIONS
+                        ? 4
+                        : undefined
                 }>
                 {data?.list.map(result => renderResultCard(result))}
             </ResultsList>

--- a/src/app/[locale]/(logged-out)/search/components/Search/Search.tsx
+++ b/src/app/[locale]/(logged-out)/search/components/Search/Search.tsx
@@ -634,6 +634,9 @@ const Search = ({ filters, cohortDiscovery, schema }: SearchProps) => {
                     queryParams.type === SearchCategory.DATA_CUSTODIANS
                         ? "tiled"
                         : "list"
+                }
+                tiledDesktopColumns={
+                    queryParams.type === SearchCategory.COLLECTIONS ? 4 : 3
                 }>
                 {data?.list.map(result => renderResultCard(result))}
             </ResultsList>
@@ -1429,7 +1432,11 @@ const Search = ({ filters, cohortDiscovery, schema }: SearchProps) => {
                                             aria-describedby="result-summary"
                                             aria-label="results list"
                                             sx={{
-                                                p: `0 ${theme.spacing(2)}`,
+                                                p:
+                                                    queryParams.type ===
+                                                    SearchCategory.COLLECTIONS
+                                                        ? 0
+                                                        : `0 ${theme.spacing(2)}`,
                                             }}>
                                             {renderResults()}
                                         </Box>

--- a/src/app/[locale]/(logged-out)/search/components/Search/Search.tsx
+++ b/src/app/[locale]/(logged-out)/search/components/Search/Search.tsx
@@ -639,6 +639,10 @@ const Search = ({ filters, cohortDiscovery, schema }: SearchProps) => {
                     queryParams.type === SearchCategory.COLLECTIONS
                         ? 4
                         : undefined
+                }
+                fillDanglingSingleCard={
+                    queryParams.type === SearchCategory.COLLECTIONS ||
+                    queryParams.type === SearchCategory.DATA_CUSTODIANS
                 }>
                 {data?.list.map(result => renderResultCard(result))}
             </ResultsList>


### PR DESCRIPTION
## Screenshots (if relevant)
<img width="1749" height="1099" alt="image" src="https://github.com/user-attachments/assets/5b8fb610-15a4-4fd1-83a4-31de755b2bf1" />


## Describe your changes

## Issue ticket link

## Checklist before requesting a review

-   [ ] I have performed a self-review of my code
-   [ ] I have added appropriate unit tests
-   [ ] I have created mocks for unit tests (where appropriate)
-   [ ] The interface is responsive (where appropriate)
-   [ ] The interface is at least AA (where appropriate)
