### PR TITLE
feat(GAT-9062): Search improvements

### DIFF
--- a/.github/workflows/dev_deployment.yaml
+++ b/.github/workflows/dev_deployment.yaml
@@ -4,7 +4,7 @@ run-name:  ${{ github.actor }} triggered deploy to DEV pipeline
 on:
   push:
     branches:
-      - feat/GAT-9062-1
+      - dev
 
 jobs:
   setup:

--- a/.github/workflows/dev_deployment.yaml
+++ b/.github/workflows/dev_deployment.yaml
@@ -4,7 +4,7 @@ run-name:  ${{ github.actor }} triggered deploy to DEV pipeline
 on:
   push:
     branches:
-      - dev
+      - feat/GAT-9062-1
 
 jobs:
   setup:

--- a/src/app/[locale]/(logged-out)/search/components/FilterPanel/FilterPanel.test.tsx
+++ b/src/app/[locale]/(logged-out)/search/components/FilterPanel/FilterPanel.test.tsx
@@ -186,6 +186,32 @@ describe("FilterPanel", () => {
         expect(accordions).toHaveLength(0);
     });
 
+    it("still renders filters and Clear all after switching away from datasets while ARDC was selected", () => {
+        const { useFeatures } = require("@/providers/FeatureProvider");
+        useFeatures.mockReturnValue({ isExternalSourcesEnabled: true });
+
+        const { rerender } = render(
+            <FilterPanel
+                {...defaultProps}
+                filterCategory="dataset"
+                dataSource="ARDC"
+            />
+        );
+
+        rerender(
+            <FilterPanel
+                {...defaultProps}
+                filterCategory="tool"
+                dataSource="HDRUK"
+            />
+        );
+
+        expect(
+            screen.getByRole("button", { name: "typeCategory" })
+        ).toBeInTheDocument();
+        expect(screen.getByText("clearAll")).toBeInTheDocument();
+    });
+
     it("calls resetQueryParamState when clear all filters is clicked", () => {
         render(
             <FilterPanel

--- a/src/app/[locale]/(logged-out)/search/components/FilterPanel/FilterPanel.tsx
+++ b/src/app/[locale]/(logged-out)/search/components/FilterPanel/FilterPanel.tsx
@@ -247,6 +247,11 @@ const FilterPanel = ({
                 ...prev,
                 [STATIC_FILTER_DATA_SOURCE]: { [dataSource]: true },
             }));
+        } else if (filterCategory !== FILTER_CATEGORY_DATASETS) {
+            setStaticFilterValues(prev => ({
+                ...prev,
+                [STATIC_FILTER_DATA_SOURCE]: { [HDRUK_SOURCE_VALUE]: true },
+            }));
         }
     }, [filterCategory, dataSource]);
 
