### PR TITLE
feat(GAT-7564): Data custodian associated resources

### DIFF
--- a/next.config.js
+++ b/next.config.js
@@ -45,6 +45,15 @@ const nextConfig = {
                 hostname: "storage.googleapis.com",
                 pathname: "/hdr-gw-wordpress-prod/**",
             },
+            ...(process.env.NODE_ENV === "development"
+                ? [
+                      {
+                          protocol: "http",
+                          hostname: "localhost",
+                          pathname: "/**",
+                      },
+                  ]
+                : []),
         ],
     },
     async headers() {

--- a/src/app/[locale]/(logged-out)/data-custodian/[dataCustodianId]/components/DataCustodianContent/DataCustodianContent.tsx
+++ b/src/app/[locale]/(logged-out)/data-custodian/[dataCustodianId]/components/DataCustodianContent/DataCustodianContent.tsx
@@ -1,8 +1,8 @@
 import { ReactElement } from "react";
 import { get } from "lodash";
 import { getTranslations } from "next-intl/server";
-import { DataProvider } from "@/interfaces/DataProvider";
 import { FieldType } from "@/interfaces/FieldType";
+import { TeamSummary } from "@/interfaces/TeamSummary";
 import Box from "@/components/Box";
 import BoxContainer from "@/components/BoxContainer";
 import DataCustodianLinks from "@/components/DataCustodianLinks";
@@ -11,7 +11,6 @@ import { MarkDownSanitizedWithHtml } from "@/components/MarkDownSanitizedWithHTM
 import Paper from "@/components/Paper";
 import TooltipIcon from "@/components/TooltipIcon";
 import Typography from "@/components/Typography";
-import apis from "@/config/apis";
 import { formatDate } from "@/utils/date";
 import { DataCustodianField, DataCustodianSection } from "../../config";
 
@@ -20,30 +19,17 @@ const DATE_FORMAT = "DD/MM/YYYY";
 const TOOLTIP_SUFFIX = "Tooltip";
 
 async function DataCustodianContent({
-    dataCustodianId,
+    summaryPromise,
     populatedSections,
 }: {
-    dataCustodianId: number;
+    summaryPromise: Promise<TeamSummary>;
     populatedSections: DataCustodianSection[];
 }): Promise<ReactElement> {
-    const resp = await fetch(
-        `${apis.teamsV1UrlIP}/${dataCustodianId}/summary`,
-        {
-            next: {
-                revalidate: 180,
-                tags: ["all", `custodian_datasets-${dataCustodianId}`],
-            },
-            cache: "force-cache",
-        }
-    );
-    if (!resp.ok) {
-        throw new Error("Failed to fetch custodian data");
-    }
-    const { data } = await resp.json();
+    const data = await summaryPromise;
 
     const t = await getTranslations(TRANSLATION_PATH);
 
-    const getValue = (data: DataProvider, field: DataCustodianField) => {
+    const getValue = (data: TeamSummary, field: DataCustodianField) => {
         const value = get(data, field.path);
 
         return value || t("notAvailable");

--- a/src/app/[locale]/(logged-out)/data-custodian/[dataCustodianId]/components/DatasetsOuter/DatasetsOuter.tsx
+++ b/src/app/[locale]/(logged-out)/data-custodian/[dataCustodianId]/components/DatasetsOuter/DatasetsOuter.tsx
@@ -18,8 +18,10 @@ export default async function DatasetsOuter({
     const [data, summary] = await Promise.all([
         getTeamDatasetsSummary(dataCustodianId, {
             cache: {
-                tags: [`custodian_datasets_summary-${dataCustodianId}`],
-                revalidate: 180,
+                tags: [
+                    "custodian_datasets_summary",
+                    `custodian_datasets_summary-${dataCustodianId}`,
+                ],
             },
         }),
         summaryPromise,

--- a/src/app/[locale]/(logged-out)/data-custodian/[dataCustodianId]/components/DatasetsOuter/DatasetsOuter.tsx
+++ b/src/app/[locale]/(logged-out)/data-custodian/[dataCustodianId]/components/DatasetsOuter/DatasetsOuter.tsx
@@ -1,31 +1,29 @@
 import { ReactElement } from "react";
+import { TeamSummary } from "@/interfaces/TeamSummary";
 import Box from "@/components/Box";
 import DatasetsContent from "@/components/DatasetsContent";
-import apis from "@/config/apis";
+import { getTeamDatasetsSummary } from "@/utils/api";
 
 const TRANSLATION_PATH = "pages.dataCustodian";
 
 export default async function DatasetsOuter({
     dataCustodianId,
+    summaryPromise,
     startIndex,
 }: {
-    dataCustodianId: number;
+    dataCustodianId: string;
+    summaryPromise: Promise<TeamSummary>;
     startIndex: number;
 }): Promise<ReactElement> {
-    const resp = await fetch(
-        `${apis.teamsV1UrlIP}/${dataCustodianId}/datasets_summary`,
-        {
-            next: {
+    const [data, summary] = await Promise.all([
+        getTeamDatasetsSummary(dataCustodianId, {
+            cache: {
+                tags: [`custodian_datasets_summary-${dataCustodianId}`],
                 revalidate: 180,
-                tags: ["all", `custodian_datasets_summary-${dataCustodianId}`],
             },
-            cache: "force-cache",
-        }
-    );
-    if (!resp.ok) {
-        throw new Error("Failed to fetch custodian data");
-    }
-    const { data } = await resp.json();
+        }),
+        summaryPromise,
+    ]);
 
     return (
         <Box
@@ -37,6 +35,7 @@ export default async function DatasetsOuter({
             }}>
             <DatasetsContent
                 datasets={data.datasets}
+                associatedDatasets={summary.associated_datasets ?? []}
                 anchorIndex={startIndex + 1}
                 translationPath={TRANSLATION_PATH}
             />

--- a/src/app/[locale]/(logged-out)/data-custodian/[dataCustodianId]/components/EntitiesOuter/EntitiesOuter.tsx
+++ b/src/app/[locale]/(logged-out)/data-custodian/[dataCustodianId]/components/EntitiesOuter/EntitiesOuter.tsx
@@ -1,34 +1,21 @@
 import { ReactElement } from "react";
+import { TeamSummary } from "@/interfaces/TeamSummary";
 import Box from "@/components/Box";
 import CollectionsContent from "@/components/CollectionsContent";
 import DataUsesContent from "@/components/DataUsesContent";
 import PublicationsContent from "@/components/PublicationsContent";
 import ToolsContent from "@/components/ToolsContent";
-import apis from "@/config/apis";
 
 const TRANSLATION_PATH = "pages.dataCustodian";
 
 export default async function EntitiesOuter({
-    dataCustodianId,
+    summaryPromise,
     startIndex,
 }: {
-    dataCustodianId: number;
+    summaryPromise: Promise<TeamSummary>;
     startIndex: number;
 }): Promise<ReactElement> {
-    const resp = await fetch(
-        `${apis.teamsV1UrlIP}/${dataCustodianId}/summary`,
-        {
-            next: {
-                revalidate: 180,
-                tags: ["all", `custodian_entities_summary-${dataCustodianId}`],
-            },
-            cache: "force-cache",
-        }
-    );
-    if (!resp.ok) {
-        throw new Error("Failed to fetch custodian data");
-    }
-    const { data } = await resp.json();
+    const data = await summaryPromise;
 
     return (
         <Box
@@ -40,21 +27,25 @@ export default async function EntitiesOuter({
             }}>
             <CollectionsContent
                 collections={data.collections}
+                associatedCollections={data.associated_collections ?? []}
                 anchorIndex={startIndex + 2}
                 translationPath={TRANSLATION_PATH}
             />
             <ToolsContent
                 tools={data.tools}
+                associatedTools={data.associated_tools ?? []}
                 anchorIndex={startIndex + 3}
                 translationPath={TRANSLATION_PATH}
             />
             <DataUsesContent
                 datauses={data.durs}
+                associatedDatauses={data.associated_durs ?? []}
                 anchorIndex={startIndex + 4}
                 translationPath={TRANSLATION_PATH}
             />
             <PublicationsContent
                 publications={data.publications}
+                associatedPublications={data.associated_publications ?? []}
                 anchorIndex={startIndex + 5}
                 translationPath={TRANSLATION_PATH}
             />

--- a/src/app/[locale]/(logged-out)/data-custodian/[dataCustodianId]/page.tsx
+++ b/src/app/[locale]/(logged-out)/data-custodian/[dataCustodianId]/page.tsx
@@ -14,7 +14,7 @@ import ActiveListSidebar from "@/modules/ActiveListSidebar";
 import apis from "@/config/apis";
 import { StaticImages } from "@/config/images";
 import { AspectRatioImage } from "@/consts/image";
-import { getTeamInfo } from "@/utils/api";
+import { getTeamInfo, getTeamSummary } from "@/utils/api";
 import metaData from "@/utils/metadata";
 import ActionBar from "./components/ActionBar";
 import DataCustodianContent from "./components/DataCustodianContent";
@@ -57,6 +57,13 @@ export default async function DataCustodianItemPage({
     }
     const { data: cohortDiscoverySupport } = await resp.json();
 
+    const summaryPromise = getTeamSummary(dataCustodianId, {
+        cache: {
+            tags: [`custodian_summary-${dataCustodianId}`],
+            revalidate: 180,
+        },
+    });
+
     const populatedSections = dataCustodianFields.filter(section =>
         section.fields.some(field => !isEmpty(get(infoData, field.path)))
     );
@@ -82,10 +89,17 @@ export default async function DataCustodianItemPage({
                             cohortDiscoverySupport.supportsCohortDiscovery
                         }
                     />
-                    <Box sx={{ ml: 2, mt: 2 }}>
-                        <Box sx={{ display: "flex", alignItems: "center", pt: 0, justifyContent: "space-between", p: 0}}>
+                    <Box>
+                        <Box
+                            sx={{
+                                display: "flex",
+                                alignItems: "center",
+                                pt: 0,
+                                justifyContent: "space-between",
+                                p: 0,
+                            }}>
                             <Box sx={{ mb: 1, p: 0 }}>
-                                <Typography variant="h1" sx={{ ml: 2, mt: 2 }}>
+                                <Typography variant="h1" sx={{ mt: 2, mb: 0 }}>
                                     {infoData.name}
                                 </Typography>
                             </Box>
@@ -106,13 +120,14 @@ export default async function DataCustodianItemPage({
                             display: "flex",
                             flexDirection: "column",
                             gap: 2,
+                            p: 0,
                         }}>
                         <Suspense
                             fallback={
                                 <Skeleton variant="rectangular" height={200} />
                             }>
                             <DataCustodianContent
-                                dataCustodianId={dataCustodianId}
+                                summaryPromise={summaryPromise}
                                 populatedSections={populatedSections}
                             />
                             {!!infoData.aliases?.length && (
@@ -137,13 +152,14 @@ export default async function DataCustodianItemPage({
                         <Suspense
                             fallback={<SectionSkeleton title="Datasets" />}>
                             <DatasetsOuter
-                                dataCustodianId={+dataCustodianId}
+                                dataCustodianId={dataCustodianId}
+                                summaryPromise={summaryPromise}
                                 startIndex={populatedSections.length}
                             />
                         </Suspense>
                         <Suspense fallback={<DataCustodianEntitiesSkeleton />}>
                             <EntitiesOuter
-                                dataCustodianId={+dataCustodianId}
+                                summaryPromise={summaryPromise}
                                 startIndex={populatedSections.length}
                             />
                         </Suspense>

--- a/src/app/[locale]/(logged-out)/data-custodian/[dataCustodianId]/page.tsx
+++ b/src/app/[locale]/(logged-out)/data-custodian/[dataCustodianId]/page.tsx
@@ -13,6 +13,7 @@ import Typography from "@/components/Typography";
 import ActiveListSidebar from "@/modules/ActiveListSidebar";
 import apis from "@/config/apis";
 import { StaticImages } from "@/config/images";
+import { DEFAULT_CACHE_REVALIDATE } from "@/consts/cache";
 import { AspectRatioImage } from "@/consts/image";
 import { getTeamInfo, getTeamSummary } from "@/utils/api";
 import metaData from "@/utils/metadata";
@@ -46,10 +47,13 @@ export default async function DataCustodianItemPage({
         `${apis.teamsV1UrlIP}/${dataCustodianId}/datasets_cohort_discovery`,
         {
             next: {
-                revalidate: 180,
-                tags: ["all", `custodian_datasets-${dataCustodianId}`],
+                revalidate: DEFAULT_CACHE_REVALIDATE,
+                tags: [
+                    "all",
+                    "custodian_datasets",
+                    `custodian_datasets-${dataCustodianId}`,
+                ],
             },
-            cache: "force-cache",
         }
     );
     if (!resp.ok) {
@@ -59,8 +63,10 @@ export default async function DataCustodianItemPage({
 
     const summaryPromise = getTeamSummary(dataCustodianId, {
         cache: {
-            tags: [`custodian_summary-${dataCustodianId}`],
-            revalidate: 180,
+            tags: [
+                "custodian_summary",
+                `custodian_summary-${dataCustodianId}`,
+            ],
         },
     });
 

--- a/src/app/[locale]/(logged-out)/search/components/Search/Search.tsx
+++ b/src/app/[locale]/(logged-out)/search/components/Search/Search.tsx
@@ -271,9 +271,13 @@ const Search = ({ filters, schema }: SearchProps) => {
     const { data: v1Data, isLoading: isV1Searching } = usePostSwr<
         SearchPaginationType<SearchResult>
     >(
-        `${apis.searchV1Url}/${queryParams.type}?view_type=mini&per_page=${
-            queryParams.per_page
-        }&page=${queryParams.page}&sort=${queryParams.sort}${
+        `${apis.searchV1Url}/${queryParams.type}?${
+            queryParams.type === SearchCategory.PUBLICATIONS
+                ? ``
+                : `view_type=mini&`
+        }per_page=${queryParams.per_page}&page=${queryParams.page}&sort=${
+            queryParams.sort
+        }${
             queryParams.type === SearchCategory.PUBLICATIONS
                 ? `&${STATIC_FILTER_SOURCE}=${queryParams.source}`
                 : ``

--- a/src/app/[locale]/account/profile/teams/components/CreateTeamForm/CreateTeamForm.tsx
+++ b/src/app/[locale]/account/profile/teams/components/CreateTeamForm/CreateTeamForm.tsx
@@ -25,6 +25,7 @@ import usePatch from "@/hooks/usePatch";
 import usePost from "@/hooks/usePost";
 import { useUnsavedChanges } from "@/hooks/useUnsavedChanges";
 import notificationService from "@/services/notification";
+import { revalidateCacheAction } from "@/app/actions/revalidateCacheAction";
 import apis from "@/config/apis";
 import {
     questionBankField,
@@ -278,6 +279,9 @@ const CreateTeamForm = () => {
             } else {
                 result = await editTeam(params.teamId, formattedFormData);
                 if (result) {
+                    await revalidateCacheAction(
+                        `custodian_summary-${params.teamId}`
+                    );
                     push(Routes.ACCOUNT_TEAMS);
                 } else {
                     setIsSaving(false);
@@ -429,6 +433,10 @@ const CreateTeamForm = () => {
                                         ...getValues(),
                                         team_logo: response?.file_location,
                                     });
+
+                                    await revalidateCacheAction(
+                                        `custodian_summary-${createdTeamId}`
+                                    );
 
                                     push(Routes.ACCOUNT_TEAMS);
                                 }}

--- a/src/components/Accordion/Accordion.test.tsx
+++ b/src/components/Accordion/Accordion.test.tsx
@@ -25,6 +25,26 @@ describe("Accordion", () => {
         expect(screen.getByText(contents)).toBeInTheDocument();
     });
 
+    it("gives the region a unique accessible name when an id is provided", () => {
+        render(
+            <Accordion
+                id="anchor1"
+                heading={heading}
+                contents={contents}
+                defaultExpanded
+            />
+        );
+
+        const region = screen.getByRole("region");
+        expect(region).toHaveAttribute("aria-labelledby", "anchor1-header");
+        expect(region).toHaveAttribute("id", "anchor1-content");
+        expect(region).toHaveAccessibleName(heading);
+        expect(screen.getByRole("button", { name: heading })).toHaveAttribute(
+            "id",
+            "anchor1-header"
+        );
+    });
+
     it("displays accordion arrow icon on left", async () => {
         const wrapper = render(
             <Accordion heading={heading} contents={contents} iconLeft />

--- a/src/components/Accordion/Accordion.tsx
+++ b/src/components/Accordion/Accordion.tsx
@@ -1,4 +1,4 @@
-import { ReactElement, ReactNode } from "react";
+import { ElementType, ReactElement, ReactNode } from "react";
 import { Tooltip } from "@mui/material";
 import MuiAccordion, {
     AccordionProps as MuiAccordionProps,
@@ -18,6 +18,7 @@ export interface AccordionProps
     iconLeft?: boolean;
     expandIcon?: IconType;
     tooltip?: string;
+    headingComponent?: ElementType;
 }
 
 const tooltipWrapper = (tooltip: string) => (children: ReactElement) =>
@@ -40,12 +41,29 @@ const Accordion = ({
     expandIcon,
     sx,
     tooltip,
+    headingComponent = "h3",
+    slotProps,
+    id,
     ...restProps
 }: AccordionProps) => {
     const Icon = expandIcon || ChevronThinIcon;
 
+    const summaryId = id ? `${id}-header` : undefined;
+    const regionId = id ? `${id}-content` : undefined;
+
     return (
         <MuiAccordion
+            id={id}
+            slotProps={{
+                ...slotProps,
+                heading: { component: headingComponent },
+                ...(id && {
+                    region: {
+                        "aria-labelledby": summaryId,
+                        id: regionId,
+                    },
+                }),
+            }}
             sx={{
                 background: "transparent",
                 boxShadow: "none",
@@ -58,6 +76,13 @@ const Accordion = ({
                 "&.MuiAccordion-root.Mui-disabled": {
                     background: "transparent",
                 },
+                ".MuiAccordionSummary-root.Mui-expanded": {
+                    minHeight: "48px",
+                },
+                ".MuiAccordionSummary-content.Mui-expanded": {
+                    marginTop: 1.5,
+                    marginBottom: 1.5,
+                },
                 ...(variant === "underline" && {
                     borderBottom: "1px solid rgba(0, 0, 0, 0.12)",
                     "&:first-of-type, &:last-of-type": {
@@ -68,13 +93,15 @@ const Accordion = ({
                     "&.MuiAccordion-root:before": {
                         height: 0,
                     },
-                    ".MuiAccordionSummary-content": {
-                        marginTop: 1,
-                        marginBottom: 1,
-                    },
-                    ".MuiAccordionSummary-root": {
-                        minHeight: "auto",
-                    },
+                    ".MuiAccordionSummary-content, .MuiAccordionSummary-content.Mui-expanded":
+                        {
+                            marginTop: 1,
+                            marginBottom: 1,
+                        },
+                    ".MuiAccordionSummary-root, .MuiAccordionSummary-root.Mui-expanded":
+                        {
+                            minHeight: "auto",
+                        },
                 }),
                 ...(iconLeft && {
                     ".MuiAccordionSummary-root .MuiAccordionSummary-content": {
@@ -88,6 +115,8 @@ const Accordion = ({
                 requiresWrapper={!!tooltip}
                 wrapper={tooltipWrapper(tooltip || "")}>
                 <MuiAccordionSummary
+                    id={summaryId}
+                    aria-controls={regionId}
                     expandIcon={
                         <Icon
                             fontSize={!heading ? "large" : "medium"}

--- a/src/components/Accordion/__snapshots__/Accordion.test.tsx.snap
+++ b/src/components/Accordion/__snapshots__/Accordion.test.tsx.snap
@@ -3,7 +3,7 @@
 exports[`Accordion displays accordion arrow icon on left 1`] = `
 <div>
   <div
-    class="MuiPaper-root MuiPaper-elevation MuiPaper-rounded MuiPaper-elevation1 MuiAccordion-root MuiAccordion-rounded MuiAccordion-gutters mui-style-b1tdb0-MuiPaper-root-MuiAccordion-root"
+    class="MuiPaper-root MuiPaper-elevation MuiPaper-rounded MuiPaper-elevation1 MuiAccordion-root MuiAccordion-rounded MuiAccordion-gutters mui-style-qhp8f-MuiPaper-root-MuiAccordion-root"
     style="--Paper-shadow: 0px 2px 1px -1px rgba(0,0,0,0.2),0px 1px 1px 0px rgba(0,0,0,0.14),0px 1px 3px 0px rgba(0,0,0,0.12);"
   >
     <h3
@@ -75,7 +75,7 @@ exports[`Accordion displays accordion arrow icon on left 1`] = `
 exports[`Accordion should render component 1`] = `
 <div>
   <div
-    class="MuiPaper-root MuiPaper-elevation MuiPaper-rounded MuiPaper-elevation1 MuiAccordion-root MuiAccordion-rounded MuiAccordion-gutters mui-style-4nesdj-MuiPaper-root-MuiAccordion-root"
+    class="MuiPaper-root MuiPaper-elevation MuiPaper-rounded MuiPaper-elevation1 MuiAccordion-root MuiAccordion-rounded MuiAccordion-gutters mui-style-1mpv158-MuiPaper-root-MuiAccordion-root"
     style="--Paper-shadow: 0px 2px 1px -1px rgba(0,0,0,0.2),0px 1px 1px 0px rgba(0,0,0,0.14),0px 1px 3px 0px rgba(0,0,0,0.12);"
   >
     <h3

--- a/src/components/AccordionSection/AccordionSection.tsx
+++ b/src/components/AccordionSection/AccordionSection.tsx
@@ -32,7 +32,12 @@ export default function AccordionSection({
             variant="plain"
             noIndent
             elevation={0}
-            heading={<Typography variant="h3">{heading}</Typography>}
+            headingComponent="h2"
+            heading={
+                <Typography variant="h3" component="span">
+                    {heading}
+                </Typography>
+            }
             contents={
                 <>
                     <BoxContainer

--- a/src/components/AccordionSectionSplit/AccordionSectionSplit.styles.ts
+++ b/src/components/AccordionSectionSplit/AccordionSectionSplit.styles.ts
@@ -1,0 +1,84 @@
+import { ElementType } from "react";
+import { styled, Typography } from "@mui/material";
+import AccordionCard from "@/components/AccordionSection/AccordionCard";
+
+const GAP = 2;
+const MOBILE_VISIBLE_ROWS = 2;
+
+export const SplitWrapper = styled("div", {
+    shouldForwardProp: prop => prop !== "columns",
+})<{ columns: number }>(({ theme, columns }) => ({
+    display: "grid",
+    gridTemplateColumns: "1fr",
+    gap: theme.spacing(GAP),
+    alignItems: "stretch",
+    ...(columns > 1 && {
+        [theme.breakpoints.up("tablet")]: {
+            gridTemplateColumns: "1fr 1fr",
+        },
+    }),
+}));
+
+export const Pane = styled("div")(({ theme }) => ({
+    display: "flex",
+    flexDirection: "column",
+    gap: theme.spacing(1),
+    minWidth: 0,
+}));
+
+export const PaneHeading = styled("div")(({ theme }) => ({
+    display: "flex",
+    alignItems: "baseline",
+    gap: theme.spacing(1),
+    minWidth: 0,
+}));
+
+export const PaneTitle = styled(Typography)<{ component?: ElementType }>({
+    minWidth: 0,
+    overflow: "hidden",
+    textOverflow: "ellipsis",
+    whiteSpace: "nowrap",
+});
+
+export const PaneCount = styled(Typography)({
+    flexShrink: 0,
+});
+
+export const SplitCard = styled(AccordionCard)(({ theme }) => ({
+    height: "100%",
+    overflow: "hidden",
+    "& .MuiCardContent-root": {
+        height: "100%",
+        gap: theme.spacing(1),
+    },
+    "& .MuiCardContent-root > *": {
+        whiteSpace: "nowrap",
+        overflow: "hidden",
+        textOverflow: "ellipsis",
+        flexShrink: 0,
+    },
+}));
+
+export const ScrollArea = styled("div", {
+    shouldForwardProp: prop => prop !== "cardHeight" && prop !== "visibleRows",
+})<{ cardHeight: number; visibleRows: number }>(
+    ({ theme, cardHeight, visibleRows }) => ({
+        display: "grid",
+        gridTemplateColumns: "1fr",
+        gridAutoRows: `${cardHeight}px`,
+        gap: theme.spacing(GAP),
+        overflowY: "auto",
+        flexGrow: 1,
+        maxHeight: `calc(${cardHeight * MOBILE_VISIBLE_ROWS}px + ${theme.spacing(
+            GAP * (MOBILE_VISIBLE_ROWS - 1)
+        )})`,
+        [theme.breakpoints.up("tablet")]: {
+            maxHeight: `calc(${cardHeight * visibleRows}px + ${theme.spacing(
+                GAP * (visibleRows - 1)
+            )})`,
+        },
+        [theme.breakpoints.up("desktop")]: {
+            gridTemplateColumns: "repeat(2, 1fr)",
+        },
+    })
+);

--- a/src/components/AccordionSectionSplit/AccordionSectionSplit.styles.ts
+++ b/src/components/AccordionSectionSplit/AccordionSectionSplit.styles.ts
@@ -5,19 +5,19 @@ import AccordionCard from "@/components/AccordionSection/AccordionCard";
 const GAP = 2;
 const MOBILE_VISIBLE_ROWS = 2;
 
-export const SplitWrapper = styled("div", {
-    shouldForwardProp: prop => prop !== "columns",
-})<{ columns: number }>(({ theme, columns }) => ({
-    display: "grid",
-    gridTemplateColumns: "1fr",
-    gap: theme.spacing(GAP),
-    alignItems: "stretch",
-    ...(columns > 1 && {
-        [theme.breakpoints.up("tablet")]: {
-            gridTemplateColumns: "1fr 1fr",
-        },
-    }),
-}));
+export const SplitWrapper = styled("div")<{ columnCount: number }>(
+    ({ theme, columnCount }) => ({
+        display: "grid",
+        gridTemplateColumns: "1fr",
+        gap: theme.spacing(GAP),
+        alignItems: "stretch",
+        ...(columnCount > 1 && {
+            [theme.breakpoints.up("tablet")]: {
+                gridTemplateColumns: "1fr 1fr",
+            },
+        }),
+    })
+);
 
 export const Pane = styled("div")(({ theme }) => ({
     display: "flex",

--- a/src/components/AccordionSectionSplit/AccordionSectionSplit.test.tsx
+++ b/src/components/AccordionSectionSplit/AccordionSectionSplit.test.tsx
@@ -1,0 +1,95 @@
+import { render, screen } from "@/utils/testUtils";
+import AccordionSectionSplit from "./AccordionSectionSplit";
+
+const makeContents = (label: string, count: number) =>
+    Array.from({ length: count }, (_, index) => (
+        <div key={`${label}_${index}`}>{`${label} ${index + 1}`}</div>
+    ));
+
+describe("AccordionSectionSplit", () => {
+    it("renders both pane headings with counts and cards", () => {
+        render(
+            <AccordionSectionSplit
+                heading="Datasets"
+                ownedHeading="Datasets"
+                ownedCount={2}
+                associatedHeading="Associated datasets"
+                associatedCount={1}
+                ownedContents={makeContents("Owned", 2)}
+                associatedContents={makeContents("Associated", 1)}
+                defaultExpanded
+            />
+        );
+
+        expect(screen.getAllByText("Datasets")).toHaveLength(2);
+        expect(screen.getByText("Associated datasets")).toBeInTheDocument();
+        expect(screen.getByText("(2)")).toBeInTheDocument();
+        expect(screen.getByText("(1)")).toBeInTheDocument();
+        expect(screen.getByText("Owned 1")).toBeInTheDocument();
+        expect(screen.getByText("Owned 2")).toBeInTheDocument();
+        expect(screen.getByText("Associated 1")).toBeInTheDocument();
+    });
+
+    it("renders the section title as a single h2 with no heading nested inside", () => {
+        render(
+            <AccordionSectionSplit
+                heading="Datasets"
+                ownedHeading="Datasets"
+                ownedCount={2}
+                associatedHeading="Associated datasets"
+                associatedCount={1}
+                ownedContents={makeContents("Owned", 2)}
+                associatedContents={makeContents("Associated", 1)}
+                defaultExpanded
+            />
+        );
+
+        const sectionHeading = screen.getByRole("heading", {
+            level: 2,
+            name: "Datasets",
+        });
+        expect(sectionHeading).toBeInTheDocument();
+        expect(
+            sectionHeading.querySelector("h1, h2, h3, h4, h5, h6")
+        ).toBeNull();
+    });
+
+    it("hides the associated pane when there are no associated items", () => {
+        render(
+            <AccordionSectionSplit
+                heading="Datasets"
+                ownedHeading="Datasets"
+                ownedCount={2}
+                associatedHeading="Associated datasets"
+                associatedCount={0}
+                ownedContents={makeContents("Owned", 2)}
+                associatedContents={[]}
+                defaultExpanded
+            />
+        );
+
+        expect(screen.getByText("(2)")).toBeInTheDocument();
+        expect(
+            screen.queryByText("Associated datasets")
+        ).not.toBeInTheDocument();
+    });
+
+    it("hides the owned pane when there are no owned items", () => {
+        render(
+            <AccordionSectionSplit
+                heading="Datasets"
+                ownedHeading="Datasets"
+                ownedCount={0}
+                associatedHeading="Associated datasets"
+                associatedCount={1}
+                ownedContents={[]}
+                associatedContents={makeContents("Associated", 1)}
+                defaultExpanded
+            />
+        );
+
+        expect(screen.queryByText("(0)")).not.toBeInTheDocument();
+        expect(screen.getByText("Associated datasets")).toBeInTheDocument();
+        expect(screen.getByText("(1)")).toBeInTheDocument();
+    });
+});

--- a/src/components/AccordionSectionSplit/AccordionSectionSplit.tsx
+++ b/src/components/AccordionSectionSplit/AccordionSectionSplit.tsx
@@ -69,7 +69,7 @@ export default function AccordionSectionSplit({
                 </Typography>
             }
             contents={
-                <SplitWrapper columns={panes.length}>
+                <SplitWrapper columnCount={panes.length}>
                     {panes.map(pane => (
                         <Pane key={pane.heading}>
                             <PaneHeading>

--- a/src/components/AccordionSectionSplit/AccordionSectionSplit.tsx
+++ b/src/components/AccordionSectionSplit/AccordionSectionSplit.tsx
@@ -1,0 +1,100 @@
+"use client";
+
+import { ReactElement } from "react";
+import { Typography } from "@mui/material";
+import Accordion, { AccordionProps } from "@/components/Accordion/Accordion";
+import {
+    Pane,
+    PaneCount,
+    PaneHeading,
+    PaneTitle,
+    ScrollArea,
+    SplitCard,
+    SplitWrapper,
+} from "./AccordionSectionSplit.styles";
+
+export interface AccordionSectionSplitProps
+    extends Omit<AccordionProps, "contents"> {
+    ownedHeading: string;
+    ownedCount: number;
+    associatedHeading: string;
+    associatedCount: number;
+    ownedContents: ReactElement[];
+    associatedContents: ReactElement[];
+    cardHeight?: number;
+    visibleRows?: number;
+    disableCardWrapper?: boolean;
+}
+
+const DEFAULT_CARD_HEIGHT = 140;
+const DEFAULT_VISIBLE_ROWS = 3;
+
+export default function AccordionSectionSplit({
+    heading,
+    ownedHeading,
+    ownedCount,
+    associatedHeading,
+    associatedCount,
+    ownedContents,
+    associatedContents,
+    cardHeight = DEFAULT_CARD_HEIGHT,
+    visibleRows = DEFAULT_VISIBLE_ROWS,
+    disableCardWrapper = false,
+    ...restProps
+}: AccordionSectionSplitProps) {
+    const panes = [
+        { heading: ownedHeading, count: ownedCount, contents: ownedContents },
+        {
+            heading: associatedHeading,
+            count: associatedCount,
+            contents: associatedContents,
+        },
+    ].filter(pane => pane.contents.length > 0);
+
+    return (
+        <Accordion
+            {...restProps}
+            variant="plain"
+            noIndent
+            elevation={0}
+            sx={{ borderBottom: 1, borderColor: "greyCustom.light" }}
+            headingComponent="h2"
+            heading={
+                <Typography
+                    variant="h1"
+                    component="span"
+                    color="primary"
+                    sx={{ fontWeight: 400, mb: 0 }}>
+                    {heading}
+                </Typography>
+            }
+            contents={
+                <SplitWrapper columns={panes.length}>
+                    {panes.map(pane => (
+                        <Pane key={pane.heading}>
+                            <PaneHeading>
+                                <PaneTitle variant="h3">
+                                    {pane.heading}
+                                </PaneTitle>
+                                <PaneCount variant="caption">
+                                    ({pane.count})
+                                </PaneCount>
+                            </PaneHeading>
+                            <ScrollArea
+                                cardHeight={cardHeight}
+                                visibleRows={visibleRows}>
+                                {disableCardWrapper
+                                    ? pane.contents
+                                    : pane.contents.map(content => (
+                                          <SplitCard key={content.key}>
+                                              {content}
+                                          </SplitCard>
+                                      ))}
+                            </ScrollArea>
+                        </Pane>
+                    ))}
+                </SplitWrapper>
+            }
+        />
+    );
+}

--- a/src/components/AccordionSectionSplit/index.ts
+++ b/src/components/AccordionSectionSplit/index.ts
@@ -1,0 +1,1 @@
+export { default } from "./AccordionSectionSplit";

--- a/src/components/CollectionsContent/CollectionsContent.tsx
+++ b/src/components/CollectionsContent/CollectionsContent.tsx
@@ -1,44 +1,89 @@
 "use client";
 
 import { useTranslations } from "next-intl";
-import { Collection } from "@/interfaces/Collection";
 import { NetworkCollection } from "@/interfaces/DataCustodianNetwork";
 import AccordionSection from "@/components/AccordionSection";
+import AccordionSectionSplit from "@/components/AccordionSectionSplit";
 import { useControlledAccordion } from "@/hooks/useControllerAccordion";
 import { RouteName } from "@/consts/routeName";
 import CardStacked from "../CardStacked";
 
 export interface CollectionsContentProps {
     collections: NetworkCollection[];
+    associatedCollections?: NetworkCollection[];
     anchorIndex: number;
     translationPath: string;
 }
 
 const TRANSLATION_PATH = ".components.CollectionsContent";
 
+const COLLECTION_CARD_HEIGHT = 200;
+const COLLECTION_VISIBLE_ROWS = 2;
+
 export default function CollectionsContent({
     collections,
+    associatedCollections,
     anchorIndex,
     translationPath,
 }: CollectionsContentProps) {
     const t = useTranslations(translationPath.concat(TRANSLATION_PATH));
-    const accordionProps = useControlledAccordion(collections.length > 0);
+    const accordionProps = useControlledAccordion(
+        collections.length > 0 || (associatedCollections?.length ?? 0) > 0
+    );
+
+    const renderCard = ({ name, id, image_link }: NetworkCollection) => (
+        <CardStacked
+            href={`/${RouteName.COLLECTION_ITEM}/${id}`}
+            title={name}
+            imgUrl={image_link}
+            key={`collection_${id}`}
+        />
+    );
+
+    const renderFixedHeightCard = (collection: NetworkCollection) => (
+        <CardStacked
+            href={`/${RouteName.COLLECTION_ITEM}/${collection.id}`}
+            title={collection.name}
+            imgUrl={collection.image_link}
+            boxStackedProps={{
+                sx: {
+                    height: "100%",
+                    "& > a": { backgroundSize: "cover" },
+                },
+            }}
+            key={`collection_${collection.id}`}
+        />
+    );
+
+    if (associatedCollections === undefined) {
+        return (
+            <AccordionSection
+                id={`anchor${anchorIndex}`}
+                disabled={!collections.length}
+                heading={t("heading", {
+                    length: collections.length,
+                })}
+                {...accordionProps}
+                contents={collections.map(renderCard)}
+            />
+        );
+    }
+
     return (
-        <AccordionSection
+        <AccordionSectionSplit
             id={`anchor${anchorIndex}`}
-            disabled={!collections.length}
-            heading={t("heading", {
-                length: collections.length,
-            })}
+            disabled={!collections.length && !associatedCollections.length}
+            heading={t("title")}
+            ownedHeading={t("title")}
+            ownedCount={collections.length}
+            associatedHeading={t("associatedHeading")}
+            associatedCount={associatedCollections.length}
+            ownedContents={collections.map(renderFixedHeightCard)}
+            associatedContents={associatedCollections.map(renderFixedHeightCard)}
+            cardHeight={COLLECTION_CARD_HEIGHT}
+            visibleRows={COLLECTION_VISIBLE_ROWS}
+            disableCardWrapper
             {...accordionProps}
-            contents={collections.map(({ name, id, image_link }) => (
-                <CardStacked
-                    href={`/${RouteName.COLLECTION_ITEM}/${id}`}
-                    title={name}
-                    imgUrl={image_link}
-                    key={`collection_${id}`}
-                />
-            ))}
         />
     );
 }

--- a/src/components/DataUsesContent/DataUsesContent.tsx
+++ b/src/components/DataUsesContent/DataUsesContent.tsx
@@ -4,12 +4,14 @@ import { Fragment } from "react";
 import { Link } from "@mui/material";
 import { useTranslations } from "next-intl";
 import { NetworkDur } from "@/interfaces/DataCustodianNetwork";
+import AccordionSectionSplit from "@/components/AccordionSectionSplit";
 import { useControlledAccordion } from "@/hooks/useControllerAccordion";
 import { RouteName } from "@/consts/routeName";
 import AccordionSection from "../AccordionSection";
 
 export interface DataUsesContentProps {
     datauses: NetworkDur[];
+    associatedDatauses?: NetworkDur[];
     anchorIndex: number;
     translationPath: string;
 }
@@ -18,31 +20,61 @@ const TRANSLATION_PATH = ".components.DatausesContent";
 
 export default function DataUsesContent({
     datauses,
+    associatedDatauses,
     anchorIndex,
     translationPath,
 }: DataUsesContentProps) {
     const t = useTranslations(translationPath.concat(TRANSLATION_PATH));
-    const accordionProps = useControlledAccordion(datauses.length > 0);
+    const accordionProps = useControlledAccordion(
+        datauses.length > 0 || (associatedDatauses?.length ?? 0) > 0
+    );
+
+    const renderCard = ({
+        project_title,
+        organisation_name,
+        id,
+        team,
+    }: NetworkDur) => (
+        <Fragment key={`dataUse_${id}`}>
+            <Link href={`/${RouteName.DATA_USE_ITEM}/${id}`}>
+                {project_title}
+            </Link>
+            {team && (
+                <Link href={`/${RouteName.DATA_CUSTODIANS_ITEM}/${team.id}`}>
+                    {team.name}
+                </Link>
+            )}
+            <div>{organisation_name}</div>
+        </Fragment>
+    );
+
+    if (associatedDatauses === undefined) {
+        return (
+            <AccordionSection
+                id={`anchor${anchorIndex}`}
+                disabled={!datauses.length}
+                heading={t("heading", {
+                    length: datauses.length,
+                })}
+                defaultExpanded={datauses.length > 0}
+                {...accordionProps}
+                contents={datauses.map(renderCard)}
+            />
+        );
+    }
 
     return (
-        <AccordionSection
+        <AccordionSectionSplit
             id={`anchor${anchorIndex}`}
-            disabled={!datauses.length}
-            heading={t("heading", {
-                length: datauses.length,
-            })}
-            defaultExpanded={datauses.length > 0}
+            disabled={!datauses.length && !associatedDatauses.length}
+            heading={t("title")}
+            ownedHeading={t("title")}
+            ownedCount={datauses.length}
+            associatedHeading={t("associatedHeading")}
+            associatedCount={associatedDatauses.length}
+            ownedContents={datauses.map(renderCard)}
+            associatedContents={associatedDatauses.map(renderCard)}
             {...accordionProps}
-            contents={datauses.map(
-                ({ project_title, organisation_name, id }) => (
-                    <Fragment key={`dataUse_${id}`}>
-                        <Link href={`/${RouteName.DATA_USE_ITEM}/${id}`}>
-                            {project_title}
-                        </Link>
-                        <div>{organisation_name}</div>
-                    </Fragment>
-                )
-            )}
         />
     );
 }

--- a/src/components/DataUsesContent/DataUsesContent.tsx
+++ b/src/components/DataUsesContent/DataUsesContent.tsx
@@ -1,7 +1,7 @@
 "use client";
 
 import { Fragment } from "react";
-import { Link } from "@mui/material";
+import { Link, Typography } from "@mui/material";
 import { useTranslations } from "next-intl";
 import { NetworkDur } from "@/interfaces/DataCustodianNetwork";
 import AccordionSectionSplit from "@/components/AccordionSectionSplit";
@@ -44,7 +44,7 @@ export default function DataUsesContent({
                     {team.name}
                 </Link>
             )}
-            <div>{organisation_name}</div>
+            <Typography variant="body2">{organisation_name}</Typography>
         </Fragment>
     );
 

--- a/src/components/DatasetsContent/DatasetsContent.test.tsx
+++ b/src/components/DatasetsContent/DatasetsContent.test.tsx
@@ -1,0 +1,70 @@
+import { NetworkDataset } from "@/interfaces/DataCustodianNetwork";
+import { render, screen } from "@/utils/testUtils";
+import DatasetsContent from "./DatasetsContent";
+
+const makeDataset = (id: number, teamId: string): NetworkDataset => ({
+    id,
+    user_id: 1,
+    team_id: teamId,
+    title: `Dataset ${id}`,
+    populationSize: 1000,
+    datasetType: "Registry",
+    team: { id: Number(teamId), name: `Team ${teamId}` },
+});
+
+describe("DatasetsContent", () => {
+    it("renders the classic section when associatedDatasets is undefined", () => {
+        render(
+            <DatasetsContent
+                datasets={[makeDataset(1, "10"), makeDataset(2, "20")]}
+                anchorIndex={2}
+                translationPath="pages.dataCustodian"
+                selectedTeamIds={new Set()}
+            />
+        );
+
+        expect(screen.getByText(/^Datasets \(/)).toBeInTheDocument();
+        expect(
+            screen.queryByText("Associated datasets")
+        ).not.toBeInTheDocument();
+        expect(screen.getByText("Dataset 1")).toBeInTheDocument();
+        expect(screen.getByText("Dataset 2")).toBeInTheDocument();
+    });
+
+    it("renders owned and associated panes with counts when associatedDatasets provided", () => {
+        render(
+            <DatasetsContent
+                datasets={[makeDataset(1, "10"), makeDataset(2, "20")]}
+                associatedDatasets={[makeDataset(3, "30")]}
+                anchorIndex={2}
+                translationPath="pages.dataCustodian"
+                selectedTeamIds={new Set()}
+            />
+        );
+
+        // outer accordion title + owned pane title
+        expect(screen.getAllByText("Datasets")).toHaveLength(2);
+        expect(screen.getByText("(2)")).toBeInTheDocument();
+        expect(screen.getByText("Associated datasets")).toBeInTheDocument();
+        expect(screen.getByText("(1)")).toBeInTheDocument();
+        expect(screen.getByText("Dataset 3")).toBeInTheDocument();
+        expect(screen.getByText("Team 30")).toBeInTheDocument();
+    });
+
+    it("filters owned datasets by selectedTeamIds but not associated ones", () => {
+        render(
+            <DatasetsContent
+                datasets={[makeDataset(1, "10"), makeDataset(2, "20")]}
+                associatedDatasets={[makeDataset(3, "30")]}
+                anchorIndex={2}
+                translationPath="pages.dataCustodian"
+                selectedTeamIds={new Set(["10"])}
+            />
+        );
+
+        expect(screen.getByText("Dataset 1")).toBeInTheDocument();
+        expect(screen.queryByText("Dataset 2")).not.toBeInTheDocument();
+        expect(screen.getByText("Dataset 3")).toBeInTheDocument();
+        expect(screen.getAllByText("(1)")).toHaveLength(2);
+    });
+});

--- a/src/components/DatasetsContent/DatasetsContent.test.tsx
+++ b/src/components/DatasetsContent/DatasetsContent.test.tsx
@@ -1,14 +1,19 @@
 import { NetworkDataset } from "@/interfaces/DataCustodianNetwork";
+import { DataCustodianDataset } from "@/interfaces/Dataset";
 import { render, screen } from "@/utils/testUtils";
 import DatasetsContent from "./DatasetsContent";
 
-const makeDataset = (id: number, teamId: string): NetworkDataset => ({
+const makeDataset = (
+    id: number,
+    teamId: string
+): NetworkDataset & DataCustodianDataset => ({
     id,
     user_id: 1,
     team_id: teamId,
     title: `Dataset ${id}`,
     populationSize: 1000,
     datasetType: "Registry",
+    is_cohort_discovery: false,
     team: { id: Number(teamId), name: `Team ${teamId}` },
 });
 

--- a/src/components/DatasetsContent/DatasetsContent.tsx
+++ b/src/components/DatasetsContent/DatasetsContent.tsx
@@ -4,22 +4,26 @@ import { Fragment } from "react";
 import { Link } from "@mui/material";
 import { isEmpty } from "lodash";
 import { useTranslations } from "next-intl";
+import { NetworkDataset } from "@/interfaces/DataCustodianNetwork";
 import { DataCustodianDataset } from "@/interfaces/Dataset";
 import AccordionSection from "@/components/AccordionSection";
+import AccordionSectionSplit from "@/components/AccordionSectionSplit";
 import { RouteName } from "@/consts/routeName";
 import { formatTextDelimiter } from "@/utils/dataset";
 
 export interface DatasetsContentProps {
     datasets: DataCustodianDataset[];
+    associatedDatasets?: NetworkDataset[];
     anchorIndex: number;
     translationPath: string;
-    selectedTeamIds: Set<string>;
+    selectedTeamIds?: Set<string>;
 }
 
 const TRANSLATION_PATH = ".components.DatasetsContent";
 
 export default function DatasetContent({
     datasets,
+    associatedDatasets,
     anchorIndex,
     translationPath,
     selectedTeamIds,
@@ -29,38 +33,68 @@ export default function DatasetContent({
         isEmpty(selectedTeamIds)
             ? true
             : dataset.team_id
-            ? selectedTeamIds.has(dataset.team_id)
+            ? !!selectedTeamIds?.has(dataset.team_id)
             : false
     );
 
+    const renderCard = (dataset: DataCustodianDataset | NetworkDataset) => {
+        const { id, title, populationSize, datasetType, team } = dataset;
+        const name = "name" in dataset ? dataset.name : undefined;
+
+        return (
+            <Fragment key={`dataset_${id}`}>
+                <Link href={`/${RouteName.DATASET_ITEM}/${id}`}>
+                    {title || name}
+                </Link>
+                {team && (
+                    <Link
+                        href={`/${RouteName.DATA_CUSTODIANS_ITEM}/${team.id}`}>
+                        {team.name}
+                    </Link>
+                )}
+                {populationSize && (
+                    <div>
+                        {t("populationSize", {
+                            length:
+                                populationSize > 0
+                                    ? populationSize.toLocaleString()
+                                    : t("unknownString"),
+                        })}
+                    </div>
+                )}
+                <div>{formatTextDelimiter(datasetType)}</div>
+            </Fragment>
+        );
+    };
+
+    if (associatedDatasets === undefined) {
+        return (
+            <AccordionSection
+                id={`anchor${anchorIndex}`}
+                disabled={!activeDatasets.length}
+                heading={t("heading", {
+                    length: activeDatasets.length,
+                })}
+                defaultExpanded={activeDatasets.length > 0}
+                contents={activeDatasets.map(renderCard)}
+            />
+        );
+    }
+
     return (
-        <AccordionSection
+        <AccordionSectionSplit
             id={`anchor${anchorIndex}`}
-            disabled={!activeDatasets.length}
-            heading={t("heading", {
-                length: activeDatasets.length,
-            })}
-            defaultExpanded={activeDatasets.length > 0}
-            contents={activeDatasets.map(
-                ({ id, title, name, populationSize, datasetType }) => (
-                    <Fragment key={`dataset_${id}`}>
-                        <Link href={`/${RouteName.DATASET_ITEM}/${id}`}>
-                            {title || name}
-                        </Link>
-                        {populationSize && (
-                            <div>
-                                {t("populationSize", {
-                                    length:
-                                        populationSize > 0
-                                            ? populationSize.toLocaleString()
-                                            : t("unknownString"),
-                                })}
-                            </div>
-                        )}
-                        <div>{formatTextDelimiter(datasetType)}</div>
-                    </Fragment>
-                )
-            )}
+            disabled={!activeDatasets.length && !associatedDatasets.length}
+            heading={t("title")}
+            ownedHeading={t("title")}
+            ownedCount={activeDatasets.length}
+            associatedHeading={t("associatedHeading")}
+            associatedCount={associatedDatasets.length}
+            defaultExpanded={
+                activeDatasets.length > 0 || associatedDatasets.length > 0
+            }
+            ownedContents={activeDatasets.map(renderCard)}
+            associatedContents={associatedDatasets.map(renderCard)}
         />
     );
 }

--- a/src/components/MarkDownSanitizedWithHTML/index.tsx
+++ b/src/components/MarkDownSanitizedWithHTML/index.tsx
@@ -97,7 +97,9 @@ export const MarkDownSanitizedWithHtml = ({
 
     return (
         <Wrapper style={styles}>
-            <Markdown options={{ overrides }}>{parsedContent}</Markdown>
+            {isLoaded ? (
+                <Markdown options={{ overrides }}>{parsedContent}</Markdown>
+            ) : null}
         </Wrapper>
     );
 };

--- a/src/components/PublicationsContent/PublicationsContent.tsx
+++ b/src/components/PublicationsContent/PublicationsContent.tsx
@@ -1,14 +1,17 @@
 "use client";
 
-import { Fragment, useState } from "react";
+import { Fragment } from "react";
 import { Link } from "@mui/material";
 import { useTranslations } from "next-intl";
 import { NetworkPublication } from "@/interfaces/DataCustodianNetwork";
 import AccordionSection from "@/components/AccordionSection";
+import AccordionSectionSplit from "@/components/AccordionSectionSplit";
 import { useControlledAccordion } from "@/hooks/useControllerAccordion";
+import { RouteName } from "@/consts/routeName";
 
 export interface PublicationsContentProps {
     publications: NetworkPublication[];
+    associatedPublications?: NetworkPublication[];
     anchorIndex: number;
     translationPath: string;
 }
@@ -17,32 +20,63 @@ const TRANSLATION_PATH = ".components.PublicationsContent";
 
 export default function PublicationContent({
     publications,
+    associatedPublications,
     anchorIndex,
     translationPath,
 }: PublicationsContentProps) {
     const t = useTranslations(translationPath.concat(TRANSLATION_PATH));
-    const accordionProps = useControlledAccordion(publications.length > 0);
-    return (
-        <AccordionSection
-            id={`anchor${anchorIndex}`}
-            disabled={!publications.length}
-            heading={t("heading", {
-                length: publications.length,
-            })}
-            {...accordionProps}
-            contents={publications.map(
-                ({ id, paper_title, authors, url, year_of_publication }) => (
-                    <Fragment key={`publication_${id}`}>
-                        <Link component="a" href={url} target="_blank">
-                            {paper_title}
-                        </Link>
-                        {authors && <div>{authors}</div>}
-                        {year_of_publication && (
-                            <div>{year_of_publication}</div>
-                        )}
-                    </Fragment>
-                )
+    const accordionProps = useControlledAccordion(
+        publications.length > 0 || (associatedPublications?.length ?? 0) > 0
+    );
+
+    const renderCard = ({
+        id,
+        paper_title,
+        authors,
+        url,
+        year_of_publication,
+        team,
+    }: NetworkPublication) => (
+        <Fragment key={`publication_${id}`}>
+            <Link component="a" href={url} target="_blank">
+                {paper_title}
+            </Link>
+            {team && (
+                <Link href={`/${RouteName.DATA_CUSTODIANS_ITEM}/${team.id}`}>
+                    {team.name}
+                </Link>
             )}
+            {authors && <div>{authors}</div>}
+            {year_of_publication && <div>{year_of_publication}</div>}
+        </Fragment>
+    );
+
+    if (associatedPublications === undefined) {
+        return (
+            <AccordionSection
+                id={`anchor${anchorIndex}`}
+                disabled={!publications.length}
+                heading={t("heading", {
+                    length: publications.length,
+                })}
+                {...accordionProps}
+                contents={publications.map(renderCard)}
+            />
+        );
+    }
+
+    return (
+        <AccordionSectionSplit
+            id={`anchor${anchorIndex}`}
+            disabled={!publications.length && !associatedPublications.length}
+            heading={t("title")}
+            ownedHeading={t("title")}
+            ownedCount={publications.length}
+            associatedHeading={t("associatedHeading")}
+            associatedCount={associatedPublications.length}
+            ownedContents={publications.map(renderCard)}
+            associatedContents={associatedPublications.map(renderCard)}
+            {...accordionProps}
         />
     );
 }

--- a/src/components/ToolsContent/ToolsContent.tsx
+++ b/src/components/ToolsContent/ToolsContent.tsx
@@ -5,12 +5,14 @@ import { Link, Typography } from "@mui/material";
 import { useTranslations } from "next-intl";
 import { NetworkTool } from "@/interfaces/DataCustodianNetwork";
 import AccordionSection from "@/components/AccordionSection";
+import AccordionSectionSplit from "@/components/AccordionSectionSplit";
 import { useControlledAccordion } from "@/hooks/useControllerAccordion";
 import { RouteName } from "@/consts/routeName";
 import { formatDate } from "@/utils/date";
 
 export interface ToolsContentProps {
     tools: NetworkTool[];
+    associatedTools?: NetworkTool[];
     anchorIndex: number;
     translationPath: string;
 }
@@ -19,34 +21,59 @@ const TRANSLATION_PATH = ".components.ToolsContent";
 
 export default function ToolsContent({
     tools,
+    associatedTools,
     anchorIndex,
     translationPath,
 }: ToolsContentProps) {
     const t = useTranslations(translationPath.concat(TRANSLATION_PATH));
-    const accordionProps = useControlledAccordion(tools.length > 0);
+    const accordionProps = useControlledAccordion(
+        tools.length > 0 || (associatedTools?.length ?? 0) > 0
+    );
+
+    const renderCard = ({ name, id, created_at, user, team }: NetworkTool) => (
+        <Fragment key={`tool_${id}`}>
+            <Link href={`/${RouteName.TOOL_ITEM}/${id}`}>{name}</Link>
+            {team && (
+                <Link href={`/${RouteName.DATA_CUSTODIANS_ITEM}/${team.id}`}>
+                    {team.name}
+                </Link>
+            )}
+            {!!user && <div>{`${user.firstname} ${user.lastname}`}</div>}
+            {!!created_at && (
+                <Typography color="GrayText">
+                    Created - {formatDate(created_at, "DD MMMM YYYY")}
+                </Typography>
+            )}
+        </Fragment>
+    );
+
+    if (associatedTools === undefined) {
+        return (
+            <AccordionSection
+                id={`anchor${anchorIndex}`}
+                disabled={!tools.length}
+                heading={t("heading", {
+                    length: tools.length,
+                })}
+                defaultExpanded={tools.length > 0}
+                {...accordionProps}
+                contents={tools.map(renderCard)}
+            />
+        );
+    }
 
     return (
-        <AccordionSection
+        <AccordionSectionSplit
             id={`anchor${anchorIndex}`}
-            disabled={!tools.length}
-            heading={t("heading", {
-                length: tools.length,
-            })}
-            defaultExpanded={tools.length > 0}
+            disabled={!tools.length && !associatedTools.length}
+            heading={t("title")}
+            ownedHeading={t("title")}
+            ownedCount={tools.length}
+            associatedHeading={t("associatedHeading")}
+            associatedCount={associatedTools.length}
+            ownedContents={tools.map(renderCard)}
+            associatedContents={associatedTools.map(renderCard)}
             {...accordionProps}
-            contents={tools.map(({ name, id, created_at, user }) => (
-                <Fragment key={`tool_${id}`}>
-                    <Link href={`/${RouteName.TOOL_ITEM}/${id}`}>{name}</Link>
-                    {!!user && (
-                        <div>{`${user.firstname} ${user.lastname}`}</div>
-                    )}
-                    {!!created_at && (
-                        <Typography color="GrayText">
-                            Created - {formatDate(created_at, "DD MMMM YYYY")}
-                        </Typography>
-                    )}
-                </Fragment>
-            ))}
         />
     );
 }

--- a/src/config/messages/en.json
+++ b/src/config/messages/en.json
@@ -1447,21 +1447,31 @@
                     "cohortDiscoveryDisabled": "This data custodian does not support Cohort Discovery"
                 },
                 "CollectionsContent": {
-                    "heading": "Collections ({ length })"
+                    "title": "Collections",
+                    "heading": "Collections ({ length })",
+                    "associatedHeading": "Associated collections"
                 },
                 "DatasetsContent": {
+                    "title": "Datasets",
                     "heading": "Datasets ({ length })",
+                    "associatedHeading": "Associated datasets",
                     "populationSize": "Dataset population size: { length }",
                     "unknownString": "Unknown"
                 },
                 "DatausesContent": {
-                    "heading": "Data Uses ({ length })"
+                    "title": "Data uses",
+                    "heading": "Data Uses ({ length })",
+                    "associatedHeading": "Associated data uses"
                 },
                 "PublicationsContent": {
-                    "heading": "Publications ({ length })"
+                    "title": "Publications",
+                    "heading": "Publications ({ length })",
+                    "associatedHeading": "Associated publications"
                 },
                 "ToolsContent": {
-                    "heading": "Analysis Scripts & Software ({ length })"
+                    "title": "Analysis scripts, tools and software",
+                    "heading": "Analysis Scripts & Software ({ length })",
+                    "associatedHeading": "Associated analysis scripts, tools and software"
                 },
                 "ServiceOfferingsContent": {
                     "heading": "Service offerings ({ length })"

--- a/src/consts/cache.ts
+++ b/src/consts/cache.ts
@@ -1,3 +1,5 @@
+export const DEFAULT_CACHE_REVALIDATE = 2 * 60 * 60; // 2 hours
+
 export const CACHE_DAR = "dar";
 export const CACHE_DAR_APPLICATION = "darApplication";
 export const CACHE_DAR_SECTIONS = "darSections";

--- a/src/interfaces/DataCustodianNetwork.ts
+++ b/src/interfaces/DataCustodianNetwork.ts
@@ -21,12 +21,19 @@ export interface DatasetsSummaryData {
     datasets: DataCustodianDataset[];
 }
 
+export interface EntityTeam {
+    id: number;
+    name: string;
+}
+
 export interface NetworkDur {
     id: number;
     project_title: string;
     organisation_name: string;
     status: string;
     team_id: string;
+    relation?: string;
+    team?: EntityTeam;
 }
 
 export interface NetworkTool {
@@ -38,6 +45,8 @@ export interface NetworkTool {
     updated_at: string;
     team_id: string;
     user?: User;
+    relation?: string;
+    team?: EntityTeam;
 }
 
 export interface NetworkPublication {
@@ -52,6 +61,8 @@ export interface NetworkPublication {
     url: string;
     team_id: string;
     year_of_publication?: string;
+    relation?: string;
+    team?: EntityTeam;
 }
 
 export interface NetworkCollection {
@@ -62,6 +73,8 @@ export interface NetworkCollection {
     created_at: string;
     updated_at: string;
     team_id: string;
+    relation?: string;
+    team?: EntityTeam;
 }
 
 export interface NetworkDataset {
@@ -71,20 +84,32 @@ export interface NetworkDataset {
     title: string;
     populationSize: number;
     datasetType: string;
+    relation?: string;
+    team?: EntityTeam;
 }
 
 export interface EntitiesSummaryData {
     id: number;
-    datasets_total: number;
-    datasets: NetworkDataset[];
+    datasets_total?: number;
+    datasets?: NetworkDataset[];
+    associated_datasets_total: number;
+    associated_datasets: NetworkDataset[];
     durs_total: number;
     durs: NetworkDur[];
+    associated_durs_total: number;
+    associated_durs: NetworkDur[];
     tools_total: number;
     tools: NetworkTool[];
+    associated_tools_total: number;
+    associated_tools: NetworkTool[];
     publications_total: number;
     publications: NetworkPublication[];
+    associated_publications_total: number;
+    associated_publications: NetworkPublication[];
     collections_total: number;
     collections: NetworkCollection[];
+    associated_collections_total: number;
+    associated_collections: NetworkCollection[];
 }
 
 export interface NetworkCustodiansSummaryData {

--- a/src/interfaces/Dataset.ts
+++ b/src/interfaces/Dataset.ts
@@ -220,6 +220,8 @@ interface DataCustodianDataset {
     title?: string;
     name?: string;
     datasetType: string;
+    team_id?: string;
+    team?: { id: number; name: string };
 }
 
 interface NewDataset extends Omit<Dataset, "versions" | "id"> {

--- a/src/interfaces/TeamSummary.ts
+++ b/src/interfaces/TeamSummary.ts
@@ -1,9 +1,12 @@
 import { Alias } from "@/interfaces/Alias";
-import { Collection } from "@/interfaces/Collection";
-import { DataUse } from "@/interfaces/DataUse";
+import {
+    NetworkCollection,
+    NetworkDataset,
+    NetworkDur,
+    NetworkPublication,
+    NetworkTool,
+} from "@/interfaces/DataCustodianNetwork";
 import { DataCustodianDataset } from "@/interfaces/Dataset";
-import { Publication } from "@/interfaces/Publication";
-import { Tool } from "@/interfaces/Tool";
 
 interface TeamSummary {
     id: number;
@@ -13,10 +16,15 @@ interface TeamSummary {
     is_provider: boolean;
     introduction: string | null;
     datasets: DataCustodianDataset[];
-    durs: DataUse[];
-    tools: Tool[];
-    publications: Publication[];
-    collections: Collection[];
+    durs: NetworkDur[];
+    tools: NetworkTool[];
+    publications: NetworkPublication[];
+    collections: NetworkCollection[];
+    associated_datasets: NetworkDataset[];
+    associated_durs: NetworkDur[];
+    associated_tools: NetworkTool[];
+    associated_publications: NetworkPublication[];
+    associated_collections: NetworkCollection[];
     url: string | null;
     service: string[] | null;
     aliases?: Alias[];

--- a/src/modules/ActiveListSidebar/ActiveListSidebar.styles.ts
+++ b/src/modules/ActiveListSidebar/ActiveListSidebar.styles.ts
@@ -5,7 +5,9 @@ import theme from "@/config/theme";
 
 
 
-export const Wrapper = styled(Box)<{ disableSticky?: boolean }>(({ disableSticky }) => ({
+export const Wrapper = styled(Box, {
+    shouldForwardProp: prop => prop !== "disableSticky",
+})<{ disableSticky?: boolean }>(({ disableSticky }) => ({
     ...(disableSticky ? {} : {
         position: "sticky",
         top: 0,

--- a/src/utils/api.ts
+++ b/src/utils/api.ts
@@ -53,6 +53,7 @@ import {
     CACHE_DAR_APPLICATION,
     CACHE_DAR_ANSWERS,
     CACHE_DAR_REVIEWS,
+    DEFAULT_CACHE_REVALIDATE,
 } from "@/consts/cache";
 import { getUserFromToken } from "@/utils/cookies";
 import { getSessionCookie } from "./getSessionCookie";
@@ -81,7 +82,7 @@ async function get<T>(
         ? {
               next: {
                   tags: [...cache.tags, "all"],
-                  revalidate: cache.revalidate || 2 * 60 * 60,
+                  revalidate: cache.revalidate || DEFAULT_CACHE_REVALIDATE,
               },
           }
         : undefined;


### PR DESCRIPTION
> AI Disclosure: Some of the code was written with the assistance of Claude (Anthropic). All changes were reviewed and approved by the author.

## Screenshots / videos (if relevant)
<img width="1432" height="699" alt="image" src="https://github.com/user-attachments/assets/e36d8773-17a8-44b9-a1cc-e6b31326080c" />
<img width="1430" height="816" alt="image" src="https://github.com/user-attachments/assets/4fb4df65-06c6-4648-a23a-9b61e5c86cd2" />


## Describe your changes
The data custodian page now distinguishes between resources a custodian owns and resources they are associated with. A new `AccordionSectionSplit` component renders each resource section (datasets, tools, data uses, publications, collections) as a two-pane accordion with per-pane counts and scrollable card lists, and the content components link associated resources back to their owning custodian. Data fetching for the page was consolidated so a single `getTeamSummary` promise is shared across the content, datasets and entities sections instead of each fetching separately. The base `Accordion` component also gained accessibility improvements — configurable heading levels and proper `aria-controls`/`aria-labelledby` wiring between summary and region — along with supporting interface fields and translations.

## Issue ticket link
https://hdruk.atlassian.net/browse/GAT-7564

## Checklist before requesting a review

- [x] I have performed a self-review of my code
- [x] I have added appropriate unit tests / e2e tests (where relevant)
- [ ] I have created mocks for api endpoints (where appropriate)
- [x] The interface is responsive (where ticket is relevant)
- [x] The interface is at least AA (where ticket is relevant)
- [ ] Commits are described as "(chore|fix|feature|test|maintenance): description"
