### PR TITLE
fix(GAT-8668): Prevent Data Custodian Network search double-counting in analytics

### DIFF
--- a/src/app/[locale]/(logged-out)/search/components/DataCustodianNetwork/DataCustodianNetwork.test.tsx
+++ b/src/app/[locale]/(logged-out)/search/components/DataCustodianNetwork/DataCustodianNetwork.test.tsx
@@ -1,0 +1,51 @@
+import { rest } from "msw";
+import apis from "@/config/apis";
+import { server } from "@/mocks/server";
+import { render, screen } from "@/utils/testUtils";
+import DataCustodianNetwork from "./DataCustodianNetwork";
+
+const DCN_URL = `${apis.searchV1Url}/data_custodian_networks`;
+
+const mockEndpoint = (requestQueries: string[]) => {
+    server.use(
+        rest.post(DCN_URL, async (req, res, ctx) => {
+            const body = await req.json();
+            requestQueries.push(body.query);
+            return res(
+                ctx.status(200),
+                ctx.json({
+                    data: [{ id: 1, name: `Network for ${body.query}` }],
+                })
+            );
+        })
+    );
+};
+
+describe("DataCustodianNetwork", () => {
+    it("fetches results on mount and renders them", async () => {
+        const requestQueries: string[] = [];
+        mockEndpoint(requestQueries);
+
+        render(<DataCustodianNetwork searchParams={{ query: "cancer" }} />);
+
+        expect(await screen.findByText("Network for cancer")).toBeInTheDocument();
+        expect(requestQueries).toEqual(["cancer"]);
+    });
+
+    it("issues a single request per search when the query changes", async () => {
+        const requestQueries: string[] = [];
+        mockEndpoint(requestQueries);
+
+        const { rerender } = render(
+            <DataCustodianNetwork searchParams={{ query: "cancer" }} />
+        );
+        expect(await screen.findByText("Network for cancer")).toBeInTheDocument();
+
+        rerender(<DataCustodianNetwork searchParams={{ query: "diabetes" }} />);
+        expect(
+            await screen.findByText("Network for diabetes")
+        ).toBeInTheDocument();
+
+        expect(requestQueries).toEqual(["cancer", "diabetes"]);
+    });
+});

