### PR TITLE
feat(GAT-8509): Add Enquiries widget

### DIFF
--- a/src/app/[locale]/account/team/[teamId]/(withLeftNav)/dashboard/dashboard.tsx
+++ b/src/app/[locale]/account/team/[teamId]/(withLeftNav)/dashboard/dashboard.tsx
@@ -11,6 +11,7 @@ import Paper from "@/components/Paper";
 import Typography from "@/components/Typography";
 import DatasetViewsBarWidget from "@/modules/DatasetViewsBarWidget/DatasetViewsBarWidget";
 import DatasetViewsWidget from "@/modules/DatasetViewsWidget/DatasetViewsWidget";
+import EnquiriesWidget from "@/modules/EnquiriesWidget/EnquiriesWidget";
 import OtherViewsWidget from "@/modules/OtherViewsWidget/OtherViewsWidget";
 import apis from "@/config/apis";
 import { CalendarMonthOutlinedIcon } from "@/consts/icons";
@@ -130,6 +131,11 @@ const Dashboard = ({ teamId, initialCounts }: DashboardProps) => {
                     endDate={endDate}
                 />
                 <OtherViewsWidget
+                    teamId={teamId}
+                    startDate={startDate}
+                    endDate={endDate}
+                />
+                <EnquiriesWidget
                     teamId={teamId}
                     startDate={startDate}
                     endDate={endDate}

--- a/src/components/CountTilesWidget/CountTilesWidget.tsx
+++ b/src/components/CountTilesWidget/CountTilesWidget.tsx
@@ -1,0 +1,79 @@
+"use client";
+
+import Skeleton from "@mui/material/Skeleton";
+import Box from "@/components/Box";
+import Paper from "@/components/Paper";
+import Typography from "@/components/Typography";
+import { colors } from "@/config/theme";
+
+export interface CountTile {
+    key: string;
+    label: string;
+    count?: number;
+}
+
+interface CountTilesWidgetProps {
+    title: string;
+    loadingLabel: string;
+    isLoading: boolean;
+    items: CountTile[];
+}
+
+const CountTilesWidget = ({
+    title,
+    loadingLabel,
+    isLoading,
+    items,
+}: CountTilesWidgetProps) => (
+    <Paper sx={{ p: 2, height: "100%" }}>
+        <Typography variant="h2" sx={{ mb: 2 }}>
+            {title}
+        </Typography>
+        {isLoading ? (
+            <Box
+                role="status"
+                aria-label={loadingLabel}
+                sx={{
+                    display: "flex",
+                    flexDirection: "column",
+                    gap: 2,
+                    p: 0,
+                    m: 0,
+                }}>
+                {items.map(({ key }) => (
+                    <Skeleton key={key} variant="rectangular" height={72} />
+                ))}
+            </Box>
+        ) : (
+            <Box
+                component="dl"
+                sx={{
+                    display: "flex",
+                    flexDirection: "column",
+                    gap: 2,
+                    m: 0,
+                    p: 0,
+                }}>
+                {items.map(({ key, label, count }) => (
+                    <Box
+                        key={key}
+                        sx={{
+                            display: "flex",
+                            justifyContent: "space-between",
+                            alignItems: "center",
+                            gap: 2,
+                            p: 2,
+                            bgcolor: colors.grey100,
+                        }}>
+                        <Typography component="dt">{label}</Typography>
+                        <Typography variant="h1" component="dd" sx={{ m: 0 }}>
+                            {(count ?? 0).toLocaleString()}
+                        </Typography>
+                    </Box>
+                ))}
+            </Box>
+        )}
+    </Paper>
+);
+
+export default CountTilesWidget;

--- a/src/config/messages/en.json
+++ b/src/config/messages/en.json
@@ -274,6 +274,15 @@
                         "dataCustodian": "Data Custodian page"
                     }
                 },
