### PR TITLE
feat(GAT-7604): Widget improvments

### DIFF
--- a/src/app/[locale]/account/team/[teamId]/(withLeftNav)/integrations/widgets/[widgetId]/components/WidgetConfigForm/WidgetConfigForm.tsx
+++ b/src/app/[locale]/account/team/[teamId]/(withLeftNav)/integrations/widgets/[widgetId]/components/WidgetConfigForm/WidgetConfigForm.tsx
@@ -16,13 +16,20 @@ import {
     BRANDING_DEFAULTS,
     BRANDING_NHS,
     DATA_CUSTODIAN_LIMIT,
+    SIZE_PRESETS,
 } from "../../const";
 import { getChipLabel, isOptionEqualToValue } from "../../utils";
 
 const TRANSLATION_PATH = `pages.account.team.widgets.edit`;
 
+const BRANDING_PRESETS = [
+    { labelKey: "brandingUseDefaults", palette: BRANDING_DEFAULTS },
+    { labelKey: "brandingUseNHS", palette: BRANDING_NHS },
+] as const;
+
 interface WidgetConfigFormProps {
     form: UseFormReturn<Widget>;
+    applyPreset: (width: number, height: number) => void;
     teamId: string;
     teamNameOptions: { value: string; label: string }[];
     formatEntityOptions: (
@@ -39,6 +46,7 @@ interface WidgetConfigFormProps {
 
 const WidgetConfigForm = ({
     form,
+    applyPreset,
     teamId,
     teamNameOptions,
     formatEntityOptions,
@@ -240,54 +248,15 @@ const WidgetConfigForm = ({
                     <Typography fontSize={16}>{t("size")}</Typography>
                     <Typography>{t("sizeInfo")}</Typography>
                     <Box sx={{ display: "flex", p: 0, gap: 3, mb: 2 }}>
-                        <Button
-                            onClick={() => {
-                                setValue("size_width", 600, {
-                                    shouldDirty: true,
-                                });
-                                setValue("size_height", 740, {
-                                    shouldDirty: true,
-                                });
-                                setValue("unit", Unit.PX, {
-                                    shouldDirty: true,
-                                });
-                            }}
-                            variant="link"
-                            sx={{ color: colors.green700 }}>
-                            {t("sizeLarge")}
-                        </Button>
-                        <Button
-                            onClick={() => {
-                                setValue("size_width", 400, {
-                                    shouldDirty: true,
-                                });
-                                setValue("size_height", 592, {
-                                    shouldDirty: true,
-                                });
-                                setValue("unit", Unit.PX, {
-                                    shouldDirty: true,
-                                });
-                            }}
-                            variant="link"
-                            sx={{ color: colors.green700 }}>
-                            {t("sizeMedium")}
-                        </Button>
-                        <Button
-                            onClick={() => {
-                                setValue("size_width", 300, {
-                                    shouldDirty: true,
-                                });
-                                setValue("size_height", 444, {
-                                    shouldDirty: true,
-                                });
-                                setValue("unit", Unit.PX, {
-                                    shouldDirty: true,
-                                });
-                            }}
-                            variant="link"
-                            sx={{ color: colors.green700 }}>
-                            {t("sizeSmall")}
-                        </Button>
+                        {SIZE_PRESETS.map(({ labelKey, width, height }) => (
+                            <Button
+                                key={labelKey}
+                                onClick={() => applyPreset(width, height)}
+                                variant="link"
+                                sx={{ color: colors.green700 }}>
+                                {t(labelKey)}
+                            </Button>
+                        ))}
                     </Box>
                 </>
             ),
@@ -327,50 +296,24 @@ const WidgetConfigForm = ({
                 <>
                     <Typography>{t("brandingInfo")}</Typography>
                     <Box sx={{ display: "flex", p: 0, gap: 3, mb: 2 }}>
-                        <Button
-                            onClick={() => {
-                                setValue(
-                                    "branding_primary",
-                                    BRANDING_DEFAULTS.branding_primary,
-                                    { shouldDirty: true }
-                                );
-                                setValue(
-                                    "branding_secondary",
-                                    BRANDING_DEFAULTS.branding_secondary,
-                                    { shouldDirty: true }
-                                );
-                                setValue(
-                                    "branding_neutral",
-                                    BRANDING_DEFAULTS.branding_neutral,
-                                    { shouldDirty: true }
-                                );
-                            }}
-                            variant="link"
-                            sx={{ color: colors.green700 }}>
-                            {t("brandingUseDefaults")}
-                        </Button>
-                        <Button
-                            onClick={() => {
-                                setValue(
-                                    "branding_primary",
-                                    BRANDING_NHS.branding_primary,
-                                    { shouldDirty: true }
-                                );
-                                setValue(
-                                    "branding_secondary",
-                                    BRANDING_NHS.branding_secondary,
-                                    { shouldDirty: true }
-                                );
-                                setValue(
-                                    "branding_neutral",
-                                    BRANDING_NHS.branding_neutral,
-                                    { shouldDirty: true }
-                                );
-                            }}
-                            variant="link"
-                            sx={{ color: colors.green700 }}>
-                            {t("brandingUseNHS")}
-                        </Button>
+                        {BRANDING_PRESETS.map(({ labelKey, palette }) => (
+                            <Button
+                                key={labelKey}
+                                onClick={() =>
+                                    Object.entries(palette).forEach(
+                                        ([field, value]) =>
+                                            setValue(
+                                                field as keyof Widget,
+                                                value,
+                                                { shouldDirty: true }
+                                            )
+                                    )
+                                }
+                                variant="link"
+                                sx={{ color: colors.green700 }}>
+                                {t(labelKey)}
+                            </Button>
+                        ))}
                     </Box>
                 </>
             ),

--- a/src/app/[locale]/account/team/[teamId]/(withLeftNav)/integrations/widgets/[widgetId]/components/WidgetCreator/WidgetCreator.tsx
+++ b/src/app/[locale]/account/team/[teamId]/(withLeftNav)/integrations/widgets/[widgetId]/components/WidgetCreator/WidgetCreator.tsx
@@ -31,7 +31,7 @@ const WidgetCreator = ({ widget, teamId, teamNames }: WidgetCreatorProps) => {
 
     const templateType = searchParams.get("template");
 
-    const { form, widgetId, onSubmit } = useWidgetForm(
+    const { form, widgetId, onSubmit, applyPreset } = useWidgetForm(
         teamId,
         teamNames,
         widget,
@@ -92,6 +92,7 @@ const WidgetCreator = ({ widget, teamId, teamNames }: WidgetCreatorProps) => {
                     content: (
                         <WidgetConfigForm
                             form={form}
+                            applyPreset={applyPreset}
                             onSubmit={handleSubmitAndPreview}
                             formatEntityOptions={formatEntityOptions}
                             selectAllOptions={selectAllOptions}

--- a/src/app/[locale]/account/team/[teamId]/(withLeftNav)/integrations/widgets/[widgetId]/const.ts
+++ b/src/app/[locale]/account/team/[teamId]/(withLeftNav)/integrations/widgets/[widgetId]/const.ts
@@ -7,6 +7,12 @@ export const DATA_CUSTODIAN_LIMIT = 25;
 
 export const WIDGET_ID_CREATE = "create";
 
+export const SIZE_PRESETS = [
+    { labelKey: "sizeLarge", width: 600, height: 740 },
+    { labelKey: "sizeMedium", width: 400, height: 592 },
+    { labelKey: "sizeSmall", width: 300, height: 444 },
+] as const;
+
 export const BRANDING_DEFAULTS = {
     branding_primary: "#475DA7",
     branding_secondary: "#2C8267",

--- a/src/app/[locale]/account/team/[teamId]/(withLeftNav)/integrations/widgets/[widgetId]/hooks/useWidgetForm.test.ts
+++ b/src/app/[locale]/account/team/[teamId]/(withLeftNav)/integrations/widgets/[widgetId]/hooks/useWidgetForm.test.ts
@@ -1,5 +1,7 @@
 import { act, waitFor } from "@testing-library/react";
+import { Widget } from "@/interfaces/Widget";
 import { renderHook } from "@/utils/testUtils";
+import { BRANDING_DEFAULTS } from "../const";
 import useWidgetForm from "./useWidgetForm";
 
 describe("useWidgetForm — keep proportions", () => {
@@ -70,6 +72,110 @@ describe("useWidgetForm — keep proportions", () => {
         act(() => result.current.form.setValue("size_width", 500));
         await waitFor(() =>
             expect(result.current.form.getValues("size_height")).toBe(250)
+        );
+    });
+
+    it("applies a preset that shares a dimension without overriding it", async () => {
+        const { result } = setup();
+        enableLock(result.current.form);
+
+        // Width edit re-bases height to keep the ratio: 740 * 400 / 600 = 493.
+        act(() => result.current.form.setValue("size_width", 400));
+        await waitFor(() =>
+            expect(result.current.form.getValues("size_height")).toBe(493)
+        );
+
+        // Preset shares the width (400) — must still apply 400 x 592 exactly.
+        act(() => result.current.applyPreset(400, 592));
+        await waitFor(() => {
+            expect(result.current.form.getValues("size_width")).toBe(400);
+            expect(result.current.form.getValues("size_height")).toBe(592);
+        });
+
+        // Subsequent single-axis edit follows the preset's new ratio.
+        act(() => result.current.form.setValue("size_width", 800));
+        await waitFor(() =>
+            expect(result.current.form.getValues("size_height")).toBe(1184)
+        );
+    });
+
+    it("does not let intermediate keystrokes corrupt the locked ratio", async () => {
+        const { result } = setup();
+        act(() => result.current.applyPreset(600, 740));
+        enableLock(result.current.form);
+
+        // Typing "1000" passes through 1; height collapses with it...
+        act(() => result.current.form.setValue("size_width", 1));
+        await waitFor(() =>
+            expect(result.current.form.getValues("size_height")).toBe(1)
+        );
+
+        // ...but the locked 600:740 ratio still applies to the final value.
+        act(() => result.current.form.setValue("size_width", 1000));
+        // 740 * 1000 / 600 = 1233.33 -> 1233 (not 1000)
+        await waitFor(() =>
+            expect(result.current.form.getValues("size_height")).toBe(1233)
+        );
+    });
+});
+
+describe("useWidgetForm — branding defaults", () => {
+    it("defaults the branding colours for a new widget", () => {
+        const { result } = renderHook(() =>
+            useWidgetForm("1", [], undefined, null)
+        );
+        expect(result.current.form.getValues("branding_primary")).toBe(
+            BRANDING_DEFAULTS.branding_primary
+        );
+        expect(result.current.form.getValues("branding_secondary")).toBe(
+            BRANDING_DEFAULTS.branding_secondary
+        );
+        expect(result.current.form.getValues("branding_neutral")).toBe(
+            BRANDING_DEFAULTS.branding_neutral
+        );
+    });
+
+    it("falls back to default colours when a saved widget has none", () => {
+        const widget = {
+            id: 1,
+            widget_name: "Test",
+            branding_primary: null,
+            branding_secondary: undefined,
+            branding_neutral: "",
+        } as unknown as Widget;
+        const { result } = renderHook(() =>
+            useWidgetForm("1", [], widget, null)
+        );
+        expect(result.current.form.getValues("branding_primary")).toBe(
+            BRANDING_DEFAULTS.branding_primary
+        );
+        expect(result.current.form.getValues("branding_secondary")).toBe(
+            BRANDING_DEFAULTS.branding_secondary
+        );
+        expect(result.current.form.getValues("branding_neutral")).toBe(
+            BRANDING_DEFAULTS.branding_neutral
+        );
+    });
+
+    it("keeps a saved widget's own branding colours", () => {
+        const widget = {
+            id: 1,
+            widget_name: "Test",
+            branding_primary: "#111111",
+            branding_secondary: "#222222",
+            branding_neutral: "#333333",
+        } as unknown as Widget;
+        const { result } = renderHook(() =>
+            useWidgetForm("1", [], widget, null)
+        );
+        expect(result.current.form.getValues("branding_primary")).toBe(
+            "#111111"
+        );
+        expect(result.current.form.getValues("branding_secondary")).toBe(
+            "#222222"
+        );
+        expect(result.current.form.getValues("branding_neutral")).toBe(
+            "#333333"
         );
     });
 });

--- a/src/app/[locale]/account/team/[teamId]/(withLeftNav)/integrations/widgets/[widgetId]/hooks/useWidgetForm.ts
+++ b/src/app/[locale]/account/team/[teamId]/(withLeftNav)/integrations/widgets/[widgetId]/hooks/useWidgetForm.ts
@@ -1,6 +1,6 @@
 "use client";
 
-import { useEffect, useMemo, useRef, useState } from "react";
+import { useCallback, useEffect, useMemo, useRef, useState } from "react";
 import { Resolver, useForm, UseFormReturn } from "react-hook-form";
 import { yupResolver } from "@hookform/resolvers/yup";
 import { useTranslations } from "next-intl";
@@ -13,7 +13,12 @@ import usePost from "@/hooks/usePost";
 import apis from "@/config/apis";
 import { RouteName } from "@/consts/routeName";
 import { CUSTODIAN, DATA_USES, DATASETS } from "@/consts/translation";
-import { BRANDING_DEFAULTS, DATA_CUSTODIAN_LIMIT, TabValues } from "../const";
+import {
+    BRANDING_DEFAULTS,
+    DATA_CUSTODIAN_LIMIT,
+    SIZE_PRESETS,
+    TabValues,
+} from "../const";
 
 const TRANSLATION_PATH = `pages.account.team.widgets.edit`;
 
@@ -53,6 +58,7 @@ export default function useWidgetForm(
         dirtyFields: Partial<Record<keyof Widget, boolean>>
     ) => Promise<void>;
     setWidgetId: React.Dispatch<React.SetStateAction<number | undefined>>;
+    applyPreset: (width: number, height: number) => void;
 } {
     const t = useTranslations(TRANSLATION_PATH);
     const { push } = useRouter();
@@ -79,12 +85,19 @@ export default function useWidgetForm(
             include_search_bar:
                 templateType === DATASETS || templateType === DATA_USES,
             include_cohort_link: false,
-            size_width: 600,
-            size_height: 740,
+            size_width: SIZE_PRESETS[0].width,
+            size_height: SIZE_PRESETS[0].height,
             unit: Unit.PX,
             widget_name: "",
             ...BRANDING_DEFAULTS,
             ...widget,
+            branding_primary:
+                widget?.branding_primary || BRANDING_DEFAULTS.branding_primary,
+            branding_secondary:
+                widget?.branding_secondary ||
+                BRANDING_DEFAULTS.branding_secondary,
+            branding_neutral:
+                widget?.branding_neutral || BRANDING_DEFAULTS.branding_neutral,
             has_datasets:
                 templateType === CUSTODIAN || templateType === DATASETS
                     ? true
@@ -163,30 +176,64 @@ export default function useWidgetForm(
     const width = Number(form.watch("size_width"));
     const height = Number(form.watch("size_height"));
     const prevSize = useRef({ width, height });
+    const ratio = useRef(1);
+    const prevLocked = useRef(false);
 
     useEffect(() => {
         const prev = prevSize.current;
         prevSize.current = { width, height };
 
-        // Only adjust when locked, values are valid, and exactly one dimension
-        // changed. Changing both at once (a size preset) just re-bases the ratio.
-        if (!keepProportions || !width || !height || !prev.width || !prev.height)
-            return;
-        const widthChanged = width !== prev.width;
-        if (widthChanged === (height !== prev.height)) return;
+        const lockJustEnabled = keepProportions && !prevLocked.current;
+        prevLocked.current = keepProportions;
 
+        if (!keepProportions || !width || !height) return;
+
+        // Capture the locked ratio when the lock is switched on
+        if (lockJustEnabled) {
+            ratio.current = width / height;
+            return;
+        }
+
+        if (!prev.width || !prev.height) return;
+
+        const widthChanged = width !== prev.width;
+        const heightChanged = height !== prev.height;
+        // ...and re-base it when both dimensions change at once (a size preset).
+        if (widthChanged && heightChanged) {
+            ratio.current = width / height;
+            return;
+        }
+        if (!widthChanged && !heightChanged) return;
+
+        // Deriving from the locked ratio (not the previous values) stops rounding
+        // drift from intermediate keystrokes, e.g. typing "1000" passing through
+        // width 1 collapsing the ratio to 1:1.
         if (widthChanged) {
-            const newHeight = Math.round((prev.height * width) / prev.width);
+            const newHeight = Math.round(width / ratio.current);
             prevSize.current = { width, height: newHeight };
             if (newHeight !== height)
                 form.setValue("size_height", newHeight, { shouldDirty: true });
         } else {
-            const newWidth = Math.round((prev.width * height) / prev.height);
+            const newWidth = Math.round(height * ratio.current);
             prevSize.current = { width: newWidth, height };
             if (newWidth !== width)
                 form.setValue("size_width", newWidth, { shouldDirty: true });
         }
     }, [keepProportions, width, height, form]);
+
+    // Selecting a predefined size re-bases the ratio to it. Pre-seeding the ref
+    // means the effect above sees no single-axis change and leaves the preset as-is,
+    // even when the preset shares a dimension with the current size.
+    const applyPreset = useCallback(
+        (presetWidth: number, presetHeight: number) => {
+            prevSize.current = { width: presetWidth, height: presetHeight };
+            ratio.current = presetWidth / presetHeight;
+            form.setValue("size_width", presetWidth, { shouldDirty: true });
+            form.setValue("size_height", presetHeight, { shouldDirty: true });
+            form.setValue("unit", Unit.PX, { shouldDirty: true });
+        },
+        [form]
+    );
 
     const createWidget = usePost<Widget>(
         `${apis.teamsV1Url}/${teamId}/widgets`,
@@ -246,5 +293,5 @@ export default function useWidgetForm(
         }
     };
 
-    return { form, widgetId, onSubmit, setWidgetId };
+    return { form, widgetId, onSubmit, setWidgetId, applyPreset };
 }


### PR DESCRIPTION
AI Disclosure: Claude Code (claude-sonnet-4-6) was used in the development of these changes.

## Screenshots / videos (if relevant)


## Describe your changes
Refactors the widget size and branding preset buttons to be driven by data (`SIZE_PRESETS` / `BRANDING_PRESETS`) instead of repeated hand-written click handlers, and lifts a reusable `applyPreset` helper into `useWidgetForm`. 

The "keep proportions" behaviour is reworked to capture and lock the aspect ratio when the toggle is enabled, deriving the linked dimension from that stored ratio rather than the previous values — this stops rounding drift from intermediate keystrokes (e.g. typing "1000" briefly passing through width 1) from corrupting the ratio. 

Applying a size preset now re-bases the ratio correctly even when it shares a dimension with the current size. Branding colours also now fall back to the defaults when a saved widget has none.

## Issue ticket link
https://hdruk.atlassian.net/browse/GAT-7604

## Checklist before requesting a review

- [x] I have performed a self-review of my code
- [x] I have added appropriate unit tests / e2e tests (where relevant)
- [ ] I have created mocks for api endpoints (where appropriate)
- [ ] The interface is responsive (where ticket is relevant)
- [ ] The interface is at least AA (where ticket is relevant)
- [ ] Commits are described as "(chore|fix|feature|test|maintenance): description"

