### PR TITLE
feat(GAT-8094): Display dataset aliases

### DIFF
--- a/src/app/[locale]/(logged-out)/search/components/ResultCard/ResultCard.tsx
+++ b/src/app/[locale]/(logged-out)/search/components/ResultCard/ResultCard.tsx
@@ -29,6 +29,7 @@ import { CohortIcon, SpeechBubbleIcon } from "@/consts/customIcons";
 import { ChevronThinIcon } from "@/consts/icons";
 import { PostLoginActions } from "@/consts/postLoginActions";
 import { RouteName } from "@/consts/routeName";
+import { formatTextDelimiter } from "@/utils/dataset";
 import { getDateRange, getPopulationSize } from "@/utils/search";
 import { Highlight, ResultTitle } from "./ResultCard.styles";
 
@@ -241,6 +242,7 @@ const ResultCard = ({
         highlight?.abstract?.[0] ??
         highlight?.description?.[0] ??
         metadata.summary.abstract;
+    const datasetAliases = metadata.summary.datasetAliases;
     const dataCustodianId = metadata.summary.publisher.gatewayId;
     // if the below is false, its because the api has failed to find the team id based off the original uid for gatewayId
     const isNumber = !Number.isNaN(dataCustodianId);
@@ -417,6 +419,15 @@ const ResultCard = ({
                                     __html: formattedText,
                                 }}
                             />
+                            {!!datasetAliases?.length && (
+                                <Typography
+                                    variant="body2"
+                                    color="text.gray"
+                                    sx={{ mb: 1.5 }}>
+                                    {t("matchedAliases")}:{" "}
+                                    {formatTextDelimiter(datasetAliases)}
+                                </Typography>
+                            )}
                             <Box
                                 sx={{
                                     p: 0,

--- a/src/config/messages/en.json
+++ b/src/config/messages/en.json
@@ -1330,6 +1330,7 @@
                     "populationSizeNotReported": "not reported",
                     "populationSize": "Dataset population size",
                     "dateLabel": "Date range",
+                    "matchedAliases": "Matched aliases",
                     "leadOrganisation": "Lead Organisation",
                     "leadOrganisationTooltip": "The name of the legal entity that signs the contract to access the data",
                     "datasets": "Datasets",

--- a/src/interfaces/Dataset.ts
+++ b/src/interfaces/Dataset.ts
@@ -59,6 +59,7 @@ interface Metadata {
         description: string;
         doiName: string;
         keywords: string[];
+        datasetAliases?: string | string[] | null;
         shortTitle: string;
         title: string;
         populationSize: number | null;


### PR DESCRIPTION
## Screenshots (if relevant)
<img width="1409" height="222" alt="image" src="https://github.com/user-attachments/assets/e530ce7b-5a4b-4544-b341-835eb8fcea88" />

## Describe your changes
Display dataset aliases on search result card

## Issue ticket link
https://hdruk.atlassian.net/browse/GAT-8094

## Checklist before requesting a review

-   [ ] I have performed a self-review of my code
-   [ ] I have added appropriate unit tests
-   [ ] I have created mocks for unit tests (where appropriate)
-   [ ] The interface is responsive (where appropriate)
-   [ ] The interface is at least AA (where appropriate)
