### PR TITLE
fix(GAT-8762): Correct BioSamples metadata key in results table

### DIFF
--- a/src/app/[locale]/(logged-out)/search/components/ResultsTable/ResultsTable.tsx
+++ b/src/app/[locale]/(logged-out)/search/components/ResultsTable/ResultsTable.tsx
@@ -30,7 +30,7 @@ const PUBLISHERS_ID = "metadata.summary.publisher.gatewayId";
 const COHORT_DISCOVERY_PATH = "isCohortDiscovery";
 const ACCESS_SERVICE_PATH =
     "metadata.accessibility.access.accessServiceCategory";
-const CONTAINS_TISSUE_PATH = "metadata.additional.containsTissue";
+const CONTAINS_BIOSAMPLES_PATH = "metadata.additional.containsBioSamples";
 const STRUCTURAL_METADATA_PATH = "metadata.additional.hasTechnicalMetadata";
 
 const columnHelper = createColumnHelper<SearchResultDataset>();
@@ -228,12 +228,12 @@ const getColumns = ({
     }),
 
     columnHelper.display({
-        id: "containsTissue",
+        id: "containsBioSamples",
         cell: ({ row: { original } }) => {
-            const containsTissue = get(original, CONTAINS_TISSUE_PATH);
+            const containsBioSamples = get(original, CONTAINS_BIOSAMPLES_PATH);
             return (
                 <div style={{ textAlign: "center" }}>
-                    {containsTissue ? <CheckIcon color="primary" /> : "-"}
+                    {containsBioSamples ? <CheckIcon color="primary" /> : "-"}
                 </div>
             );
         },


### PR DESCRIPTION
## Screenshots / videos (if relevant)
<img width="2160" height="285" alt="image" src="https://github.com/user-attachments/assets/dc452ff7-dbd1-40a6-9444-b9b4b6f04c5e" />


## Describe your changes
The "BioSample availability" column in the search datasets table view never rendered a tick because the frontend read a stale metadata key (`metadata.additional.containsTissue`) that the search API no longer returns

## Issue ticket link
https://hdruk.atlassian.net/browse/GAT-8762

## Checklist before requesting a review

- [x] I have performed a self-review of my code
- [ ] I have added appropriate unit tests / e2e tests (where relevant)
- [ ] I have created mocks for api endpoints (where appropriate)
- [ ] The interface is responsive (where ticket is relevant)
- [ ] The interface is at least AA (where ticket is relevant)
- [ ] Commits are described as "(chore|fix|feature|test|maintenance): description"
