### PR TITLE
feat(GAT-8513): Add Learn More and Improve Usage widgets

### DIFF
--- a/src/app/[locale]/account/team/[teamId]/(withLeftNav)/dashboard/dashboard.tsx
+++ b/src/app/[locale]/account/team/[teamId]/(withLeftNav)/dashboard/dashboard.tsx
@@ -12,6 +12,8 @@ import Typography from "@/components/Typography";
 import DatasetViewsBarWidget from "@/modules/DatasetViewsBarWidget/DatasetViewsBarWidget";
 import DatasetViewsWidget from "@/modules/DatasetViewsWidget/DatasetViewsWidget";
 import EnquiriesWidget from "@/modules/EnquiriesWidget/EnquiriesWidget";
+import ImproveYourUsageWidget from "@/modules/ImproveYourUsageWidget/ImproveYourUsageWidget";
+import LearnMoreWidget from "@/modules/LearnMoreWidget/LearnMoreWidget";
 import OtherViewsWidget from "@/modules/OtherViewsWidget/OtherViewsWidget";
 import apis from "@/config/apis";
 import { CalendarMonthOutlinedIcon } from "@/consts/icons";
@@ -140,6 +142,8 @@ const Dashboard = ({ teamId, initialCounts }: DashboardProps) => {
                     startDate={startDate}
                     endDate={endDate}
                 />
+                <LearnMoreWidget />
+                <ImproveYourUsageWidget />
             </Box>
         </BoxContainer>
     );

--- a/src/config/messages/en.json
+++ b/src/config/messages/en.json
@@ -283,6 +283,18 @@
                         "dataAccessRequests": "Data Access Requests"
                     }
                 },