@@ -324,6 +329,7 @@ const FilterPanel = ({
         // If 'External data portals' is selected, hide all dataset filters (ARDC has no aggregations)
         if (
             isExternalSourcesEnabled &&
+            filterCategory === FILTER_CATEGORY_DATASETS &&
             staticFilterValues[STATIC_FILTER_DATA_SOURCE]?.[ARDC_SOURCE_VALUE]
         ) {
             formattedFilters = formattedFilters.filter(

--- a/src/app/[locale]/(logged-out)/search/components/Search/Search.tsx
+++ b/src/app/[locale]/(logged-out)/search/components/Search/Search.tsx
@@ -262,6 +262,7 @@ const Search = ({ filters, schema }: SearchProps) => {
     const dataSource = queryParams.dataSource || HDRUK_SOURCE_VALUE;
     const isExternalSourceSelected =
         isExternalSourcesEnabled && dataSource !== HDRUK_SOURCE_VALUE;
+    const externalSearchEnabled = isDatasets && isExternalSourcesEnabled;
 
     const ardcSearchUrl = `https://researchdata.edu.au/health/search?filter-type=all-fields${
         queryParams.query ? `&q=${encodeURIComponent(queryParams.query)}` : ""
@@ -285,7 +286,7 @@ const Search = ({ filters, schema }: SearchProps) => {
             keepPreviousData: true,
             withPagination: true,
             shouldFetch:
-                (!isDatasets || !isExternalSourcesEnabled) &&
+                !externalSearchEnabled &&
                 (forceSearch ||
                     queryParams.type !== SearchCategory.PUBLICATIONS ||
                     queryParams.source === GATEWAY_SOURCE_FIELD ||
@@ -308,12 +309,13 @@ const Search = ({ filters, schema }: SearchProps) => {
             },
             {
                 keepPreviousData: true,
-                shouldFetch: isDatasets && isExternalSourcesEnabled,
+                shouldFetch: externalSearchEnabled,
+                revalidateOnMount: true,
             }
         );
 
     const { externalResults, isPolling: isExternalPolling } =
-        useLoadExternalData(v2Data, isDatasets && isExternalSourcesEnabled);
+        useLoadExternalData(v2Data, externalSearchEnabled, isV2Searching);
 
     const ardcResult = externalResults[ARDC_SOURCE_VALUE] ?? null;
 

--- a/src/app/[locale]/(logged-out)/search/hooks/useLoadExternalData.test.ts
+++ b/src/app/[locale]/(logged-out)/search/hooks/useLoadExternalData.test.ts
@@ -169,7 +169,6 @@ describe("useLoadExternalData", () => {
 
             act(() => capturedOnSuccess?.(resolvedPollData));
 
-            // New token, same query+type (e.g. filter change)
             v2Data = { ...baseV2Data, token: "tok-2" };
             rerender();
 
@@ -193,6 +192,27 @@ describe("useLoadExternalData", () => {
 
             expect(result.current.isPolling).toBe(true);
             expect(result.current.externalResults).toEqual({});
+        });
+    });
+
+    describe("isValidating guard", () => {
+        it("does not poll while the aggregation is (re)validating", () => {
+            renderHook(() => useLoadExternalData(baseV2Data, true, true));
+
+            const [, options] = mockUseGet.mock.calls[0];
+            expect(options.shouldFetch).toBe(false);
+        });
+
+        it("polls once validation finishes", () => {
+            let isValidating = true;
+            const { rerender } = renderHook(() =>
+                useLoadExternalData(baseV2Data, true, isValidating)
+            );
+            expect(mockUseGet.mock.calls.at(-1)?.[1].shouldFetch).toBe(false);
+
+            isValidating = false;
+            rerender();
+            expect(mockUseGet.mock.calls.at(-1)?.[1].shouldFetch).toBe(true);
         });
     });
 });

--- a/src/app/[locale]/(logged-out)/search/hooks/useLoadExternalData.test.ts
+++ b/src/app/[locale]/(logged-out)/search/hooks/useLoadExternalData.test.ts
@@ -193,6 +193,52 @@ describe("useLoadExternalData", () => {
             expect(result.current.isPolling).toBe(true);
             expect(result.current.externalResults).toEqual({});
         });
+
+        it("serves a revisited query from cache instead of re-polling its expired token", () => {
+            const emptyResolved: SearchAggregationData = {
+                query: "",
+                type: "datasets",
+                token: "tok-empty",
+                pending: [],
+                results: { [ARDC_SOURCE_VALUE]: ardcResult },
+            };
+            let v2Data: SearchAggregationData = {
+                ...emptyResolved,
+                pending: [ARDC_SOURCE_VALUE],
+                results: {},
+            };
+            const { result, rerender } = renderHook(() =>
+                useLoadExternalData(v2Data, true)
+            );
+
+            // Resolve the no-query search
+            act(() => capturedOnSuccess?.(emptyResolved));
+
+            // Run a different query and resolve it (overwrites nothing now)
+            v2Data = { ...baseV2Data, token: "tok-asthma" };
+            rerender();
+            act(() =>
+                capturedOnSuccess?.({
+                    ...baseV2Data,
+                    token: "tok-asthma",
+                    pending: [],
+                    results: { [ARDC_SOURCE_VALUE]: ardcResult },
+                })
+            );
+
+            // Clear the query: SWR replays the cached no-query response (expired token)
+            v2Data = {
+                ...emptyResolved,
+                pending: [ARDC_SOURCE_VALUE],
+                results: {},
+            };
+            rerender();
+
+            expect(result.current.isPolling).toBe(false);
+            expect(result.current.externalResults[ARDC_SOURCE_VALUE]).toEqual(
+                ardcResult
+            );
+        });
     });
 
     describe("isValidating guard", () => {

--- a/src/app/[locale]/(logged-out)/search/hooks/useLoadExternalData.ts
+++ b/src/app/[locale]/(logged-out)/search/hooks/useLoadExternalData.ts
@@ -23,16 +23,14 @@ const useLoadExternalData = (
     const token = v2Data?.token ?? null;
     const query = v2Data?.query ?? "";
     const type = v2Data?.type ?? "";
+    const cacheKey = `${query}|${type}`;
 
-    const [cache, setCache] = useState<{
-        query: string;
-        type: string;
-        results: Partial<Record<DataSource, SearchAggregationProviderResult>>;
-    } | null>(null);
+    const [cache, setCache] = useState<
+        Record<string, Partial<Record<DataSource, SearchAggregationProviderResult>>>
+    >({});
     const [polledToken, setPolledToken] = useState<string | null>(null);
 
-    const cachedResults =
-        cache?.query === query && cache?.type === type ? cache.results : null;
+    const cachedResults = cache[cacheKey] ?? null;
 
     const alreadyPolled = !!token && polledToken === token;
     const shouldPoll =
@@ -57,7 +55,10 @@ const useLoadExternalData = (
                 const allResolved =
                     Array.isArray(data.pending) && data.pending.length === 0;
                 if (allResolved) {
-                    setCache({ query, type, results: data.results ?? {} });
+                    setCache(prev => ({
+                        ...prev,
+                        [cacheKey]: data.results ?? {},
+                    }));
                     setPolledToken(token);
                 }
             },

--- a/src/app/[locale]/(logged-out)/search/hooks/useLoadExternalData.ts
+++ b/src/app/[locale]/(logged-out)/search/hooks/useLoadExternalData.ts
@@ -12,7 +12,8 @@ import { DataSource } from "@/consts/search";
 
 const useLoadExternalData = (
     v2Data: SearchAggregationData | undefined,
-    enabled: boolean
+    enabled: boolean,
+    isValidating = false
 ): {
     externalResults: Partial<
         Record<DataSource, SearchAggregationProviderResult>
@@ -34,7 +35,12 @@ const useLoadExternalData = (
         cache?.query === query && cache?.type === type ? cache.results : null;
 
     const alreadyPolled = !!token && polledToken === token;
-    const shouldPoll = enabled && !!token && !alreadyPolled && !cachedResults;
+    const shouldPoll =
+        enabled &&
+        !isValidating &&
+        !!token &&
+        !alreadyPolled &&
+        !cachedResults;
 
     // Dependent SWR — key is null until token exists; refreshInterval drives polling
     useGet<SearchPollData>(

--- a/src/hooks/usePostSwr.ts
+++ b/src/hooks/usePostSwr.ts
@@ -21,6 +21,7 @@ interface Options {
     successNotificationsOn?: boolean;
     itemName?: string;
     action?: ReactNode;
+    revalidateOnMount?: boolean;
 }
 
 const usePostSwr = <T>(
@@ -37,13 +38,14 @@ const usePostSwr = <T>(
         errorNotificationsOn,
         withPagination = false,
         shouldFetch = true,
+        revalidateOnMount,
     } = options || {};
     const t = useTranslations("api");
 
     const { data, error, mutate, isLoading, isValidating } = useSWR<T>(
         shouldFetch ? [url, formData] : null,
-        () => {
-            return apiService.postRequest<T>(url, formData, {
+        () =>
+            apiService.postRequest<T>(url, formData, {
                 notificationOptions: {
                     localeKey,
                     itemName,
@@ -53,8 +55,7 @@ const usePostSwr = <T>(
                     action,
                 },
                 withPagination,
-            });
-        },
+            }) as Promise<T>,
         {
             keepPreviousData,
             revalidateOnFocus: false,
@@ -63,6 +64,7 @@ const usePostSwr = <T>(
             refreshWhenOffline: false,
             refreshWhenHidden: false,
             refreshInterval: 0,
+            revalidateOnMount,
         }
     );
 


### PR DESCRIPTION
## Screenshots (if relevant)

## Describe your changes
Partner results 404 when clearing or changing the query — the results cache only held one query at a time, so going back to a previous search re-polled an expired token. Now results are cached per-query, so revisiting a search reuses them instead of hitting the dead token.

Filters disappeared after switching tabs with Partner portals selected — leftover ARDC state hid filters on other tabs. Now it resets when you leave the Datasets tab.

## Issue ticket link

## Checklist before requesting a review

-   [ ] I have performed a self-review of my code
-   [ ] I have added appropriate unit tests
-   [ ] I have created mocks for unit tests (where appropriate)
-   [ ] The interface is responsive (where appropriate)
-   [ ] The interface is at least AA (where appropriate)