--- a/src/app/[locale]/(logged-out)/search/components/DataCustodianNetwork/DataCustodianNetwork.tsx
+++ b/src/app/[locale]/(logged-out)/search/components/DataCustodianNetwork/DataCustodianNetwork.tsx
@@ -69,8 +69,11 @@ const DataCustodianNetwork = ({
     );
 
     useEffect(() => {
-        mutate();
-    }, [searchParams, mutate]);
+        if (!data) {
+            mutate();
+        }
+        // eslint-disable-next-line react-hooks/exhaustive-deps
+    }, []);
 
     return (
         <Box sx={{ mb: 1, p: 0 }}>

--- a/src/app/[locale]/(logged-out)/search/components/DataCustodianNetwork/DataCustodianNetwork.tsx
+++ b/src/app/[locale]/(logged-out)/search/components/DataCustodianNetwork/DataCustodianNetwork.tsx
@@ -62,9 +62,6 @@ const DataCustodianNetwork = ({
         {
             query: searchParams.query,
             filters: dataCustodianFilters,
-        },
-        {
-            revalidateOnMount: true,
         }
     );
 

--- a/src/app/[locale]/(logged-out)/search/components/DataCustodianNetwork/DataCustodianNetwork.tsx
+++ b/src/app/[locale]/(logged-out)/search/components/DataCustodianNetwork/DataCustodianNetwork.tsx
@@ -1,4 +1,3 @@
-import { useEffect } from "react";
 import { useTranslations } from "next-intl";
 import { SearchResultDataCustodianCol } from "@/interfaces/Search";
 import Box from "@/components/Box";
@@ -58,22 +57,16 @@ const DataCustodianNetwork = ({
 
     const dataCustodianFilters = generateDataCustodianFilters();
 
-    const { data, mutate, isLoading } = usePostSwr<
-        SearchResultDataCustodianCol[]
-    >(
+    const { data, isLoading } = usePostSwr<SearchResultDataCustodianCol[]>(
         `${apis.searchV1Url}/data_custodian_networks?view_type=mini&per_page=${SEARCH_PER_PAGE}`,
         {
             query: searchParams.query,
             filters: dataCustodianFilters,
+        },
+        {
+            revalidateOnMount: true,
         }
     );
-
-    useEffect(() => {
-        if (!data) {
-            mutate();
-        }
-        // eslint-disable-next-line react-hooks/exhaustive-deps
-    }, []);
 
     return (
         <Box sx={{ mb: 1, p: 0 }}>

--- a/src/app/[locale]/(logged-out)/search/components/Search/Search.tsx
+++ b/src/app/[locale]/(logged-out)/search/components/Search/Search.tsx
@@ -291,28 +291,26 @@ const Search = ({ filters, schema }: SearchProps) => {
                     queryParams.source === GATEWAY_SOURCE_FIELD ||
                     (queryParams.source === EUROPE_PMC_SOURCE_FIELD &&
                         !!queryParams.query)),
-            revalidateOnMount: true,
         }
     );
 
     const { data: v2Data, isValidating: isV2Searching } =
         usePostSwr<SearchAggregationData>(
-        apis.searchV2AggregationUrl,
-        {
-            query: queryParams.query || undefined,
-            type: "datasets",
-            sort: queryParams.sort,
-            per_page: queryParams.per_page,
-            page: queryParams.page,
-            view_type: "mini",
-            ...pickedFilters,
-        },
-        {
-            keepPreviousData: true,
-            shouldFetch: isDatasets && isExternalSourcesEnabled,
-            revalidateOnMount: true,
-        }
-    );
+            apis.searchV2AggregationUrl,
+            {
+                query: queryParams.query || undefined,
+                type: "datasets",
+                sort: queryParams.sort,
+                per_page: queryParams.per_page,
+                page: queryParams.page,
+                view_type: "mini",
+                ...pickedFilters,
+            },
+            {
+                keepPreviousData: true,
+                shouldFetch: isDatasets && isExternalSourcesEnabled,
+            }
+        );
 
     const { externalResults, isPolling: isExternalPolling } =
         useLoadExternalData(v2Data, isDatasets && isExternalSourcesEnabled);

--- a/src/app/[locale]/(logged-out)/search/components/Search/Search.tsx
+++ b/src/app/[locale]/(logged-out)/search/components/Search/Search.tsx
@@ -267,11 +267,9 @@ const Search = ({ filters, schema }: SearchProps) => {
         queryParams.query ? `&q=${encodeURIComponent(queryParams.query)}` : ""
     }`;
 
-    const {
-        data: v1Data,
-        isLoading: isV1Searching,
-        mutate,
-    } = usePostSwr<SearchPaginationType<SearchResult>>(
+    const { data: v1Data, isLoading: isV1Searching } = usePostSwr<
+        SearchPaginationType<SearchResult>
+    >(
         `${apis.searchV1Url}/${queryParams.type}?view_type=mini&per_page=${
             queryParams.per_page
         }&page=${queryParams.page}&sort=${queryParams.sort}${
@@ -293,14 +291,12 @@ const Search = ({ filters, schema }: SearchProps) => {
                     queryParams.source === GATEWAY_SOURCE_FIELD ||
                     (queryParams.source === EUROPE_PMC_SOURCE_FIELD &&
                         !!queryParams.query)),
+            revalidateOnMount: true,
         }
     );
 
-    const {
-        data: v2Data,
-        isValidating: isV2Searching,
-        mutate: mutateV2,
-    } = usePostSwr<SearchAggregationData>(
+    const { data: v2Data, isValidating: isV2Searching } =
+        usePostSwr<SearchAggregationData>(
         apis.searchV2AggregationUrl,
         {
             query: queryParams.query || undefined,
@@ -314,6 +310,7 @@ const Search = ({ filters, schema }: SearchProps) => {
         {
             keepPreviousData: true,
             shouldFetch: isDatasets && isExternalSourcesEnabled,
+            revalidateOnMount: true,
         }
     );
 
@@ -358,18 +355,6 @@ const Search = ({ filters, schema }: SearchProps) => {
         apis.saveSearchesV1Url,
         { itemName: "Saved search" }
     );
-
-    useEffect(() => {
-        // Fixes the weird re-jiggling of the search results upon navigating
-        // back to the page.
-        if (!v1Data) {
-            mutate();
-        }
-        if (isExternalSourcesEnabled && !v2Data) {
-            mutateV2();
-        }
-        // eslint-disable-next-line react-hooks/exhaustive-deps
-    }, []);
 
     // Update the list of libraries
     const { data: libraryData, mutate: mutateLibraries } = useGet<Library[]>(

--- a/src/hooks/usePostSwr.ts
+++ b/src/hooks/usePostSwr.ts
@@ -21,6 +21,7 @@ interface Options {
     successNotificationsOn?: boolean;
     itemName?: string;
     action?: ReactNode;
+    revalidateOnMount?: boolean;
 }
 
 const usePostSwr = <T>(
@@ -37,6 +38,7 @@ const usePostSwr = <T>(
         errorNotificationsOn,
         withPagination = false,
         shouldFetch = true,
+        revalidateOnMount = false,
     } = options || {};
     const t = useTranslations("api");
 
@@ -58,7 +60,7 @@ const usePostSwr = <T>(
         {
             keepPreviousData,
             revalidateOnFocus: false,
-            revalidateOnMount: false,
+            revalidateOnMount,
             revalidateOnReconnect: false,
             refreshWhenOffline: false,
             refreshWhenHidden: false,

--- a/src/hooks/usePostSwr.ts
+++ b/src/hooks/usePostSwr.ts
@@ -21,7 +21,6 @@ interface Options {
     successNotificationsOn?: boolean;
     itemName?: string;
     action?: ReactNode;
-    revalidateOnMount?: boolean;
 }
 
 const usePostSwr = <T>(
@@ -38,7 +37,6 @@ const usePostSwr = <T>(
         errorNotificationsOn,
         withPagination = false,
         shouldFetch = true,
-        revalidateOnMount = false,
     } = options || {};
     const t = useTranslations("api");
 
@@ -60,7 +58,7 @@ const usePostSwr = <T>(
         {
             keepPreviousData,
             revalidateOnFocus: false,
-            revalidateOnMount,
+            revalidateIfStale: false,
             revalidateOnReconnect: false,
             refreshWhenOffline: false,
             refreshWhenHidden: false,


### PR DESCRIPTION
> AI disclaimer - CLAUDE was used for this. The investigation was driven manually from a database observation (two analytics rows per DCN search with different UUIDs, identical timestamps and payloads); CLAUDE traced the root cause across the frontend and search-service, then implemented the one-line component fix and the regression test. Diagnosis/direction was steered by hand (~50/50), the implementation was CLAUDE.

## Describe your changes
Search analytics were recording roughly twice as many Data Custodian Network searches as Collection searches, even though both surface under the same Collections tab and should be comparable. The embedded `DataCustodianNetwork` component fetched its results via SWR (whose key already includes the query/filters) but also fired a manual `mutate()` on every `searchParams` change. Because `mutate()` bypasses SWR's request deduping, each search refinement sent two identical requests to `/data_custodian_networks`, and the search-service logged each one as a separate analytics row with its own UUID. This changes the effect to a guarded, mount-only trigger so the initial load still fires once while subsequent searches refetch a single time via the SWR key — matching the pattern already used for the main search results. A regression test asserts exactly one request is issued per search.

## Issue ticket link
https://hdruk.atlassian.net/browse/GAT-8668

## Checklist before requesting a review

- [x] I have performed a self-review of my code
- [x] I have added appropriate unit tests / e2e tests (where relevant)
- [ ] I have created mocks for api endpoints (where appropriate)
- [ ] The interface is responsive (where ticket is relevant)
- [ ] The interface is at least AA (where ticket is relevant)
- [ ] Commits are described as "(chore|fix|feature|test|maintenance): description"
