### PR TITLE
feat(GAT-7563): Data Custodian Network = Split owned/associated content

### DIFF
--- a/mocks/data/dataProviders/v1/dataProviders.data.ts
+++ b/mocks/data/dataProviders/v1/dataProviders.data.ts
@@ -3,7 +3,7 @@ import { DataProvider } from "@/interfaces/DataProvider";
 
 const generateDataProviderV1 = (data = {}): DataProvider => {
     return {
-        name: faker.datatype.string(),
+        name: faker.company.name(),
         _id: faker.datatype.uuid(),
         ...data,
     };

--- a/src/app/[locale]/(logged-out)/data-custodian-network/[dataCustodianNetworkId]/components/DataCustodianContent/DataCustodianContent.tsx
+++ b/src/app/[locale]/(logged-out)/data-custodian-network/[dataCustodianNetworkId]/components/DataCustodianContent/DataCustodianContent.tsx
@@ -5,6 +5,7 @@ import { Link } from "@mui/material";
 import { useTranslations } from "next-intl";
 import { DataProvider as DataCustodians } from "@/interfaces/DataProvider";
 import AccordionSectionSplit from "@/components/AccordionSectionSplit";
+import Box from "@/components/Box";
 import { RouteName } from "@/consts/routeName";
 
 const TRANSLATION_PATH =
@@ -34,31 +35,22 @@ export default function DataCustodianContent({
             <Link href={`/${RouteName.DATA_CUSTODIANS_ITEM}/${id}`}>
                 {name}
             </Link>
-            <table>
-                <tbody>
-                    <tr>
-                        <td>{`${t("datasets", {
-                            length: datasets_count,
-                        })}`}</td>
-                        <td>{`${t("datause", {
-                            length: durs_count,
-                        })}`}</td>
-                    </tr>
-                    <tr>
-                        <td>{`${t("tools", {
-                            length: tools_count,
-                        })}`}</td>
-                        <td>{`${t("publications", {
-                            length: publications_count,
-                        })}`}</td>
-                    </tr>
-                    <tr>
-                        <td>{`${t("collections", {
-                            length: collections_count,
-                        })}`}</td>
-                    </tr>
-                </tbody>
-            </table>
+            <Box
+                sx={{
+                    p: 0,
+                    display: "grid",
+                    gridTemplateColumns: "repeat(2, 1fr)",
+                }}>
+                <div>{t("datasets", { length: datasets_count ?? 0 })}</div>
+                <div>{t("datause", { length: durs_count ?? 0 })}</div>
+                <div>{t("tools", { length: tools_count ?? 0 })}</div>
+                <div>
+                    {t("publications", { length: publications_count ?? 0 })}
+                </div>
+                <div>
+                    {t("collections", { length: collections_count ?? 0 })}
+                </div>
+            </Box>
         </Fragment>
     );
 

--- a/src/app/[locale]/(logged-out)/data-custodian-network/[dataCustodianNetworkId]/components/DataCustodianContent/DataCustodianContent.tsx
+++ b/src/app/[locale]/(logged-out)/data-custodian-network/[dataCustodianNetworkId]/components/DataCustodianContent/DataCustodianContent.tsx
@@ -1,7 +1,7 @@
 "use client";
 
 import { Fragment } from "react";
-import { Link } from "@mui/material";
+import { Link, Typography } from "@mui/material";
 import { useTranslations } from "next-intl";
 import { DataProvider as DataCustodians } from "@/interfaces/DataProvider";
 import AccordionSectionSplit from "@/components/AccordionSectionSplit";
@@ -41,15 +41,21 @@ export default function DataCustodianContent({
                     display: "grid",
                     gridTemplateColumns: "repeat(2, 1fr)",
                 }}>
-                <div>{t("datasets", { length: datasets_count ?? 0 })}</div>
-                <div>{t("datause", { length: durs_count ?? 0 })}</div>
-                <div>{t("tools", { length: tools_count ?? 0 })}</div>
-                <div>
+                <Typography>
+                    {t("datasets", { length: datasets_count ?? 0 })}
+                </Typography>
+                <Typography>
+                    {t("datause", { length: durs_count ?? 0 })}
+                </Typography>
+                <Typography>
+                    {t("tools", { length: tools_count ?? 0 })}
+                </Typography>
+                <Typography>
                     {t("publications", { length: publications_count ?? 0 })}
-                </div>
-                <div>
+                </Typography>
+                <Typography>
                     {t("collections", { length: collections_count ?? 0 })}
-                </div>
+                </Typography>
             </Box>
         </Fragment>
     );

--- a/src/app/[locale]/(logged-out)/data-custodian-network/[dataCustodianNetworkId]/components/DataCustodianContent/DataCustodianContent.tsx
+++ b/src/app/[locale]/(logged-out)/data-custodian-network/[dataCustodianNetworkId]/components/DataCustodianContent/DataCustodianContent.tsx
@@ -31,9 +31,7 @@ export default function DataCustodianContent({
         durs_count,
     }: DataCustodians) => (
         <Fragment key={`data-custodian-${id}`}>
-            <Link
-                href={`/${RouteName.DATA_CUSTODIANS_ITEM}/${id}`}
-                style={{ textDecoration: "none" }}>
+            <Link href={`/${RouteName.DATA_CUSTODIANS_ITEM}/${id}`}>
                 {name}
             </Link>
             <table>
@@ -71,11 +69,8 @@ export default function DataCustodianContent({
             heading={t("title")}
             ownedHeading={t("title")}
             ownedCount={dataCustodians.length}
-            associatedHeading=""
-            associatedCount={0}
             defaultExpanded={dataCustodians.length > 0}
             ownedContents={dataCustodians.map(renderCard)}
-            associatedContents={[]}
         />
     );
 }

--- a/src/app/[locale]/(logged-out)/data-custodian-network/[dataCustodianNetworkId]/components/DataCustodianContent/DataCustodianContent.tsx
+++ b/src/app/[locale]/(logged-out)/data-custodian-network/[dataCustodianNetworkId]/components/DataCustodianContent/DataCustodianContent.tsx
@@ -4,7 +4,7 @@ import { Fragment } from "react";
 import { Link } from "@mui/material";
 import { useTranslations } from "next-intl";
 import { DataProvider as DataCustodians } from "@/interfaces/DataProvider";
-import AccordionSection from "@/components/AccordionSection";
+import AccordionSectionSplit from "@/components/AccordionSectionSplit";
 import { RouteName } from "@/consts/routeName";
 
 const TRANSLATION_PATH =
@@ -21,58 +21,61 @@ export default function DataCustodianContent({
 }: DataCustodianContentProps) {
     const t = useTranslations(TRANSLATION_PATH);
 
+    const renderCard = ({
+        name,
+        id,
+        datasets_count,
+        publications_count,
+        tools_count,
+        collections_count,
+        durs_count,
+    }: DataCustodians) => (
+        <Fragment key={`data-custodian-${id}`}>
+            <Link
+                href={`/${RouteName.DATA_CUSTODIANS_ITEM}/${id}`}
+                style={{ textDecoration: "none" }}>
+                {name}
+            </Link>
+            <table>
+                <tbody>
+                    <tr>
+                        <td>{`${t("datasets", {
+                            length: datasets_count,
+                        })}`}</td>
+                        <td>{`${t("datause", {
+                            length: durs_count,
+                        })}`}</td>
+                    </tr>
+                    <tr>
+                        <td>{`${t("tools", {
+                            length: tools_count,
+                        })}`}</td>
+                        <td>{`${t("publications", {
+                            length: publications_count,
+                        })}`}</td>
+                    </tr>
+                    <tr>
+                        <td>{`${t("collections", {
+                            length: collections_count,
+                        })}`}</td>
+                    </tr>
+                </tbody>
+            </table>
+        </Fragment>
+    );
+
     return (
-        <AccordionSection
+        <AccordionSectionSplit
             id={`anchor${anchorIndex}`}
             disabled={!dataCustodians.length}
-            heading={t("heading", {
-                length: dataCustodians.length,
-            })}
+            heading={t("title")}
+            ownedHeading={t("title")}
+            ownedCount={dataCustodians.length}
+            associatedHeading=""
+            associatedCount={0}
             defaultExpanded={dataCustodians.length > 0}
-            contents={dataCustodians.map(
-                ({
-                    name,
-                    id,
-                    datasets_count,
-                    publications_count,
-                    tools_count,
-                    collections_count,
-                    durs_count,
-                }) => (
-                    <Fragment key={`data-custodian-${id}`}>
-                        <Link
-                            href={`/${RouteName.DATA_CUSTODIANS_ITEM}/${id}`}
-                            style={{ textDecoration: "none" }}>
-                            {name}
-                        </Link>
-                        <table>
-                            <tbody>
-                                <tr>
-                                    <td>{`${t("datasets", {
-                                        length: datasets_count,
-                                    })}`}</td>
-                                    <td>{`${t("datause", {
-                                        length: durs_count,
-                                    })}`}</td>
-                                </tr>
-                                <tr>
-                                    <td>{`${t("tools", {
-                                        length: tools_count,
-                                    })}`}</td>
-                                    <td>{`${t("publications", {
-                                        length: publications_count,
-                                    })}`}</td>
-                                </tr>
-                                <tr>
-                                    <td>{`${t("collections", {
-                                        length: collections_count,
-                                    })}`}</td>
-                                </tr>
-                            </tbody>
-                        </table>
-                    </Fragment>
-                )
-            )}
+            ownedContents={dataCustodians.map(renderCard)}
+            associatedContents={[]}
         />
     );
 }

--- a/src/app/[locale]/(logged-out)/data-custodian-network/[dataCustodianNetworkId]/components/DataCustodianNetworkPage/DataCustodianNetworkPage.tsx
+++ b/src/app/[locale]/(logged-out)/data-custodian-network/[dataCustodianNetworkId]/components/DataCustodianNetworkPage/DataCustodianNetworkPage.tsx
@@ -43,7 +43,9 @@ export default function DataCustodianNetworkPage({
 }: DataCustodianNetworkProps) {
     const t = useTranslations(TRANSLATION_PATH);
 
-    const activeLinkList = accordions.map(section => ({ label: t(section.sectionName)}))
+    const activeLinkList = accordions.map(section => ({
+        label: t(section.sectionName),
+    }));
 
     const publisherFilter: Filter = {
         keys: FILTER_PUBLISHER_NAME,
@@ -132,6 +134,10 @@ export default function DataCustodianNetworkPage({
                     <Suspense fallback={<SectionSkeleton title="Datasets" />}>
                         <DatasetsOuter
                             datasets={dataNetworkDatasets}
+                            associatedDatasets={
+                                dataNetworkCustodiansEntities.associated_datasets ??
+                                []
+                            }
                             selectedTeamIds={selectedTeamIds}
                         />
                     </Suspense>

--- a/src/app/[locale]/(logged-out)/data-custodian-network/[dataCustodianNetworkId]/components/DatasetsOuter/DatasetsOuter.tsx
+++ b/src/app/[locale]/(logged-out)/data-custodian-network/[dataCustodianNetworkId]/components/DatasetsOuter/DatasetsOuter.tsx
@@ -1,5 +1,7 @@
-import { DatasetsSummaryData } from "@/interfaces/DataCustodianNetwork";
-import { FilterValues } from "@/interfaces/Filter";
+import {
+    DatasetsSummaryData,
+    NetworkDataset,
+} from "@/interfaces/DataCustodianNetwork";
 import Box from "@/components/Box";
 import DatasetsContent from "@/components/DatasetsContent";
 
@@ -7,9 +9,11 @@ const TRANSLATION_PATH = "pages.dataCustodianNetwork";
 
 export default function DatasetsOuter({
     datasets,
+    associatedDatasets,
     selectedTeamIds,
 }: {
     datasets: DatasetsSummaryData;
+    associatedDatasets: NetworkDataset[];
     selectedTeamIds: Set<string>;
 }) {
     return (
@@ -22,6 +26,7 @@ export default function DatasetsOuter({
             }}>
             <DatasetsContent
                 datasets={datasets.datasets}
+                associatedDatasets={associatedDatasets}
                 anchorIndex={2}
                 translationPath={TRANSLATION_PATH}
                 selectedTeamIds={selectedTeamIds}

--- a/src/app/[locale]/(logged-out)/data-custodian-network/[dataCustodianNetworkId]/components/NetworkContent/NetworkContent.tsx
+++ b/src/app/[locale]/(logged-out)/data-custodian-network/[dataCustodianNetworkId]/components/NetworkContent/NetworkContent.tsx
@@ -41,21 +41,29 @@ const NetworkContent = ({
             }}>
             <DataUsesContent
                 datauses={activeDataUses}
+                associatedDatauses={entitiesSummaryData.associated_durs ?? []}
                 anchorIndex={3}
                 translationPath={TRANSLATION_PATH}
             />
             <ToolsContent
                 tools={activeTools}
+                associatedTools={entitiesSummaryData.associated_tools ?? []}
                 anchorIndex={4}
                 translationPath={TRANSLATION_PATH}
             />
             <PublicationsContent
                 publications={activePublications}
+                associatedPublications={
+                    entitiesSummaryData.associated_publications ?? []
+                }
                 anchorIndex={5}
                 translationPath={TRANSLATION_PATH}
             />
             <CollectionsContent
                 collections={activeCollections}
+                associatedCollections={
+                    entitiesSummaryData.associated_collections ?? []
+                }
                 anchorIndex={6}
                 translationPath={TRANSLATION_PATH}
             />

--- a/src/components/AccordionSectionSplit/AccordionSectionSplit.tsx
+++ b/src/components/AccordionSectionSplit/AccordionSectionSplit.tsx
@@ -17,10 +17,10 @@ export interface AccordionSectionSplitProps
     extends Omit<AccordionProps, "contents"> {
     ownedHeading: string;
     ownedCount: number;
-    associatedHeading: string;
-    associatedCount: number;
+    associatedHeading?: string;
+    associatedCount?: number;
     ownedContents: ReactElement[];
-    associatedContents: ReactElement[];
+    associatedContents?: ReactElement[];
     cardHeight?: number;
     visibleRows?: number;
     disableCardWrapper?: boolean;
@@ -33,10 +33,10 @@ export default function AccordionSectionSplit({
     heading,
     ownedHeading,
     ownedCount,
-    associatedHeading,
-    associatedCount,
+    associatedHeading = "",
+    associatedCount = 0,
     ownedContents,
-    associatedContents,
+    associatedContents = [],
     cardHeight = DEFAULT_CARD_HEIGHT,
     visibleRows = DEFAULT_VISIBLE_ROWS,
     disableCardWrapper = false,

--- a/src/config/messages/en.json
+++ b/src/config/messages/en.json
@@ -1496,6 +1496,7 @@
                     "heading": "Introduction"
                 },
                 "DataCustodianContent": {
+                    "title": "Data Custodian",
                     "heading": "Data Custodians ({ length })",
                     "datasets": "Datasets ({ length })",
                     "datause": "Data Use ({ length })",
@@ -1504,24 +1505,34 @@
                     "collections": "Collections ({ length })"
                 },
                 "DatasetsContent": {
+                    "title": "Datasets",
                     "heading": "Datasets ({ length })",
+                    "associatedHeading": "Associated datasets",
                     "populationSize": "Dataset population size: { length }",
                     "unknownString": "Unknown"
                 },
                 "DatausesContent": {
-                    "heading": "Data Uses ({ length })"
+                    "title": "Data uses",
+                    "heading": "Data Uses ({ length })",
+                    "associatedHeading": "Associated data uses"
                 },
                 "PublicationsContent": {
-                    "heading": "Publications ({ length })"
+                    "title": "Publications",
+                    "heading": "Publications ({ length })",
+                    "associatedHeading": "Associated publications"
                 },
                 "ToolsContent": {
-                    "heading": "Analysis Scripts & Software ({ length })"
+                    "title": "Analysis scripts, tools and software",
+                    "heading": "Analysis Scripts & Software ({ length })",
+                    "associatedHeading": "Associated analysis scripts, tools and software"
                 },
                 "ServiceOfferingsContent": {
                     "heading": "Service offerings ({ length })"
                 },
                 "CollectionsContent": {
-                    "heading": "Collections ({ length })"
+                    "title": "Collections",
+                    "heading": "Collections ({ length })",
+                    "associatedHeading": "Associated collections"
                 }
             }
         },

--- a/src/config/messages/en.json
+++ b/src/config/messages/en.json
@@ -1497,7 +1497,6 @@
                 },
                 "DataCustodianContent": {
                     "title": "Data Custodian",
-                    "heading": "Data Custodians ({ length })",
                     "datasets": "Datasets ({ length })",
                     "datause": "Data Use ({ length })",
                     "tools": "Tools ({ length })",


### PR DESCRIPTION
> AI Disclosure: Some of the code was written with the assistance of Claude (Anthropic). All changes were reviewed and approved by the author.


## Screenshots / videos (if relevant)
<img width="1499" height="864" alt="image" src="https://github.com/user-attachments/assets/5a9306af-504a-42ea-8edc-dac5a3b54183" />

## Describe your changes
Reworks the data custodian network page so each entity section can present its content split into "owned" and "associated" groups. The Data Custodians section now renders through `AccordionSectionSplit` instead of `AccordionSection`, and associated datasets, data uses, tools, publications and collections (from the `associated_*` fields on the network entities summary) are threaded down into their respective content components. `AccordionSectionSplit`'s associated-side props are made optional so sections can opt in without always supplying an associated group. Translation strings gain `title` and `associatedHeading` keys, and the Data Custodians heading is simplified.

## Issue ticket link
https://hdruk.atlassian.net/browse/GAT-7563

## Checklist before requesting a review

- [x] I have performed a self-review of my code
- [ ] I have added appropriate unit tests / e2e tests (where relevant)
- [ ] I have created mocks for api endpoints (where appropriate)
- [ ] The interface is responsive (where ticket is relevant)
- [ ] The interface is at least AA (where ticket is relevant)
- [ ] Commits are described as "(chore|fix|feature|test|maintenance): description"
