### PR TITLE
fix(GAT-9170): Results card now uses team.id rather than gatewayId

### DIFF
--- a/src/app/[locale]/(logged-out)/search/components/ResultCard/ResultCard.tsx
+++ b/src/app/[locale]/(logged-out)/search/components/ResultCard/ResultCard.tsx
@@ -241,8 +241,7 @@ const ResultCard = ({
         highlight?.abstract?.[0] ??
         highlight?.description?.[0] ??
         metadata.summary.abstract;
-    const dataCustodianId = metadata.summary.publisher.gatewayId;
-    // if the below is false, its because the api has failed to find the team id based off the original uid for gatewayId
+    const dataCustodianId = team?.id;
     const isNumber = !Number.isNaN(dataCustodianId);
     const linkHref = `/${RouteName.DATA_CUSTODIANS_ITEM}/${dataCustodianId}`;
 

--- a/src/app/[locale]/(logged-out)/search/components/ResultsTable/ResultsTable.tsx
+++ b/src/app/[locale]/(logged-out)/search/components/ResultsTable/ResultsTable.tsx
@@ -26,7 +26,6 @@ interface ResultTableProps {
 
 const CONFORMS_TO_PATH = "metadata.accessibility.formatAndStandards.conformsTo";
 const PUBLISHER_NAME_PATH = "metadata.summary.publisher.name";
-const PUBLISHERS_ID = "metadata.summary.publisher.gatewayId";
 const COHORT_DISCOVERY_PATH = "isCohortDiscovery";
 const ACCESS_SERVICE_PATH =
     "metadata.accessibility.access.accessServiceCategory";
@@ -90,8 +89,7 @@ const getColumns = ({
     columnHelper.display({
         id: "dataProvider",
         cell: ({ row: { original } }) => {
-            const dataCustodianId = get(original, PUBLISHERS_ID);
-            // if the below is false, its because the api has failed to find the team id based off the original uid for gatewayId
+            const dataCustodianId = original.team?.id;
             const isNumber = !Number.isNaN(Number(dataCustodianId));
             const linkHref = `/${RouteName.DATA_CUSTODIANS_ITEM}/${dataCustodianId}`;
 

--- a/src/app/[locale]/(logged-out)/search/components/Search/Search.tsx
+++ b/src/app/[locale]/(logged-out)/search/components/Search/Search.tsx
@@ -271,9 +271,13 @@ const Search = ({ filters, schema }: SearchProps) => {
     const { data: v1Data, isLoading: isV1Searching } = usePostSwr<
         SearchPaginationType<SearchResult>
     >(
-        `${apis.searchV1Url}/${queryParams.type}?view_type=mini&per_page=${
-            queryParams.per_page
-        }&page=${queryParams.page}&sort=${queryParams.sort}${
+        `${apis.searchV1Url}/${queryParams.type}?${
+            queryParams.type === SearchCategory.PUBLICATIONS
+                ? ``
+                : `view_type=mini&`
+        }per_page=${queryParams.per_page}&page=${queryParams.page}&sort=${
+            queryParams.sort
+        }${
             queryParams.type === SearchCategory.PUBLICATIONS
                 ? `&${STATIC_FILTER_SOURCE}=${queryParams.source}`
                 : ``


### PR DESCRIPTION
## Screenshots (if relevant)

## Describe your changes
Results card now uses team.id rather than gatewayId

## Issue ticket link
https://hdruk.atlassian.net/browse/GAT-9170

## Checklist before requesting a review

-   [ ] I have performed a self-review of my code
-   [ ] I have added appropriate unit tests
-   [ ] I have created mocks for unit tests (where appropriate)
-   [ ] The interface is responsive (where appropriate)
-   [ ] The interface is at least AA (where appropriate)