+                "enquiries": {
+                    "title": "Enquiries and requests",
+                    "loading": "Loading enquiries and requests",
+                    "labels": {
+                        "generalEnquiries": "General enquiries",
+                        "feasibilityEnquiries": "Feasibility enquiries",
+                        "dataAccessRequests": "Data Access Requests"
+                    }
+                },
                 "resources": {
                     "title": "Your resources",
                     "chooseResources": "Choose resources",

--- a/src/modules/EnquiriesWidget/EnquiriesWidget.test.tsx
+++ b/src/modules/EnquiriesWidget/EnquiriesWidget.test.tsx
@@ -1,0 +1,155 @@
+import { rest } from "msw";
+import { render, screen, waitFor } from "@/utils/testUtils";
+import { server } from "@/mocks/server";
+import apis from "@/config/apis";
+import EnquiriesWidget from "./EnquiriesWidget";
+
+const TEAM_ID = "1";
+const GENERAL_ENQUIRIES = 12;
+const FEASIBILITY_ENQUIRIES = 14;
+const DATA_ACCESS_REQUESTS = 16;
+
+const defaultProps = {
+    teamId: TEAM_ID,
+    startDate: "2025-06-01",
+    endDate: "2026-06-01",
+};
+
+const dashboardUrl = `${apis.teamsV3Url}/${TEAM_ID}/dashboard`;
+
+const teamHandler = (isQuestionBank: boolean) =>
+    rest.get(`${apis.teamsV1Url}/${TEAM_ID}`, (_req, res, ctx) =>
+        res(
+            ctx.status(200),
+            ctx.json({ data: { is_question_bank: isQuestionBank, users: [] } })
+        )
+    );
+
+describe("EnquiriesWidget", () => {
+
+    it("renders the totals returned for each enquiry type", async () => {
+        server.use(
+            teamHandler(true),
+            rest.get(`${dashboardUrl}/general-enquires/count`, (_req, res, ctx) =>
+                res(
+                    ctx.status(200),
+                    ctx.json({
+                        data: { total: GENERAL_ENQUIRIES, total_by_interval: 0 },
+                    })
+                )
+            ),
+            rest.get(
+                `${dashboardUrl}/fesability-enquires/count`,
+                (_req, res, ctx) =>
+                    res(
+                        ctx.status(200),
+                        ctx.json({
+                            data: {
+                                total: FEASIBILITY_ENQUIRIES,
+                                total_by_interval: 0,
+                            },
+                        })
+                    )
+            ),
+            rest.get(
+                `${dashboardUrl}/data-access-requests/count`,
+                (_req, res, ctx) =>
+                    res(
+                        ctx.status(200),
+                        ctx.json({
+                            data: {
+                                total: DATA_ACCESS_REQUESTS,
+                                total_by_interval: 0,
+                            },
+                        })
+                    )
+            )
+        );
+
+        render(<EnquiriesWidget {...defaultProps} />);
+
+        await waitFor(() => {
+            expect(
+                screen.getByText(GENERAL_ENQUIRIES.toLocaleString())
+            ).toBeInTheDocument();
+        });
+        expect(
+            screen.getByText(FEASIBILITY_ENQUIRIES.toLocaleString())
+        ).toBeInTheDocument();
+        expect(
+            screen.getByText(DATA_ACCESS_REQUESTS.toLocaleString())
+        ).toBeInTheDocument();
+    });
+
+    it("falls back to 0 when an endpoint returns no count", async () => {
+        server.use(
+            teamHandler(true),
+            rest.get(`${dashboardUrl}/general-enquires/count`, (_req, res, ctx) =>
+                res(ctx.status(200), ctx.json({ data: { total: null } }))
+            ),
+            rest.get(
+                `${dashboardUrl}/fesability-enquires/count`,
+                (_req, res, ctx) =>
+                    res(
+                        ctx.status(200),
+                        ctx.json({
+                            data: {
+                                total: FEASIBILITY_ENQUIRIES,
+                                total_by_interval: 0,
+                            },
+                        })
+                    )
+            ),
+            rest.get(
+                `${dashboardUrl}/data-access-requests/count`,
+                (_req, res, ctx) =>
+                    res(ctx.status(200), ctx.json({ data: { total: null } }))
+            )
+        );
+
+        render(<EnquiriesWidget {...defaultProps} />);
+
+        await waitFor(() => {
+            expect(
+                screen.getByText(FEASIBILITY_ENQUIRIES.toLocaleString())
+            ).toBeInTheDocument();
+        });
+        expect(screen.getAllByText("0")).toHaveLength(2);
+    });
+
+    it("hides the Data Access Requests tile when the question bank is disabled", async () => {
+        server.use(
+            teamHandler(false),
+            rest.get(`${dashboardUrl}/general-enquires/count`, (_req, res, ctx) =>
+                res(
+                    ctx.status(200),
+                    ctx.json({
+                        data: { total: GENERAL_ENQUIRIES, total_by_interval: 0 },
+                    })
+                )
+            ),
+            rest.get(
+                `${dashboardUrl}/fesability-enquires/count`,
+                (_req, res, ctx) =>
+                    res(
+                        ctx.status(200),
+                        ctx.json({
+                            data: {
+                                total: FEASIBILITY_ENQUIRIES,
+                                total_by_interval: 0,
+                            },
+                        })
+                    )
+            )
+        );
+
+        render(<EnquiriesWidget {...defaultProps} />);
+
+        await waitFor(() => {
+            expect(
+                screen.getByText(GENERAL_ENQUIRIES.toLocaleString())
+            ).toBeInTheDocument();
+        });
+        expect(screen.queryByText("Data Access Requests")).not.toBeInTheDocument();
+    });
+});

--- a/src/modules/EnquiriesWidget/EnquiriesWidget.tsx
+++ b/src/modules/EnquiriesWidget/EnquiriesWidget.tsx
@@ -1,0 +1,84 @@
+"use client";
+
+import { useTranslations } from "next-intl";
+import { DashboardEntityCount } from "@/interfaces/Dashboard";
+import CountTilesWidget from "@/components/CountTilesWidget/CountTilesWidget";
+import useGet from "@/hooks/useGet";
+import useGetTeam from "@/hooks/useGetTeam";
+import apis from "@/config/apis";
+
+const TRANSLATION_PATH = "pages.account.dashboard.enquiries";
+
+interface EnquiriesWidgetProps {
+    teamId: string;
+    startDate: string;
+    endDate: string;
+}
+
+const EnquiriesWidget = ({
+    teamId,
+    startDate,
+    endDate,
+}: EnquiriesWidgetProps) => {
+    const t = useTranslations(TRANSLATION_PATH);
+
+    const { team } = useGetTeam(teamId);
+    const isDarEnabled = team?.is_question_bank ?? false;
+
+    const params = new URLSearchParams({ startDate, endDate }).toString();
+    const dashboardUrl = `${apis.teamsV3Url}/${teamId}/dashboard`;
+
+    const { data: generalEnquiries, isLoading: generalLoading } =
+        useGet<DashboardEntityCount>(
+            `${dashboardUrl}/general-enquires/count?${params}`,
+            {}
+        );
+    const { data: feasibilityEnquiries, isLoading: feasibilityLoading } =
+        useGet<DashboardEntityCount>(
+            `${dashboardUrl}/fesability-enquires/count?${params}`,
+            {}
+        );
+    const { data: dataAccessRequests, isLoading: darLoading } =
+        useGet<DashboardEntityCount>(
+            isDarEnabled
+                ? `${dashboardUrl}/data-access-requests/count?${params}`
+                : null,
+            {}
+        );
+
+    const isLoading =
+        generalLoading || feasibilityLoading || (isDarEnabled && darLoading);
+
+    const items = [
+        {
+            key: "generalEnquiries",
+            label: t("labels.generalEnquiries"),
+            count: generalEnquiries?.total,
+        },
+        {
+            key: "feasibilityEnquiries",
+            label: t("labels.feasibilityEnquiries"),
+            count: feasibilityEnquiries?.total,
+        },
+        ...(isDarEnabled
+            ? [
+                  {
+                      key: "dataAccessRequests",
+                      label: t("labels.dataAccessRequests"),
+                      count: dataAccessRequests?.total,
+                  },
+              ]
+            : []),
+    ];
+
+    return (
+        <CountTilesWidget
+            title={t("title")}
+            loadingLabel={t("loading")}
+            isLoading={isLoading}
+            items={items}
+        />
+    );
+};
+
+export default EnquiriesWidget;

--- a/src/modules/OtherViewsWidget/OtherViewsWidget.tsx
+++ b/src/modules/OtherViewsWidget/OtherViewsWidget.tsx
@@ -1,16 +1,11 @@
 "use client";
 
-import Skeleton from "@mui/material/Skeleton";
 import { useTranslations } from "next-intl";
-import Box from "@/components/Box";
-import Paper from "@/components/Paper";
-import Typography from "@/components/Typography";
+import CountTilesWidget from "@/components/CountTilesWidget/CountTilesWidget";
 import useGet from "@/hooks/useGet";
 import apis from "@/config/apis";
-import { colors } from "@/config/theme";
 
 const TRANSLATION_PATH = "pages.account.dashboard.otherViews";
-const TILE_COUNT = 2;
 
 interface OtherViewsWidgetProps {
     teamId: string;
@@ -36,65 +31,25 @@ const OtherViewsWidget = ({
     const isLoading = collectionsLoading || dataCustodianLoading;
 
     const items = [
-        { key: "collections", count: collectionsViews },
-        { key: "dataCustodian", count: dataCustodianViews },
+        {
+            key: "collections",
+            label: t("labels.collections"),
+            count: collectionsViews,
+        },
+        {
+            key: "dataCustodian",
+            label: t("labels.dataCustodian"),
+            count: dataCustodianViews,
+        },
     ];
 
     return (
-        <Paper sx={{ p: 2, height: "100%" }}>
-            <Typography variant="h2" sx={{ mb: 2 }}>
-                {t("title")}
-            </Typography>
-            {isLoading ? (
-                <Box
-                    role="status"
-                    aria-label={t("loading")}
-                    sx={{
-                        display: "flex",
-                        flexDirection: "column",
-                        gap: 2,
-                        p: 0,
-                        m: 0,
-                    }}>
-                    {Array.from({ length: TILE_COUNT }, (_, i) => (
-                        <Skeleton key={i} variant="rectangular" height={72} />
-                    ))}
-                </Box>
-            ) : (
-                <Box
-                    component="dl"
-                    sx={{
-                        display: "flex",
-                        flexDirection: "column",
-                        gap: 2,
-                        m: 0,
-                        p: 0,
-                    }}>
-                    {items.map(({ key, count }) => (
-                        <Box
-                            key={key}
-                            sx={{
-                                display: "flex",
-                                justifyContent: "space-between",
-                                alignItems: "center",
-                                gap: 2,
-                                p: 2,
-                                bgcolor: colors.grey100,
-                            }}>
-                            <Typography component="dt">
-                                {t(`labels.${key}`)}
-                            </Typography>
-                            <Typography
-                                variant="h1"
-                                component="dd"
-                                sx={{ m: 0 }}>
-                                {(count ?? 0).toLocaleString()}
-                            </Typography>
-                        </Box>
-                    ))}
-                </Box>
-            )}
-        </Paper>
+        <CountTilesWidget
+            title={t("title")}
+            loadingLabel={t("loading")}
+            isLoading={isLoading}
+            items={items}
+        />
     );
 };
 


### PR DESCRIPTION
AI Disclosure: Claude Code (claude-sonnet-4-6) was used in the development of these changes.

## Screenshots / videos (if relevant)
<img width="783" height="247" alt="image" src="https://github.com/user-attachments/assets/a9a9d52b-4f61-4d0b-ac03-7b286f620aaf" />


## Describe your changes
Adds an Enquiries and Requests widget to the team dashboard that displays counts for general enquiries, feasibility enquiries, and data access requests. A new generic `CountTilesWidget` component was extracted to share the tile-list UI with the existing `OtherViewsWidget`, which was refactored accordingly. The DAR tile is conditionally shown based on whether the team has the question bank enabled (`is_question_bank`).

## Issue ticket link
https://hdruk.atlassian.net/browse/GAT-8509

## Checklist before requesting a review

- [x] I have performed a self-review of my code
- [x] I have added appropriate unit tests / e2e tests (where relevant)
- [ ] I have created mocks for api endpoints (where appropriate)
- [ ] The interface is responsive (where ticket is relevant)
- [x] The interface is at least AA (where ticket is relevant)
- [ ] Commits are described as "(chore|fix|feature|test|maintenance): description"
