### PR TITLE
feat(GAT-550): add other views chart

### DIFF
--- a/src/app/[locale]/account/team/[teamId]/(withLeftNav)/dashboard/dashboard.tsx
+++ b/src/app/[locale]/account/team/[teamId]/(withLeftNav)/dashboard/dashboard.tsx
@@ -11,6 +11,7 @@ import Paper from "@/components/Paper";
 import Typography from "@/components/Typography";
 import DatasetViewsBarWidget from "@/modules/DatasetViewsBarWidget/DatasetViewsBarWidget";
 import DatasetViewsWidget from "@/modules/DatasetViewsWidget/DatasetViewsWidget";
+import OtherViewsWidget from "@/modules/OtherViewsWidget/OtherViewsWidget";
 import apis from "@/config/apis";
 import { CalendarMonthOutlinedIcon } from "@/consts/icons";
 import { formatDate } from "@/utils/date";
@@ -124,6 +125,11 @@ const Dashboard = ({ teamId, initialCounts }: DashboardProps) => {
                     endDate={endDate}
                 />
                 <DatasetViewsBarWidget
+                    teamId={teamId}
+                    startDate={startDate}
+                    endDate={endDate}
+                />
+                <OtherViewsWidget
                     teamId={teamId}
                     startDate={startDate}
                     endDate={endDate}

--- a/src/config/messages/en.json
+++ b/src/config/messages/en.json
@@ -266,6 +266,14 @@
                     "showMost": "Show most views",
                     "viewsLabel": "Views"
                 },