+                "improveUsage": {
+                    "title": "Improve your usage",
+                    "previousLabel": "Previous tip",
+                    "nextLabel": "Next tip",
+                    "tips": {
+                        "demographicMetadata": "Adding demographic metadata (e.g. age, sex, ethnicity, geography) makes your datasets far more <b>discoverable and usable</b>, helping researchers quickly assess relevance and feasibility — which leads to <b>more appropriate, higher-quality data access requests and greater research impact,</b> while reducing unnecessary enquiries.",
+                        "metadataDescriptions": "Provide clear, high-quality metadata descriptions (including data coverage, linkage, and update frequency) — this helps researchers understand your dataset upfront, leading to <b>more targeted access requests, fewer back-and-forth queries, and a smoother approval process,</b> ultimately saving time for both custodians and applicants."
+                    }
+                },
+                "learnMore": {
+                    "title": "Learn more about the Gateway"
+                },
                 "resources": {
                     "title": "Your resources",
                     "chooseResources": "Choose resources",

--- a/src/consts/icons.tsx
+++ b/src/consts/icons.tsx
@@ -5,6 +5,7 @@ import AddAPhotoIcon from "@mui/icons-material/AddAPhoto";
 import AdminPanelSettingsIcon from "@mui/icons-material/AdminPanelSettings";
 import AppsIcon from "@mui/icons-material/Apps";
 import ArchiveIcon from "@mui/icons-material/Archive";
+import ArrowBack from "@mui/icons-material/ArrowBack";
 import ArrowBackIosNewIcon from "@mui/icons-material/ArrowBackIosNew";
 import ArrowDropDownIcon from "@mui/icons-material/ArrowDropDown";
 import ArrowDropUpIcon from "@mui/icons-material/ArrowDropUp";
@@ -85,6 +86,7 @@ export * from "./customIcons";
 
 export {
     OpenInNewIcon,
+    ArrowBack,
     ArrowForward,
     AppsIcon,
     FilterAltOffIcon,

--- a/src/modules/ImproveYourUsageWidget/ImproveYourUsageWidget.test.tsx
+++ b/src/modules/ImproveYourUsageWidget/ImproveYourUsageWidget.test.tsx
@@ -1,0 +1,34 @@
+import userEvent from "@testing-library/user-event";
+import { render, screen } from "@/utils/testUtils";
+import ImproveYourUsageWidget from "./ImproveYourUsageWidget";
+
+describe("ImproveYourUsageWidget", () => {
+    it("cycles to the next tip and wraps back around", async () => {
+        render(<ImproveYourUsageWidget />);
+
+        await userEvent.click(
+            screen.getByRole("button", { name: "Next tip" })
+        );
+        expect(
+            screen.getByText(/Provide clear, high-quality metadata/)
+        ).toBeInTheDocument();
+
+        await userEvent.click(
+            screen.getByRole("button", { name: "Next tip" })
+        );
+        expect(
+            screen.getByText(/Adding demographic metadata/)
+        ).toBeInTheDocument();
+    });
+
+    it("shows the previous tip when navigating backwards", async () => {
+        render(<ImproveYourUsageWidget />);
+
+        await userEvent.click(
+            screen.getByRole("button", { name: "Previous tip" })
+        );
+        expect(
+            screen.getByText(/Provide clear, high-quality metadata/)
+        ).toBeInTheDocument();
+    });
+});

--- a/src/modules/ImproveYourUsageWidget/ImproveYourUsageWidget.tsx
+++ b/src/modules/ImproveYourUsageWidget/ImproveYourUsageWidget.tsx
@@ -1,0 +1,57 @@
+"use client";
+
+import { useState } from "react";
+import { Box, IconButton } from "@mui/material";
+import { useTranslations } from "next-intl";
+import Paper from "@/components/Paper";
+import Typography from "@/components/Typography";
+import { ArrowBack, ArrowForward } from "@/consts/icons";
+
+const TRANSLATION_PATH = "pages.account.dashboard.improveUsage";
+const TIP_TRANSLATION_KEYS = ["demographicMetadata", "metadataDescriptions"];
+
+const ImproveYourUsageWidget = () => {
+    const t = useTranslations(TRANSLATION_PATH);
+    const [index, setIndex] = useState(0);
+
+    const showTip = (next: number) =>
+        setIndex(
+            (next + TIP_TRANSLATION_KEYS.length) % TIP_TRANSLATION_KEYS.length
+        );
+
+    return (
+        <Paper sx={{ p: 2, height: "100%" }}>
+            <Box
+                sx={{
+                    display: "flex",
+                    justifyContent: "space-between",
+                    alignItems: "center",
+                    gap: 2,
+                    mb: 2,
+                }}>
+                <Typography variant="h2">{t("title")}</Typography>
+                <Box sx={{ display: "flex", gap: 1, flexShrink: 0 }}>
+                    <IconButton
+                        color="primary"
+                        aria-label={t("previousLabel")}
+                        onClick={() => showTip(index - 1)}>
+                        <ArrowBack />
+                    </IconButton>
+                    <IconButton
+                        color="primary"
+                        aria-label={t("nextLabel")}
+                        onClick={() => showTip(index + 1)}>
+                        <ArrowForward />
+                    </IconButton>
+                </Box>
+            </Box>
+            <Typography aria-live="polite" aria-atomic>
+                {t.rich(`tips.${TIP_TRANSLATION_KEYS[index]}`, {
+                    b: chunks => <strong>{chunks}</strong>,
+                })}
+            </Typography>
+        </Paper>
+    );
+};
+
+export default ImproveYourUsageWidget;

--- a/src/modules/LearnMoreWidget/LearnMoreWidget.test.tsx
+++ b/src/modules/LearnMoreWidget/LearnMoreWidget.test.tsx
@@ -1,0 +1,23 @@
+import { render, screen } from "@/utils/testUtils";
+import LearnMoreWidget from "./LearnMoreWidget";
+
+describe("LearnMoreWidget", () => {
+    it("renders the title and embeds the playlist iframe", () => {
+        const { container } = render(<LearnMoreWidget />);
+
+        expect(
+            screen.getByRole("heading", {
+                name: "Learn more about the Gateway",
+            })
+        ).toBeInTheDocument();
+
+        const iframe = container.querySelector("iframe");
+        expect(iframe).toBeInTheDocument();
+        expect(iframe).toHaveAttribute(
+            "src",
+            expect.stringContaining(
+                "youtube.com/embed/videoseries?list=PLBI5k9SgYrIvz_h0hq83yFnTM4t9P569b"
+            )
+        );
+    });
+});

--- a/src/modules/LearnMoreWidget/LearnMoreWidget.tsx
+++ b/src/modules/LearnMoreWidget/LearnMoreWidget.tsx
@@ -1,0 +1,32 @@
+"use client";
+
+import { useTranslations } from "next-intl";
+import Paper from "@/components/Paper";
+import Typography from "@/components/Typography";
+import { IFrameWrapper } from "@/styles/IFrameContainer.styles";
+
+const PLAYLIST_ID = "PLBI5k9SgYrIvz_h0hq83yFnTM4t9P569b";
+const EMBED_URL = `https://www.youtube.com/embed/videoseries?list=${PLAYLIST_ID}&rel=0`;
+
+const LearnMoreWidget = () => {
+    const t = useTranslations("pages.account.dashboard.learnMore");
+
+    return (
+        <Paper sx={{ p: 2, height: "100%" }}>
+            <Typography variant="h2" sx={{ mb: 2 }}>
+                {t("title")}
+            </Typography>
+            <IFrameWrapper>
+                <iframe
+                    src={EMBED_URL}
+                    title={t("title")}
+                    allow="autoplay; encrypted-media; fullscreen"
+                    allowFullScreen
+                    style={{ border: 0 }}
+                />
+            </IFrameWrapper>
+        </Paper>
+    );
+};
+
+export default LearnMoreWidget;


### PR DESCRIPTION
> AI Disclosure: Claude Code (claude-sonnet-4-6) was used in the development of these changes.

## Screenshots / videos (if relevant)
<img width="1532" height="497" alt="image" src="https://github.com/user-attachments/assets/4a770707-d804-4ccd-ad91-00907bd53731" />
<img width="711" height="628" alt="image" src="https://github.com/user-attachments/assets/1cbfa8bb-78c2-401b-91a4-a1cc03b6eae7" />

## Describe your changes
Adds two new widgets to the team dashboard. "Improve your usage" presents rotating metadata best-practice tips with accessible previous/next controls and an aria-live region so screen readers announce each tip. "Learn more about the Gateway" embeds a YouTube playlist of onboarding videos. Both are dropped into the existing dashboard grid alongside the other widgets, with all copy sourced from the `en.json` translations and a new `ArrowBack` icon exported from the shared icon set.

## Issue ticket link
https://hdruk.atlassian.net/browse/GAT-8513

## Checklist before requesting a review

- [x] I have performed a self-review of my code
- [x] I have added appropriate unit tests / e2e tests (where relevant)
- [ ] I have created mocks for api endpoints (where appropriate)
- [ ] The interface is responsive (where ticket is relevant)
- [x] The interface is at least AA (where ticket is relevant)
- [ ] Commits are described as "(chore|fix|feature|test|maintenance): description"
