### PR TITLE
feat(GAT-7604): Data custodian display tweaks

### DIFF
--- a/src/app/[locale]/(logged-out)/dataset/[datasetId]/components/DatasetMindMap/DatasetMindMap.tsx
+++ b/src/app/[locale]/(logged-out)/dataset/[datasetId]/components/DatasetMindMap/DatasetMindMap.tsx
@@ -72,6 +72,7 @@ const DatasetMindMap = ({
                 let action: (() => void) | null = null;
                 let hidden = false;
                 let cohort = false;
+                let { label } = node.data;
 
                 const { title } = data.metadata.metadata.summary;
                 const safeTitle = encodeURIComponent(title);
@@ -101,6 +102,9 @@ const DatasetMindMap = ({
                     href = `${node.data.href}&datasetTitles=${safeTitle}`;
                 } else if (node.id === "node-dataCustodian") {
                     href = `/data-custodian/${teamId}`;
+                    label =
+                        data.metadata.metadata.summary.dataCustodian?.name ||
+                        node.data.label;
                 } else if (node.id === "node-curatedPublications") {
                     const entityCount = linkageCounts.publications_using;
                     if (!entityCount) {
@@ -156,6 +160,7 @@ const DatasetMindMap = ({
                     ...node,
                     data: {
                         ...node.data,
+                        label,
                         href,
                         action,
                         hidden,

--- a/src/app/[locale]/(logged-out)/dataset/[datasetId]/components/Sources/Sources.tsx
+++ b/src/app/[locale]/(logged-out)/dataset/[datasetId]/components/Sources/Sources.tsx
@@ -1,7 +1,7 @@
 "use client";
 
 import { Divider } from "@mui/material";
-import { isEqual } from "lodash";
+import { get, isEqual } from "lodash";
 import { useTranslations } from "next-intl";
 import { Metadata } from "@/interfaces/Dataset";
 import Paper from "@/components/Paper";
@@ -29,6 +29,8 @@ const Sources = ({ data }: SourcesProps) => {
     // This is using HDRUK schema so it's not collectionSituation as in the GWDM case
     const { collectionSource } = data.provenance.origin;
 
+    const dataCustodianName = get(data, "summary.dataCustodian.name");
+
     return (
         <Paper sx={{ borderRadius: 2, p: 2 }}>
             <Typography variant="h4">
@@ -45,6 +47,14 @@ const Sources = ({ data }: SourcesProps) => {
                 )}
 
             <Divider sx={{ my: 1 }} />
+
+            {dataCustodianName && (
+                <Typography variant="h4">
+                    <b>{`${t("dataCustodian")}: `}</b>
+                    {dataCustodianName}
+                </Typography>
+            )}
+
             <Typography variant="h4">
                 <b>{`${t("collectionSources")}: `}</b>
                 {collectionSource

--- a/src/app/[locale]/(logged-out)/dataset/[datasetId]/page.tsx
+++ b/src/app/[locale]/(logged-out)/dataset/[datasetId]/page.tsx
@@ -3,9 +3,11 @@ import { notFound } from "next/navigation";
 import Box from "@/components/Box";
 import BoxContainer from "@/components/BoxContainer";
 import LayoutDataItemPage from "@/components/LayoutDataItemPage";
+import Link from "@/components/Link";
 import Typography from "@/components/Typography";
 import ActiveListSidebar from "@/modules/ActiveListSidebar";
 import { DataStatus } from "@/consts/application";
+import { RouteName } from "@/consts/routeName";
 import { getDataset } from "@/utils/api";
 import { getLatestVersion } from "@/utils/dataset";
 import metaData from "@/utils/metadata";
@@ -90,6 +92,16 @@ export default async function DatasetItemPage({
         name: datasetVersion.metadata?.metadata?.summary?.title,
     };
 
+    const dataCustodianName = get(
+        datasetVersion,
+        "metadata.metadata.summary.dataCustodian.name"
+    );
+
+    const dataCustodianId = get(
+        datasetVersion,
+        "metadata.metadata.summary.dataCustodian.identifier"
+    );
+
     return (
         <LayoutDataItemPage
             navigation={<ActiveListSidebar items={activeLinkList} />}
@@ -104,14 +116,34 @@ export default async function DatasetItemPage({
                         }}>
                         {datasetStats && (
                             <Box sx={{ p: 0, gap: 2 }}>
-                                <Typography
-                                    variant="h2"
-                                    sx={{ pt: 0.5, pb: 0.5 }}>
-                                    {
-                                        datasetVersion.metadata?.metadata
-                                            ?.summary?.title
-                                    }
-                                </Typography>
+                                <Box
+                                    sx={{
+                                        display: "flex",
+                                        flexWrap: "wrap",
+                                        alignItems: "baseline",
+                                        gap: 1,
+                                        pt: 0.5,
+                                        pb: 0.5,
+                                    }}>
+                                    <Typography variant="h2">
+                                        {
+                                            datasetVersion.metadata?.metadata
+                                                ?.summary?.title
+                                        }
+                                    </Typography>
+                                    {dataCustodianName && dataCustodianId && (
+                                        <>
+                                            <Typography variant="h2">
+                                                -
+                                            </Typography>
+                                            <Link
+                                                variant="h2"
+                                                href={`/${RouteName.DATA_CUSTODIANS_ITEM}/${dataCustodianId}`}>
+                                                {dataCustodianName}
+                                            </Link>
+                                        </>
+                                    )}
+                                </Box>
                                 <Box
                                     sx={{
                                         overflow: "hidden",

--- a/src/config/messages/en.json
+++ b/src/config/messages/en.json
@@ -1554,6 +1554,7 @@
                     "isMemberOf": "Similar Datasets ({ count })"
                 },
                 "Sources": {
+                    "dataCustodian": "Data Custodian",
                     "datasetTypes": "Dataset Types",
                     "datasetSubtypes": "Dataset Sub-types",
                     "collectionSources": "Collection Sources",


### PR DESCRIPTION
> AI disclaimer - CLAUDE was used for this. The plan and scaffolding were done manually; CLAUDE implemented the display tweaks (roughly 50% AI). Changes are small, self-contained rendering additions across three existing components.

## Screenshots / videos (if relevant)
<img width="2020" height="579" alt="image" src="https://github.com/user-attachments/assets/01c315e2-d019-4ec9-8cba-7c638cbb5d72" />

## Describe your changes
Surfaces the data custodian on the dataset page. The dataset title header now shows the linked data custodian name (linking through to the data custodian page) alongside the title, the Sources panel gains a "Data Custodian" row, and the dataset mind map's data-custodian node is labelled with the custodian's name rather than the generic default. A new `dataCustodian` translation key backs the Sources label.

## Issue ticket link
https://hdruk.atlassian.net/browse/GAT-7604

## Checklist before requesting a review

- [x] I have performed a self-review of my code
- [ ] I have added appropriate unit tests / e2e tests (where relevant)
- [ ] I have created mocks for api endpoints (where appropriate)
- [ ] The interface is responsive (where ticket is relevant)
- [ ] The interface is at least AA (where ticket is relevant)
- [ ] Commits are described as "(chore|fix|feature|test|maintenance): description"
