### PR TITLE
feat(GAT-8798): Add 'Run Now' button to integrations

### DIFF
--- a/mocks/data/integration/v1/integration.data.ts
+++ b/mocks/data/integration/v1/integration.data.ts
@@ -1,5 +1,5 @@
 import { faker } from "@faker-js/faker";
-import { FederationRunResponse } from "@/interfaces/Federation";
+import { FederationTestResponse } from "@/interfaces/Federation";
 import {
     Integration,
     FederationType,
@@ -34,7 +34,9 @@ const generateIntegrationV1 = (data = {}): Integration => {
     };
 };
 
-const generateFederationResponseV1 = (data = {}): FederationRunResponse => {
+const generateFederationTestResponseV1 = (
+    data = {}
+): FederationTestResponse => {
     const success = faker.datatype.boolean();
     return {
         success,
@@ -49,7 +51,7 @@ const generateIntegrationsV1 = (n = 3): Integration[] => {
 };
 
 const integrationV1 = generateIntegrationV1();
-const federationsResponseV1 = generateFederationResponseV1();
+const federationTestResponseV1 = generateFederationTestResponseV1();
 const integrationsV1 = generateIntegrationsV1();
 
 export {
@@ -57,5 +59,5 @@ export {
     generateIntegrationV1,
     integrationsV1,
     integrationV1,
-    federationsResponseV1,
+    federationTestResponseV1,
 };

--- a/mocks/handlers/integration/v1/integration.handler.ts
+++ b/mocks/handlers/integration/v1/integration.handler.ts
@@ -1,10 +1,10 @@
 import { rest } from "msw";
-import { FederationRunResponse } from "@/interfaces/Federation";
+import { FederationTestResponse } from "@/interfaces/Federation";
 import { Integration } from "@/interfaces/Integration";
 import { PaginationType } from "@/interfaces/Pagination";
 import apis from "@/config/apis";
 import {
-    federationsResponseV1,
+    federationTestResponseV1,
     integrationV1,
     integrationsV1,
 } from "@/mocks/data/integration";
@@ -101,11 +101,11 @@ const postIntegrationV1 = ({
 };
 
 interface PostFedResponse {
-    data: FederationRunResponse;
+    data: FederationTestResponse;
 }
 
 const postFederationsTestV1 = ({
-    data = federationsResponseV1,
+    data = federationTestResponseV1,
     teamId = teamV1.id,
     status = 200,
 }) => {

--- a/mocks/handlers/integration/v1/integration.handler.ts
+++ b/mocks/handlers/integration/v1/integration.handler.ts
@@ -124,9 +124,36 @@ const postFederationsTestV1 = ({
     );
 };
 
+interface getFederationRunProps {
+    teamId?: number;
+    federationId?: number;
+    status?: number;
+}
+
+const getFederationRunV1 = ({
+    teamId = teamV1.id,
+    federationId = integrationV1.id,
+    status = 200,
+}: getFederationRunProps = {}) => {
+    return rest.get(
+        `${apis.teamsV1Url}/${teamId}/federations/${federationId}/run`,
+        (req, res, ctx) => {
+            if (status !== 200) {
+                return res(
+                    ctx.status(status),
+                    ctx.json(`Request failed with status code ${status}`)
+                );
+            }
+
+            return res(ctx.status(status), ctx.json({ message: "OK" }));
+        }
+    );
+};
+
 export {
     getIntegrationV1,
     getIntegrationsV1,
     postIntegrationV1,
     postFederationsTestV1,
+    getFederationRunV1,
 };

--- a/src/app/[locale]/account/team/[teamId]/(withLeftNav)/integrations/integration/list/[intId]/components/EditIntegrationForm/EditIntegrationForm.test.tsx
+++ b/src/app/[locale]/account/team/[teamId]/(withLeftNav)/integrations/integration/list/[intId]/components/EditIntegrationForm/EditIntegrationForm.test.tsx
@@ -1,7 +1,33 @@
 import mockRouter from "next-router-mock";
-import { screen, render, act } from "@/utils/testUtils";
+import { FederationTestStatus } from "@/interfaces/Federation";
+import { screen, render, act, waitFor, fireEvent } from "@/utils/testUtils";
+import { integrationV1 } from "@/mocks/data/integration";
 import { teamV1 } from "@/mocks/data/team";
+import {
+    getFederationRunV1,
+    getIntegrationV1,
+} from "@/mocks/handlers/integration";
+import { server } from "@/mocks/server";
 import EditIntegrationForm from "./EditIntegrationForm";
+
+jest.mock("@/hooks/useTestFederation", () => ({
+    __esModule: true,
+    default: jest.fn(() => ({
+        testStatus: FederationTestStatus.TESTED_IS_TRUE,
+        testResponse: undefined,
+        setTestedConfig: jest.fn(),
+        handleTest: jest.fn(),
+    })),
+    watchFederationKeys: [
+        "auth_type",
+        "auth_secret_key",
+        "endpoint_baseurl",
+        "endpoint_datasets",
+        "endpoint_dataset",
+        "run_time_hour",
+        "notifications",
+    ],
+}));
 
 describe("EditIntegrationForm", () => {
     mockRouter.query = { teamId: teamV1.id.toString(), intId: "2" };
@@ -10,4 +36,51 @@ describe("EditIntegrationForm", () => {
         const allSelects = screen.getAllByRole("combobox");
         expect(allSelects[0]).toHaveClass("Mui-disabled");
     });
+
+    it("should run the 'Run now' button through Run now -> Running -> Complete -> Run now", async () => {
+        const mockIntegration = {
+            ...integrationV1,
+            id: 2,
+            federation_type: "DATASETS" as const,
+            enabled: true,
+            tested: true,
+            run_time_hour: 12,
+            run_time_minute: "30",
+        };
+        server.use(
+            getIntegrationV1({ data: mockIntegration }),
+            getFederationRunV1({ federationId: 2 })
+        );
+
+        await act(() => render(<EditIntegrationForm />));
+
+        const runNowButton = await waitFor(() => {
+            const button = screen.getByRole("button", { name: "Run now" });
+            expect(button).not.toBeDisabled();
+            return button;
+        });
+
+        fireEvent.click(runNowButton);
+
+        await waitFor(() => {
+            expect(
+                screen.getByRole("button", { name: /Running/ })
+            ).toBeDisabled();
+        });
+
+        await waitFor(() => {
+            expect(
+                screen.getByRole("button", { name: "Complete" })
+            ).toBeInTheDocument();
+        });
+
+        await waitFor(
+            () => {
+                expect(
+                    screen.getByRole("button", { name: "Run now" })
+                ).toBeInTheDocument();
+            },
+            { timeout: 4000 }
+        );
+    }, 10000);
 });

--- a/src/app/[locale]/account/team/[teamId]/(withLeftNav)/integrations/integration/list/[intId]/components/EditIntegrationForm/EditIntegrationForm.tsx
+++ b/src/app/[locale]/account/team/[teamId]/(withLeftNav)/integrations/integration/list/[intId]/components/EditIntegrationForm/EditIntegrationForm.tsx
@@ -1,12 +1,13 @@
 "use client";
 
-import { useEffect, useMemo } from "react";
+import { useEffect, useMemo, useRef, useState } from "react";
 import { useForm } from "react-hook-form";
 import { yupResolver } from "@hookform/resolvers/yup";
 import { Stack, Typography } from "@mui/material";
 import { pick } from "lodash";
+import { useTranslations } from "next-intl";
 import { useParams, useRouter } from "next/navigation";
-import { Federation } from "@/interfaces/Federation";
+import { Federation, FederationRunStatus } from "@/interfaces/Federation";
 import {
     Integration,
     IntegrationForm,
@@ -19,6 +20,7 @@ import InputWrapper from "@/components/InputWrapper";
 import Paper from "@/components/Paper";
 import RunFederationTest from "@/components/RunFederationTest";
 import SwitchInline from "@/components/SwitchInline";
+import { AutorenewIcon, CheckIcon } from "@/consts/icons";
 import useGet from "@/hooks/useGet";
 import useGetTeam from "@/hooks/useGetTeam";
 import usePost from "@/hooks/usePost";
@@ -35,10 +37,12 @@ import {
     integrationValidationSchema,
 } from "@/config/forms/integration";
 import { RouteName } from "@/consts/routeName";
+import apiService from "@/services/api";
 import { requiresSecretKey } from "@/utils/integrations";
 
 const EditIntegrationForm = () => {
     const { push } = useRouter();
+    const t = useTranslations("api");
     const params = useParams<{
         teamId: string;
         intId: string;
@@ -160,7 +164,51 @@ const EditIntegrationForm = () => {
     };
 
     const tested = watch("tested");
+    const enabled = watch("enabled");
     const auth_type = watch("auth_type");
+
+    const [runNowStatus, setRunNowStatus] = useState<FederationRunStatus>(
+        FederationRunStatus.IDLE
+    );
+    const revertTimeoutRef = useRef<ReturnType<typeof setTimeout>>();
+
+    useEffect(() => {
+        return () => clearTimeout(revertTimeoutRef.current);
+    }, []);
+
+    const MIN_RUNNING_DISPLAY_MS = 600;
+
+    const handleRunNow = async () => {
+        setRunNowStatus(FederationRunStatus.RUNNING);
+
+        const minDisplay = new Promise(resolve =>
+            setTimeout(resolve, MIN_RUNNING_DISPLAY_MS)
+        );
+        const [response] = await Promise.all([
+            apiService.getRequest(
+                `${apis.teamsV1Url}/${params?.teamId}/federations/${params?.intId}/run`,
+                {
+                    notificationOptions: {
+                        itemName: "Integration",
+                        t,
+                    },
+                }
+            ),
+            minDisplay,
+        ]);
+
+        setRunNowStatus(
+            response !== null
+                ? FederationRunStatus.COMPLETE
+                : FederationRunStatus.IDLE
+        );
+        if (response !== null) {
+            revertTimeoutRef.current = setTimeout(
+                () => setRunNowStatus(FederationRunStatus.IDLE),
+                3000
+            );
+        }
+    };
 
     /* unregister 'auth_secret_key' if 'auth_type' is set to "NO_AUTH" */
     useEffect(() => {
@@ -268,7 +316,33 @@ const EditIntegrationForm = () => {
                     padding={0}
                     display="flex"
                     justifyContent="end"
+                    gap={2}
                     marginBottom={10}>
+                    <Button
+                        type="button"
+                        variant="outlined"
+                        color="success"
+                        disabled={
+                            !isEditing ||
+                            formState.isDirty ||
+                            !tested ||
+                            !enabled ||
+                            runNowStatus === FederationRunStatus.RUNNING
+                        }
+                        startIcon={
+                            runNowStatus === FederationRunStatus.RUNNING ? (
+                                <AutorenewIcon />
+                            ) : runNowStatus === FederationRunStatus.COMPLETE ? (
+                                <CheckIcon />
+                            ) : undefined
+                        }
+                        onClick={handleRunNow}>
+                        {runNowStatus === FederationRunStatus.RUNNING
+                            ? "Running"
+                            : runNowStatus === FederationRunStatus.COMPLETE
+                            ? "Complete"
+                            : "Run now"}
+                    </Button>
                     <Button type="submit">Save configuration</Button>
                 </Box>
             </Paper>

--- a/src/app/[locale]/account/team/[teamId]/(withLeftNav)/integrations/integration/list/[intId]/components/EditIntegrationForm/EditIntegrationForm.tsx
+++ b/src/app/[locale]/account/team/[teamId]/(withLeftNav)/integrations/integration/list/[intId]/components/EditIntegrationForm/EditIntegrationForm.tsx
@@ -23,9 +23,9 @@ import useGet from "@/hooks/useGet";
 import useGetTeam from "@/hooks/useGetTeam";
 import usePost from "@/hooks/usePost";
 import usePut from "@/hooks/usePut";
-import useRunFederation, {
+import useTestFederation, {
     watchFederationKeys,
-} from "@/hooks/useRunFederation";
+} from "@/hooks/useTestFederation";
 import { useUnsavedChanges } from "@/hooks/useUnsavedChanges";
 import apis from "@/config/apis";
 import {
@@ -72,8 +72,8 @@ const EditIntegrationForm = () => {
         defaultValues: integrationDefaultValues,
     });
 
-    const { runStatus, setTestedConfig, runResponse, handleRun } =
-        useRunFederation({
+    const { testStatus, setTestedConfig, testResponse, handleTest } =
+        useTestFederation({
             teamId: params?.teamId || "",
             integration: integration || {
                 ...integrationDefaultValues,
@@ -255,10 +255,10 @@ const EditIntegrationForm = () => {
                     </Paper>
                     <Box sx={{ p: 0, flex: 1 }}>
                         <RunFederationTest
-                            status={runStatus}
-                            runResponse={runResponse}
+                            status={testStatus}
+                            runResponse={testResponse}
                             isEnabled={formState.isValid}
-                            onRun={handleRun}
+                            onTest={handleTest}
                         />
                     </Box>
                 </Box>

--- a/src/components/RunFederationTest/RunFederationTest.test.tsx
+++ b/src/components/RunFederationTest/RunFederationTest.test.tsx
@@ -1,14 +1,15 @@
+import { FederationTestStatus } from "@/interfaces/Federation";
 import { render, screen, waitFor } from "@/utils/testUtils";
 import RunFederationTest from "./RunFederationTest";
 
 describe("RunFederationTest", () => {
-    const onRun = jest.fn();
+    const onTest = jest.fn();
 
     it("should render `Integration tested successfully` message if component is not enabled", async () => {
         render(
             <RunFederationTest
-                onRun={onRun}
-                status="TESTED_IS_TRUE"
+                onTest={onTest}
+                status={FederationTestStatus.TESTED_IS_TRUE}
                 isEnabled
                 runResponse={undefined}
             />
@@ -26,8 +27,8 @@ describe("RunFederationTest", () => {
     it("should render 'incomplete required fields' message and disable run button", async () => {
         render(
             <RunFederationTest
-                onRun={onRun}
-                status="NOT_RUN"
+                onTest={onTest}
+                status={FederationTestStatus.NOT_RUN}
                 isEnabled={false}
                 runResponse={undefined}
             />
@@ -45,8 +46,8 @@ describe("RunFederationTest", () => {
     it("should render 'test must be carried out' message if not not run", async () => {
         render(
             <RunFederationTest
-                onRun={onRun}
-                status="NOT_RUN"
+                onTest={onTest}
+                status={FederationTestStatus.NOT_RUN}
                 isEnabled
                 runResponse={undefined}
             />
@@ -64,8 +65,8 @@ describe("RunFederationTest", () => {
     it("should render loading message when isRunning is true", async () => {
         render(
             <RunFederationTest
-                onRun={onRun}
-                status="IS_RUNNING"
+                onTest={onTest}
+                status={FederationTestStatus.IS_RUNNING}
                 isEnabled
                 runResponse={undefined}
             />
@@ -86,8 +87,8 @@ describe("RunFederationTest", () => {
 
         render(
             <RunFederationTest
-                onRun={onRun}
-                status="RUN_COMPLETE"
+                onTest={onTest}
+                status={FederationTestStatus.RUN_COMPLETE}
                 isEnabled
                 runResponse={runResponse}
             />
@@ -113,8 +114,8 @@ describe("RunFederationTest", () => {
         };
         render(
             <RunFederationTest
-                onRun={onRun}
-                status="RUN_COMPLETE"
+                onTest={onTest}
+                status={FederationTestStatus.RUN_COMPLETE}
                 isEnabled
                 runResponse={runResponse}
             />

--- a/src/components/RunFederationTest/RunFederationTest.tsx
+++ b/src/components/RunFederationTest/RunFederationTest.tsx
@@ -1,6 +1,9 @@
 /** @jsxImportSource @emotion/react */
 import { ReactNode } from "react";
-import { FederationRunResponse } from "@/interfaces/Federation";
+import {
+    FederationTestResponse,
+    FederationTestStatus,
+} from "@/interfaces/Federation";
 import Box from "@/components/Box";
 import Button from "@/components/Button";
 import TickCrossIcon from "@/components/TickCrossIcon";
@@ -11,10 +14,10 @@ import Link from "../Link";
 import * as styles from "./RunFederationTest.styles";
 
 interface RunFederationTestProps {
-    onRun: () => void;
-    status: "NOT_RUN" | "IS_RUNNING" | "RUN_COMPLETE" | "TESTED_IS_TRUE";
+    onTest: () => void;
+    status: FederationTestStatus;
     isEnabled?: boolean;
-    runResponse?: FederationRunResponse;
+    runResponse?: FederationTestResponse;
 }
 
 const Container = ({ children }: { children: ReactNode }) => {
@@ -32,12 +35,12 @@ const Container = ({ children }: { children: ReactNode }) => {
 };
 
 const RunFederationTest = ({
-    status = "NOT_RUN",
+    status = FederationTestStatus.NOT_RUN,
     runResponse,
-    onRun,
+    onTest,
     isEnabled = false,
 }: RunFederationTestProps) => {
-    if (status === "IS_RUNNING") {
+    if (status === FederationTestStatus.IS_RUNNING) {
         return (
             <Container>
                 <Typography css={styles.loading}>
@@ -47,7 +50,7 @@ const RunFederationTest = ({
         );
     }
 
-    if (status === "RUN_COMPLETE" && runResponse) {
+    if (status === FederationTestStatus.RUN_COMPLETE && runResponse) {
         return (
             <Container>
                 <Box
@@ -113,7 +116,7 @@ const RunFederationTest = ({
     }
 
     const message =
-        status === "TESTED_IS_TRUE"
+        status === FederationTestStatus.TESTED_IS_TRUE
             ? "Integration tested successfully"
             : isEnabled
             ? "A test must be carried out before you can enable this configuration"
@@ -142,7 +145,7 @@ const RunFederationTest = ({
                         color: "inherit",
                     })}
                     disabled={!isEnabled}
-                    onClick={() => onRun()}>
+                    onClick={() => onTest()}>
                     Run test
                 </Button>
             </Box>

--- a/src/consts/icons.tsx
+++ b/src/consts/icons.tsx
@@ -15,6 +15,7 @@ import ArrowLeftIcon from "@mui/icons-material/ArrowLeft";
 import ArrowRightIcon from "@mui/icons-material/ArrowRight";
 import ArrowUpwardIcon from "@mui/icons-material/ArrowUpward";
 import ArticleIcon from "@mui/icons-material/Article";
+import AutorenewIcon from "@mui/icons-material/Autorenew";
 import BackupIcon from "@mui/icons-material/Backup";
 import BookmarkIcon from "@mui/icons-material/Bookmark";
 import CancelIcon from "@mui/icons-material/Cancel";
@@ -107,6 +108,7 @@ export {
     ArrowRightIcon,
     ArrowLeftIcon,
     AccountCircleIcon,
+    AutorenewIcon,
     BackupIcon,
     AdminPanelSettingsIcon,
     SupervisorAccountIcon,

--- a/src/hooks/useTestFederation.test.tsx
+++ b/src/hooks/useTestFederation.test.tsx
@@ -1,12 +1,13 @@
 import { useForm } from "react-hook-form";
-import useRunFederation from "@/hooks/useRunFederation";
+import { FederationTestStatus } from "@/interfaces/Federation";
+import useTestFederation from "@/hooks/useTestFederation";
 import { act, renderHook, waitFor } from "@/utils/testUtils";
 import { integrationV1 } from "@/mocks/data/integration";
 import { teamV1 } from "@/mocks/data/team";
 import { postFederationsTestV1 } from "@/mocks/handlers/integration";
 import { server } from "@/mocks/server";
 
-describe("useRunFederation", () => {
+describe("useTestFederation", () => {
     const teamId = teamV1.id.toString();
 
     it("should return the `NOT_RUN` status on first load when `tested` is false", async () => {
@@ -15,7 +16,7 @@ describe("useRunFederation", () => {
             useForm({ defaultValues: mockIntegration })
         );
         const { result } = renderHook(() =>
-            useRunFederation({
+            useTestFederation({
                 teamId,
                 integration: mockIntegration,
                 control: formResult.current.control,
@@ -26,9 +27,9 @@ describe("useRunFederation", () => {
         );
         await waitFor(() => {
             expect(result.current).toEqual({
-                handleRun: expect.any(Function),
-                runResponse: undefined,
-                runStatus: "NOT_RUN",
+                handleTest: expect.any(Function),
+                testResponse: undefined,
+                testStatus: FederationTestStatus.NOT_RUN,
                 setTestedConfig: expect.any(Function),
             });
         });
@@ -40,7 +41,7 @@ describe("useRunFederation", () => {
             useForm({ defaultValues: mockIntegration })
         );
         const { result } = renderHook(() =>
-            useRunFederation({
+            useTestFederation({
                 teamId,
                 integration: mockIntegration,
                 control: formResult.current.control,
@@ -51,20 +52,20 @@ describe("useRunFederation", () => {
         );
         await waitFor(() => {
             expect(result.current).toEqual({
-                handleRun: expect.any(Function),
-                runResponse: undefined,
-                runStatus: "TESTED_IS_TRUE",
+                handleTest: expect.any(Function),
+                testResponse: undefined,
+                testStatus: FederationTestStatus.TESTED_IS_TRUE,
                 setTestedConfig: expect.any(Function),
             });
         });
     });
     it("should return the `RUN_COMPLETE` following api call", async () => {
-        const runResponse = {
+        const testResponse = {
             success: false,
             status: 404,
             title: "Test failed",
         };
-        server.use(postFederationsTestV1({ data: runResponse }));
+        server.use(postFederationsTestV1({ data: testResponse }));
 
         const mockIntegration = { ...integrationV1, tested: true };
 
@@ -72,7 +73,7 @@ describe("useRunFederation", () => {
             useForm({ defaultValues: mockIntegration })
         );
         const { result } = renderHook(() =>
-            useRunFederation({
+            useTestFederation({
                 teamId,
                 integration: mockIntegration,
                 control: formResult.current.control,
@@ -83,14 +84,14 @@ describe("useRunFederation", () => {
         );
 
         act(() => {
-            result.current.handleRun();
+            result.current.handleTest();
         });
 
         await waitFor(() => {
             expect(result.current).toEqual({
-                handleRun: expect.any(Function),
-                runResponse,
-                runStatus: "RUN_COMPLETE",
+                handleTest: expect.any(Function),
+                testResponse,
+                testStatus: FederationTestStatus.RUN_COMPLETE,
                 setTestedConfig: expect.any(Function),
             });
         });

--- a/src/hooks/useTestFederation.tsx
+++ b/src/hooks/useTestFederation.tsx
@@ -1,7 +1,11 @@
 import { useEffect, useState } from "react";
 import { Control, useWatch } from "react-hook-form";
 import { isEqual, pick } from "lodash";
-import { Federation, FederationRunResponse } from "@/interfaces/Federation";
+import {
+    Federation,
+    FederationTestResponse,
+    FederationTestStatus,
+} from "@/interfaces/Federation";
 import { Integration, IntegrationForm } from "@/interfaces/Integration";
 import usePost from "@/hooks/usePost";
 import apis from "@/config/apis";
@@ -16,7 +20,7 @@ export const watchFederationKeys = [
     "notifications",
 ];
 
-interface useRunFederationProps {
+interface useTestFederationProps {
     teamId: string;
     integration: Integration | undefined;
     reset: () => void;
@@ -29,7 +33,7 @@ interface useRunFederationProps {
     tested: boolean;
 }
 
-const useRunFederation = ({
+const useTestFederation = ({
     teamId,
     integration,
     reset,
@@ -37,14 +41,14 @@ const useRunFederation = ({
     tested,
     setValue,
     getValues,
-}: useRunFederationProps) => {
-    const [runStatus, setRunStatus] = useState<
-        "NOT_RUN" | "IS_RUNNING" | "RUN_COMPLETE" | "TESTED_IS_TRUE"
-    >("NOT_RUN");
+}: useTestFederationProps) => {
+    const [testStatus, setTestStatus] = useState<FederationTestStatus>(
+        FederationTestStatus.NOT_RUN
+    );
 
     const [testedConfig, setTestedConfig] = useState<Federation>();
 
-    const [runResponse, setRunResponse] = useState<FederationRunResponse>();
+    const [testResponse, setTestResponse] = useState<FederationTestResponse>();
 
     const fieldsToWatch = useWatch({
         control,
@@ -71,7 +75,7 @@ const useRunFederation = ({
 
         const configChanges = !isEqual(updatedForm, testedConfig);
         if (configChanges) {
-            setRunStatus("NOT_RUN");
+            setTestStatus(FederationTestStatus.NOT_RUN);
             setValue("tested", false);
             setValue("enabled", false);
         }
@@ -80,9 +84,9 @@ const useRunFederation = ({
 
     useEffect(() => {
         if (!tested && !integration) return;
-        if (runStatus !== "NOT_RUN") return;
+        if (testStatus !== FederationTestStatus.NOT_RUN) return;
         if (integration?.tested || tested) {
-            setRunStatus("TESTED_IS_TRUE");
+            setTestStatus(FederationTestStatus.TESTED_IS_TRUE);
         }
     }, [integration, tested, reset, setValue]);
 
@@ -94,10 +98,10 @@ const useRunFederation = ({
         }
     );
 
-    const handleRun = async () => {
+    const handleTest = async () => {
         if (!integration) return;
 
-        setRunStatus("IS_RUNNING");
+        setTestStatus(FederationTestStatus.IS_RUNNING);
 
         const payload = pick(
             getValues(),
@@ -111,24 +115,24 @@ const useRunFederation = ({
 
         const response = (await runFederationTest(
             updatedPayload
-        )) as unknown as FederationRunResponse;
+        )) as unknown as FederationTestResponse;
 
-        /* Send 'runStatus' to show correct section within run component */
-        setRunStatus("RUN_COMPLETE");
+        /* Send 'testStatus' to show correct section within run component */
+        setTestStatus(FederationTestStatus.RUN_COMPLETE);
 
         /* Update 'tested' property on integration form data */
         setValue("tested", response.success);
 
-        /* Send run response to be rendered within run component */
-        setRunResponse(response);
+        /* Send test response to be rendered within run component */
+        setTestResponse(response);
     };
 
     return {
-        runStatus,
+        testStatus,
         setTestedConfig,
-        runResponse,
-        handleRun,
+        testResponse,
+        handleTest,
     };
 };
 
-export default useRunFederation;
+export default useTestFederation;

--- a/src/interfaces/Federation.ts
+++ b/src/interfaces/Federation.ts
@@ -23,4 +23,10 @@ export enum FederationTestStatus {
     TESTED_IS_TRUE = "TESTED_IS_TRUE",
 }
 
+export enum FederationRunStatus {
+    IDLE = "IDLE",
+    RUNNING = "RUNNING",
+    COMPLETE = "COMPLETE",
+}
+
 export type { FederationTestResponse, Federation };

--- a/src/interfaces/Federation.ts
+++ b/src/interfaces/Federation.ts
@@ -1,6 +1,6 @@
 import { AuthType } from "./Integration";
 
-interface FederationRunResponse {
+interface FederationTestResponse {
     status: number;
     success: boolean;
     title: string;
@@ -16,4 +16,11 @@ interface Federation {
     run_time_hour: number;
 }
 
-export type { FederationRunResponse, Federation };
+export enum FederationTestStatus {
+    NOT_RUN = "NOT_RUN",
+    IS_RUNNING = "IS_RUNNING",
+    RUN_COMPLETE = "RUN_COMPLETE",
+    TESTED_IS_TRUE = "TESTED_IS_TRUE",
+}
+
+export type { FederationTestResponse, Federation };


### PR DESCRIPTION
## Screenshots (if relevant)
Pre-run
<img width="1261" height="757" alt="image" src="https://github.com/user-attachments/assets/a6e013b4-f7c0-4665-8d12-73741f76f0d7" />

Running

<img width="1261" height="818" alt="image" src="https://github.com/user-attachments/assets/19d3182e-8eb2-48d3-82ef-3930ccb54ce3" />


Complete
<img width="1261" height="818" alt="image" src="https://github.com/user-attachments/assets/17e020a0-ec31-4728-8603-cb475f2d7f66" />


## Describe your changes

Add the 'Run Now' button, which calls an existing API endpoint. Button has three transition states, outlined in the screenshot. 

Note, this is two commits. The first one clears up the naming for the 'Run Test' function. The second commit adds the button.

## Issue ticket link

https://hdruk.atlassian.net/browse/GAT-8798

## Checklist before requesting a review

-   [x] I have performed a self-review of my code
-   [x] I have added appropriate unit tests
-   [x] I have created mocks for unit tests (where appropriate)
-   [x] The interface is responsive (where appropriate)
-   [ ] The interface is at least AA (where appropriate)