+                "otherViews": {
+                    "title": "Other views",
+                    "loading": "Loading other views",
+                    "labels": {
+                        "collections": "Collections",
+                        "dataCustodian": "Data Custodian page"
+                    }
+                },
                 "resources": {
                     "title": "Your resources",
                     "chooseResources": "Choose resources",

--- a/src/modules/OtherViewsWidget/OtherViewsWidget.test.tsx
+++ b/src/modules/OtherViewsWidget/OtherViewsWidget.test.tsx
@@ -1,0 +1,38 @@
+import { rest } from "msw";
+import { render, screen, waitFor } from "@/utils/testUtils";
+import { server } from "@/mocks/server";
+import apis from "@/config/apis";
+import OtherViewsWidget from "./OtherViewsWidget";
+
+const TEAM_ID = "1";
+const DATA_CUSTODIAN_VIEWS = 123;
+
+const defaultProps = {
+    teamId: TEAM_ID,
+    startDate: "2025-06-01",
+    endDate: "2026-06-01",
+};
+
+const dashboardUrl = `${apis.teamsV3Url}/${TEAM_ID}/dashboard`;
+
+describe("OtherViewsWidget", () => {
+    it("falls back to 0 when an endpoint returns no count", async () => {
+        server.use(
+            rest.get(`${dashboardUrl}/collections/views`, (_req, res, ctx) =>
+                res(ctx.status(200), ctx.json({ data: null }))
+            ),
+            rest.get(`${dashboardUrl}/datacustodians/views`, (_req, res, ctx) =>
+                res(ctx.status(200), ctx.json({ data: DATA_CUSTODIAN_VIEWS }))
+            )
+        );
+
+        render(<OtherViewsWidget {...defaultProps} />);
+
+        await waitFor(() => {
+            expect(
+                screen.getByText(DATA_CUSTODIAN_VIEWS.toLocaleString())
+            ).toBeInTheDocument();
+        });
+        expect(screen.getByText("0")).toBeInTheDocument();
+    });
+});

--- a/src/modules/OtherViewsWidget/OtherViewsWidget.tsx
+++ b/src/modules/OtherViewsWidget/OtherViewsWidget.tsx
@@ -1,0 +1,101 @@
+"use client";
+
+import Skeleton from "@mui/material/Skeleton";
+import { useTranslations } from "next-intl";
+import Box from "@/components/Box";
+import Paper from "@/components/Paper";
+import Typography from "@/components/Typography";
+import useGet from "@/hooks/useGet";
+import apis from "@/config/apis";
+import { colors } from "@/config/theme";
+
+const TRANSLATION_PATH = "pages.account.dashboard.otherViews";
+const TILE_COUNT = 2;
+
+interface OtherViewsWidgetProps {
+    teamId: string;
+    startDate: string;
+    endDate: string;
+}
+
+const OtherViewsWidget = ({
+    teamId,
+    startDate,
+    endDate,
+}: OtherViewsWidgetProps) => {
+    const t = useTranslations(TRANSLATION_PATH);
+
+    const params = new URLSearchParams({ startDate, endDate }).toString();
+    const dashboardUrl = `${apis.teamsV3Url}/${teamId}/dashboard`;
+
+    const { data: collectionsViews, isLoading: collectionsLoading } =
+        useGet<number>(`${dashboardUrl}/collections/views?${params}`, {});
+    const { data: dataCustodianViews, isLoading: dataCustodianLoading } =
+        useGet<number>(`${dashboardUrl}/datacustodians/views?${params}`, {});
+
+    const isLoading = collectionsLoading || dataCustodianLoading;
+
+    const items = [
+        { key: "collections", count: collectionsViews },
+        { key: "dataCustodian", count: dataCustodianViews },
+    ];
+
+    return (
+        <Paper sx={{ p: 2, height: "100%" }}>
+            <Typography variant="h2" sx={{ mb: 2 }}>
+                {t("title")}
+            </Typography>
+            {isLoading ? (
+                <Box
+                    role="status"
+                    aria-label={t("loading")}
+                    sx={{
+                        display: "flex",
+                        flexDirection: "column",
+                        gap: 2,
+                        p: 0,
+                        m: 0,
+                    }}>
+                    {Array.from({ length: TILE_COUNT }, (_, i) => (
+                        <Skeleton key={i} variant="rectangular" height={72} />
+                    ))}
+                </Box>
+            ) : (
+                <Box
+                    component="dl"
+                    sx={{
+                        display: "flex",
+                        flexDirection: "column",
+                        gap: 2,
+                        m: 0,
+                        p: 0,
+                    }}>
+                    {items.map(({ key, count }) => (
+                        <Box
+                            key={key}
+                            sx={{
+                                display: "flex",
+                                justifyContent: "space-between",
+                                alignItems: "center",
+                                gap: 2,
+                                p: 2,
+                                bgcolor: colors.grey100,
+                            }}>
+                            <Typography component="dt">
+                                {t(`labels.${key}`)}
+                            </Typography>
+                            <Typography
+                                variant="h1"
+                                component="dd"
+                                sx={{ m: 0 }}>
+                                {(count ?? 0).toLocaleString()}
+                            </Typography>
+                        </Box>
+                    ))}
+                </Box>
+            )}
+        </Paper>
+    );
+};
+
+export default OtherViewsWidget;


### PR DESCRIPTION
> AI disclaimer - CLAUDE was used for this. The approach was planned manually (plan mode), and exploration of the existing dataset-views widget pattern + the backend endpoints was directed by me. CLAUDE scaffolded the component, tests, translations and wiring (~60%)

## Screenshots / videos (if relevant)
<img width="765" height="387" alt="image" src="https://github.com/user-attachments/assets/04a7dd60-6113-4dd7-8932-4e28ba75692a" />

## Describe your changes
Adds an "Other views" widget to the team dashboard, sitting alongside the existing dataset-views widgets. It surfaces view counts for the team's non-dataset Gateway objects — Collections and their Data Custodian page — by consuming the existing v3 dashboard endpoints (`/dashboard/collections/views` and `/dashboard/datacustodians/views`), each returning a single total for the selected reporting period. Counts are rendered as a description list (label/value pairs) for screen-reader semantics, with a `role="status"` skeleton while loading and a fallback to 0 when an endpoint returns no value. The item list is config-driven so additional object types can be added in one line once the backend exposes them.

## Issue ticket link
https://hdruk.atlassian.net/browse/GAT-8507

## Checklist before requesting a review

- [x] I have performed a self-review of my code
- [x] I have added appropriate unit tests / e2e tests (where relevant)
- [ ] I have created mocks for api endpoints (where appropriate)
- [ ] The interface is responsive (where ticket is relevant)
- [x] The interface is at least AA (where ticket is relevant)
- [ ] Commits are described as "(chore|fix|feature|test|maintenance): description"
