### PR TITLE
fix(GAT-0000): Fix dashboard view/enquiry counts

### DIFF
--- a/src/modules/EnquiriesWidget/EnquiriesWidget.test.tsx
+++ b/src/modules/EnquiriesWidget/EnquiriesWidget.test.tsx
@@ -34,7 +34,7 @@ describe("EnquiriesWidget", () => {
                 res(
                     ctx.status(200),
                     ctx.json({
-                        data: { total: GENERAL_ENQUIRIES, total_by_interval: 0 },
+                        data: { total: 0, total_by_interval: GENERAL_ENQUIRIES },
                     })
                 )
             ),
@@ -45,8 +45,8 @@ describe("EnquiriesWidget", () => {
                         ctx.status(200),
                         ctx.json({
                             data: {
-                                total: FEASIBILITY_ENQUIRIES,
-                                total_by_interval: 0,
+                                total: 0,
+                                total_by_interval: FEASIBILITY_ENQUIRIES,
                             },
                         })
                     )
@@ -58,8 +58,8 @@ describe("EnquiriesWidget", () => {
                         ctx.status(200),
                         ctx.json({
                             data: {
-                                total: DATA_ACCESS_REQUESTS,
-                                total_by_interval: 0,
+                                total: 0,
+                                total_by_interval: DATA_ACCESS_REQUESTS,
                             },
                         })
                     )
@@ -85,7 +85,7 @@ describe("EnquiriesWidget", () => {
         server.use(
             teamHandler(true),
             rest.get(`${dashboardUrl}/general-enquires/count`, (_req, res, ctx) =>
-                res(ctx.status(200), ctx.json({ data: { total: null } }))
+                res(ctx.status(200), ctx.json({ data: { total_by_interval: null } }))
             ),
             rest.get(
                 `${dashboardUrl}/fesability-enquires/count`,
@@ -94,8 +94,8 @@ describe("EnquiriesWidget", () => {
                         ctx.status(200),
                         ctx.json({
                             data: {
-                                total: FEASIBILITY_ENQUIRIES,
-                                total_by_interval: 0,
+                                total: 0,
+                                total_by_interval: FEASIBILITY_ENQUIRIES,
                             },
                         })
                     )
@@ -103,7 +103,7 @@ describe("EnquiriesWidget", () => {
             rest.get(
                 `${dashboardUrl}/data-access-requests/count`,
                 (_req, res, ctx) =>
-                    res(ctx.status(200), ctx.json({ data: { total: null } }))
+                    res(ctx.status(200), ctx.json({ data: { total_by_interval: null } }))
             )
         );
 
@@ -124,7 +124,7 @@ describe("EnquiriesWidget", () => {
                 res(
                     ctx.status(200),
                     ctx.json({
-                        data: { total: GENERAL_ENQUIRIES, total_by_interval: 0 },
+                        data: { total: 0, total_by_interval: GENERAL_ENQUIRIES },
                     })
                 )
             ),
@@ -135,8 +135,8 @@ describe("EnquiriesWidget", () => {
                         ctx.status(200),
                         ctx.json({
                             data: {
-                                total: FEASIBILITY_ENQUIRIES,
-                                total_by_interval: 0,
+                                total: 0,
+                                total_by_interval: FEASIBILITY_ENQUIRIES,
                             },
                         })
                     )

--- a/src/modules/EnquiriesWidget/EnquiriesWidget.tsx
+++ b/src/modules/EnquiriesWidget/EnquiriesWidget.tsx
@@ -53,19 +53,19 @@ const EnquiriesWidget = ({
         {
             key: "generalEnquiries",
             label: t("labels.generalEnquiries"),
-            count: generalEnquiries?.total,
+            count: generalEnquiries?.total_by_interval,
         },
         {
             key: "feasibilityEnquiries",
             label: t("labels.feasibilityEnquiries"),
-            count: feasibilityEnquiries?.total,
+            count: feasibilityEnquiries?.total_by_interval,
         },
         ...(isDarEnabled
             ? [
                   {
                       key: "dataAccessRequests",
                       label: t("labels.dataAccessRequests"),
-                      count: dataAccessRequests?.total,
+                      count: dataAccessRequests?.total_by_interval,
                   },
               ]
             : []),

--- a/src/modules/OtherViewsWidget/OtherViewsWidget.test.tsx
+++ b/src/modules/OtherViewsWidget/OtherViewsWidget.test.tsx
@@ -19,10 +19,13 @@ describe("OtherViewsWidget", () => {
     it("falls back to 0 when an endpoint returns no count", async () => {
         server.use(
             rest.get(`${dashboardUrl}/collections/views`, (_req, res, ctx) =>
-                res(ctx.status(200), ctx.json({ data: null }))
+                res(ctx.status(200), ctx.json({ data: [] }))
             ),
             rest.get(`${dashboardUrl}/datacustodians/views`, (_req, res, ctx) =>
-                res(ctx.status(200), ctx.json({ data: DATA_CUSTODIAN_VIEWS }))
+                res(
+                    ctx.status(200),
+                    ctx.json({ data: [{ counter: DATA_CUSTODIAN_VIEWS }] })
+                )
             )
         );
 

--- a/src/modules/OtherViewsWidget/OtherViewsWidget.tsx
+++ b/src/modules/OtherViewsWidget/OtherViewsWidget.tsx
@@ -7,6 +7,10 @@ import apis from "@/config/apis";
 
 const TRANSLATION_PATH = "pages.account.dashboard.otherViews";
 
+interface ViewCount {
+    counter: number;
+}
+
 interface OtherViewsWidgetProps {
     teamId: string;
     startDate: string;
@@ -24,9 +28,9 @@ const OtherViewsWidget = ({
     const dashboardUrl = `${apis.teamsV3Url}/${teamId}/dashboard`;
 
     const { data: collectionsViews, isLoading: collectionsLoading } =
-        useGet<number>(`${dashboardUrl}/collections/views?${params}`, {});
+        useGet<ViewCount[]>(`${dashboardUrl}/collections/views?${params}`, {});
     const { data: dataCustodianViews, isLoading: dataCustodianLoading } =
-        useGet<number>(`${dashboardUrl}/datacustodians/views?${params}`, {});
+        useGet<ViewCount[]>(`${dashboardUrl}/datacustodians/views?${params}`, {});
 
     const isLoading = collectionsLoading || dataCustodianLoading;
 
@@ -34,12 +38,12 @@ const OtherViewsWidget = ({
         {
             key: "collections",
             label: t("labels.collections"),
-            count: collectionsViews,
+            count: collectionsViews?.[0]?.counter,
         },
         {
             key: "dataCustodian",
             label: t("labels.dataCustodian"),
-            count: dataCustodianViews,
+            count: dataCustodianViews?.[0]?.counter,
         },
     ];
 


### PR DESCRIPTION
## Describe your changes
The dashboard "Other views" widget was rendering `[object Object]` for the Collections and Data Custodian tiles. The `/views` endpoints return their payload wrapped in a single-element array (`[{ counter: N }]`), but the widget treated the value as a plain number and passed the whole array to the tile. It now reads the counter from the first array element. Separately, the Enquiries widget tiles now read `total_by_interval` instead of `total` so the counts respect the dashboard's date-range selector, keeping them consistent with the period-scoped Other views widget beside them. The resource cards at the top of the dashboard are intentionally left on the all-time `total`

## Issue ticket link
https://hdruk.atlassian.net/browse/GAT-0000

## Checklist before requesting a review

- [x] I have performed a self-review of my code
- [x] I have added appropriate unit tests / e2e tests (where relevant)
- [ ] I have created mocks for api endpoints (where appropriate)
- [ ] The interface is responsive (where ticket is relevant)
- [ ] The interface is at least AA (where ticket is relevant)
- [ ] Commits are described as "(chore|fix|feature|test|maintenance): description"
