### PR TITLE
fix(GAT-8754): Fix empty widget preview state

### DIFF
--- a/src/widgets/WidgetDisplay.test.tsx
+++ b/src/widgets/WidgetDisplay.test.tsx
@@ -96,6 +96,61 @@ describe("WidgetDisplay", () => {
     expect(screen.getByText("Collection 1")).toBeInTheDocument();
     });
 
+  it("defaults to the first non-empty category when datasets are empty", () => {
+    const noDatasets: WidgetEntityData = {
+      ...mockData,
+      datasets: [],
+    };
+
+    mockHook.mockReturnValue({
+      datasets: [],
+      collections,
+      scripts,
+      data_uses: dataUses,
+    });
+
+    render(<WidgetDisplay data={noDatasets} />);
+
+    expect(
+      screen.getByRole("button", {
+        name: /open to show search type options/i,
+      })
+    ).toHaveTextContent("Data Uses / Research Projects");
+    expect(
+      screen.queryByText("Datasets & Biosamples")
+    ).not.toBeInTheDocument();
+    expect(screen.getByText("Data Use 1")).toBeInTheDocument();
+  });
+
+  it("shows a no-data message and no nav when all categories are empty", () => {
+    const empty: WidgetEntityData = {
+      ...mockData,
+      datasets: [],
+      collections: [],
+      scripts: [],
+      data_uses: [],
+    };
+
+    mockHook.mockReturnValue({
+      datasets: [],
+      collections: [],
+      scripts: [],
+      data_uses: [],
+    });
+
+    render(<WidgetDisplay data={empty} />);
+
+    expect(
+      screen.getByText(/No data was selected for this widget/i)
+    ).toBeInTheDocument();
+
+    expect(
+      screen.queryByRole("button", {
+        name: /open to show search type options/i,
+      })
+    ).not.toBeInTheDocument();
+  });
+
   it("updates search input", () => {
     render(<WidgetDisplay data={mockData} />);
 

--- a/src/widgets/WidgetDisplay.tsx
+++ b/src/widgets/WidgetDisplay.tsx
@@ -27,6 +27,7 @@ const TRANSLATIONS = {
     footerDesc:
         "Cohort Discovery indentifies relevant populations across datasets",
     cohortButton: "Open Cohort Discovery",
+    noData: "No data was selected for this widget",
 };
 
 type WidgetDisplayProps = { data: WidgetEntityData; isIframe?: boolean };
@@ -71,10 +72,29 @@ export default function WidgetDisplay({
         [branding_primary, branding_secondary, branding_neutral]
     );
 
-    const renderedContent = useMemo(() => {
-        const results = resultsByType[entityType];
+    const filteredMenuCategories = useMemo(
+        () => CATEGORIES.filter(category => data?.[category].length > 0),
+        [data]
+    );
 
-        switch (entityType) {
+    const activeType = filteredMenuCategories.includes(entityType)
+        ? entityType
+        : filteredMenuCategories[0];
+
+    const renderedContent = useMemo(() => {
+        if (!activeType) {
+            return (
+                <Box sx={{ p: 4, textAlign: "center" }}>
+                    <Typography variant="subtitle1" component="p">
+                        {TRANSLATIONS.noData}
+                    </Typography>
+                </Box>
+            );
+        }
+
+        const results = resultsByType[activeType];
+
+        switch (activeType) {
             case "datasets":
                 return (
                     <DatasetsList
@@ -104,12 +124,7 @@ export default function WidgetDisplay({
                     />
                 );
         }
-    }, [entityType, resultsByType, branding]);
-
-    const filteredMenuCategories = useMemo(
-        () => CATEGORIES.filter(category => data?.[category].length > 0),
-        [data]
-    );
+    }, [activeType, resultsByType, branding]);
 
     return (
         <Box
@@ -137,15 +152,17 @@ export default function WidgetDisplay({
                     branding={branding}
                 />
 
-                <CategoryMenu
-                    value={entityType}
-                    options={filteredMenuCategories}
-                    onChange={setEntityType}
-                    menuAnchor={menuAnchor}
-                    setMenuAnchor={setMenuAnchor}
-                    containerRef={widgetContainer}
-                    branding={branding}
-                />
+                {activeType && (
+                    <CategoryMenu
+                        value={activeType}
+                        options={filteredMenuCategories}
+                        onChange={setEntityType}
+                        menuAnchor={menuAnchor}
+                        setMenuAnchor={setMenuAnchor}
+                        containerRef={widgetContainer}
+                        branding={branding}
+                    />
+                )}
 
                 <Box sx={{ flex: 1, overflow: "auto", mb: 1, p: 0 }}>
                     {renderedContent}


### PR DESCRIPTION
## Screenshots / videos (if relevant)
<img width="976" height="454" alt="image" src="https://github.com/user-attachments/assets/52149d8e-73df-4af6-9f79-6cf41762b372" />

## Describe your changes
The embeddable widget preview always defaulted its category dropdown to "Datasets & Biosamples", even for widgets that contained no datasets — showing a misleading label and an empty list. The selected category is now derived from the categories that actually have content: it keeps the user's selection when valid, otherwise falls back to the first populated category. When a widget has no content in any category, the category nav is hidden entirely and the content area shows a "No data was selected for this widget" message instead. This keeps the preview honest about what a widget will actually display.

## Issue ticket link
https://hdruk.atlassian.net/browse/GAT-8754

## Checklist before requesting a review

- [x] I have performed a self-review of my code
- [x] I have added appropriate unit tests / e2e tests (where relevant)
- [ ] I have created mocks for api endpoints (where appropriate)
- [ ] The interface is responsive (where ticket is relevant)
- [ ] The interface is at least AA (where ticket is relevant)
- [ ] Commits are described as "(chore|fix|feature|test|maintenance): description"
