### PR TITLE
feat(GAT-8821): Correct DAR dialog & save draft logic

### DIFF
--- a/src/app/[locale]/account/(withoutLeftNav)/profile/data-access-requests/applications/[applicationId]/components/ApplicationSection.tsx
+++ b/src/app/[locale]/account/(withoutLeftNav)/profile/data-access-requests/applications/[applicationId]/components/ApplicationSection.tsx
@@ -64,8 +64,6 @@ import {
     renderFormHydrationField,
 } from "@/utils/formHydration";
 import { updateDarApplicationAnswersAction } from "@/app/actions/updateDarApplicationAnswers";
-import { updateDarApplicationTeamAction } from "@/app/actions/updateDarApplicationTeam";
-import { updateDarApplicationUserAction } from "@/app/actions/updateDarApplicationUser";
 import notFound from "@/app/not-found";
 import { DarActionBar } from "./DarActionBar";
 import DarFieldArray from "./DarFieldArray";
@@ -212,7 +210,9 @@ const ApplicationSection = ({
                 ? formData[PROJECT_TITLE_FIELD]
                 : getValues(PROJECT_TITLE_FIELD),
             applicant_id: data.applicant_id,
-            submission_status: DarApplicationStatus.DRAFT,
+            submission_status: formData
+                ? DarApplicationStatus.SUBMITTED
+                : DarApplicationStatus.DRAFT,
         };
 
         const values = formData ?? getValues();
@@ -224,48 +224,34 @@ const ApplicationSection = ({
             excludedQuestionFields
         );
 
-        if (formData) {
-            const [resAnswers, resApplication] = await Promise.all([
-                updateDarApplicationAnswersAction(applicationId, userId, {
-                    ...applicationData,
-                    answers,
-                }),
-                isResearcher
-                    ? updateDarApplicationUserAction(applicationId, userId, {
-                          submission_status: DarApplicationStatus.SUBMITTED,
-                      })
-                    : teamId &&
-                      updateDarApplicationTeamAction(applicationId, teamId, {
-                          submission_status: DarApplicationStatus.SUBMITTED,
-                      }),
-            ]);
+        const resAnswers = await updateDarApplicationAnswersAction(
+            applicationId,
+            userId,
+            {
+                ...applicationData,
+                answers,
+            }
+        );
 
-            if (resAnswers && resApplication) {
+        if (formData) {
+            if (resAnswers) {
+                notificationService.apiSuccess(
+                    "Data Access Request submitted successfully"
+                );
                 push(
                     `/${RouteName.ACCOUNT}/${RouteName.PROFILE}/${RouteName.DATA_ACCESS_REQUESTS}/${RouteName.APPLICATIONS}`
                 );
             } else {
                 notificationService.apiError("Failed to submit application");
             }
-        } else {
-            const resAnswers = await updateDarApplicationAnswersAction(
-                applicationId,
-                userId,
-                {
-                    ...applicationData,
-                    answers,
-                }
+        } else if (resAnswers) {
+            notificationService.apiSuccess(
+                "Successfully updated Data Access Request"
             );
-
-            if (resAnswers) {
-                notificationService.apiSuccess(
-                    "Successfully updated Data Access Request"
-                );
-            } else {
-                notificationService.apiError(
-                    "Failed to update Data Access Request"
-                );
-            }
+        } else {
+            notificationService.apiError(
+                "Failed to update Data Access Request"
+            );
         }
     };
 
@@ -277,6 +263,10 @@ const ApplicationSection = ({
         await saveApplication();
     };
 
+    const handleInvalidSubmit = () => {
+        notificationService.apiError(t("missingRequiredFields"));
+    };
+
     const handleManageApplication = () => {
         showDialog(DarManageDialog, { darApplicationEndpoint, applicationId });
     };
@@ -286,6 +276,12 @@ const ApplicationSection = ({
         (isResearcher &&
             teamApplication &&
             teamApplication?.approval_status !== null);
+
+    const isApplicationEditable =
+        !teamApplication ||
+        (teamApplication?.approval_status === null &&
+            teamApplication.submission_status !==
+                DarApplicationStatus.SUBMITTED);
 
     const renderSectionHeader = (field: DarFormattedField) => (
         <>
@@ -566,8 +562,12 @@ const ApplicationSection = ({
                         teamId={teamId}
                         userId={userId}
                         saveDraftOnClick={handleSaveAsDraft}
-                        submitOnClick={handleSubmit(handleSave)}
+                        submitOnClick={handleSubmit(
+                            handleSave,
+                            handleInvalidSubmit
+                        )}
                         isResearcher={isResearcher}
+                        showSaveDraft={isApplicationEditable}
                         manageApplicationOnStatus={handleManageApplication}
                     />
 
@@ -799,14 +799,12 @@ const ApplicationSection = ({
                         )}
 
                         <Box sx={{ gap: 1, p: 0, display: "flex" }}>
-                            {isResearcher &&
-                                (!teamApplication ||
-                                    (teamApplication?.approval_status ===
-                                        null &&
-                                        teamApplication.submission_status !==
-                                            DarApplicationStatus.SUBMITTED)) && (
+                            {isResearcher && isApplicationEditable && (
                                     <Button
-                                        onClick={handleSubmit(handleSave)}
+                                        onClick={handleSubmit(
+                                            handleSave,
+                                            handleInvalidSubmit
+                                        )}
                                         type="submit"
                                         variant="outlined"
                                         color="secondary">

--- a/src/app/[locale]/account/(withoutLeftNav)/profile/data-access-requests/applications/[applicationId]/components/DarActionBar.test.tsx
+++ b/src/app/[locale]/account/(withoutLeftNav)/profile/data-access-requests/applications/[applicationId]/components/DarActionBar.test.tsx
@@ -8,6 +8,7 @@ const defaultProps = {
     submitOnClick: jest.fn(),
     manageApplicationOnStatus: jest.fn(),
     isResearcher: true,
+    showSaveDraft: true,
 };
 
 const mockData = {
@@ -54,5 +55,22 @@ describe("DarActionBar", () => {
         render(<DarActionBar {...defaultProps} />);
         expect(await screen.findByText("Dataset Alpha")).toBeInTheDocument();
         expect(await screen.findByText("Dataset Beta")).toBeInTheDocument();
+    });
+
+    it("renders the save draft button when showSaveDraft is true", async () => {
+        mockFetch(mockData);
+        render(<DarActionBar {...defaultProps} />);
+        expect(
+            await screen.findByRole("button", { name: "Save draft" })
+        ).toBeInTheDocument();
+    });
+
+    it("does not render the save draft button when showSaveDraft is false", async () => {
+        mockFetch(mockData);
+        render(<DarActionBar {...defaultProps} showSaveDraft={false} />);
+        expect(await screen.findByText("My Research Project")).toBeInTheDocument();
+        expect(
+            screen.queryByRole("button", { name: "Save draft" })
+        ).not.toBeInTheDocument();
     });
 })

--- a/src/app/[locale]/account/(withoutLeftNav)/profile/data-access-requests/applications/[applicationId]/components/DarActionBar.tsx
+++ b/src/app/[locale]/account/(withoutLeftNav)/profile/data-access-requests/applications/[applicationId]/components/DarActionBar.tsx
@@ -34,6 +34,7 @@ interface DarFormHeaderProps {
     submitOnClick: () => Promise<void> | void | undefined;
     manageApplicationOnStatus: () => Promise<void> | void | undefined;
     isResearcher: boolean;
+    showSaveDraft: boolean;
 }
 
 const DarActionBar = ({
@@ -44,6 +45,7 @@ const DarActionBar = ({
     submitOnClick,
     manageApplicationOnStatus,
     isResearcher,
+    showSaveDraft,
 }: DarFormHeaderProps) => {
     const idTitle = `DAR Application ${applicationId}`;
     const t = useTranslations(TRANSLATION_PATH);
@@ -151,9 +153,13 @@ const DarActionBar = ({
                 sx={{ my: 2, ml: 2 }}>
                 {isResearcher ? (
                     <>
-                        <Button color="greyCustom" onClick={saveDraftOnClick}>
-                            {t("saveDraft")}
-                        </Button>
+                        {showSaveDraft && (
+                            <Button
+                                color="greyCustom"
+                                onClick={saveDraftOnClick}>
+                                {t("saveDraft")}
+                            </Button>
+                        )}
                         <Button color="primary" onClick={submitOnClick}>
                             {t("submitApplication")}
                         </Button>

--- a/src/app/[locale]/account/profile/cohort-discovery-admin/components/CohortTable/CohortTable.test.tsx
+++ b/src/app/[locale]/account/profile/cohort-discovery-admin/components/CohortTable/CohortTable.test.tsx
@@ -9,6 +9,8 @@ const requests = [
     generateCohortRequestV1({
         request_status: "APPROVED",
         nhse_sde_request_status: "IN PROCESS",
+        created_at: "2025-01-15T00:00:00.000Z",
+        updated_at: "2025-06-20T00:00:00.000Z",
     }),
     generateCohortRequestV1({
         request_status: "REJECTED",

--- a/src/components/DarStatusTracker/DarStatusTracker.tsx
+++ b/src/components/DarStatusTracker/DarStatusTracker.tsx
@@ -22,8 +22,12 @@ export default function DarStatusTracker({
     statuses,
 }: DarStatusTrackerProps) {
     const t = useTranslations(TRANSLATION_PATH);
+    const orderedStatuses = statuses.includes(DarApplicationStatus.DRAFT)
+        ? statuses
+        : [DarApplicationStatus.DRAFT, ...statuses];
+
     const formattedStatuses = [
-        ...statuses,
+        ...orderedStatuses,
         approvalStatus &&
         approvalStatus !== DarApplicationApprovalStatus.FEEDBACK
             ? approvalStatus
@@ -53,6 +57,10 @@ export default function DarStatusTracker({
                     mb: 3,
                 }}>
                 {formattedStatuses.map((status, index) => {
+                    if (status === DarApplicationStatus.DRAFT) {
+                        return null;
+                    }
+
                     const isActive = index === activeIndex;
                     const isFuture = index > activeIndex;
 

--- a/src/config/messages/en.json
+++ b/src/config/messages/en.json
@@ -2112,7 +2112,9 @@
                 "rejectedButtonText": "Reject",
                 "changeStatus": "Change Application Status",
                 "intro": "Use the options below to log your decision about this application.",
-                "defaultDraftMessage": "This is an automated notification that the application has been changed from 'In review' to 'Draft' status. No comment has been added by the Data Custodian."
+                "defaultDraftMessage": "This is an automated notification that the application has been changed from 'In review' to 'Draft' status. No comment has been added by the Data Custodian.",
+                "statusUpdateSuccess": "Application status updated successfully",
+                "statusUpdateError": "Failed to update application status"
             },
             "DarActionDialog": {
                 "actionPermanent": "I understand this action is permanent",

--- a/src/modules/DarManageDialog/DarManageDialog.tsx
+++ b/src/modules/DarManageDialog/DarManageDialog.tsx
@@ -13,6 +13,7 @@ import Form from "@/components/Form";
 import InputWrapper from "@/components/InputWrapper";
 import Typography from "@/components/Typography";
 import useModal from "@/hooks/useModal";
+import notificationService from "@/services/notification";
 import { inputComponents } from "@/config/forms";
 import { colors } from "@/config/theme";
 import { CACHE_DAR_REVIEWS } from "@/consts/cache";
@@ -86,12 +87,15 @@ const DarManageDialog = ({ applicationId }: DarManageDialogProps) => {
             payload
         );
 
-        revalidateCacheAction(`${CACHE_DAR_REVIEWS}${applicationId}`);
+        await revalidateCacheAction(`${CACHE_DAR_REVIEWS}${applicationId}`);
 
         hideModal();
 
         if (updateResponse) {
+            notificationService.apiSuccess(t("statusUpdateSuccess"));
             push(redirectUrl);
+        } else {
+            notificationService.apiError(t("statusUpdateError"));
         }
     };
 


### PR DESCRIPTION
> AI disclaimer - Root-cause investigation and implementation were done by CLAUDE

## Screenshots / videos (if relevant)

## Describe your changes
DAR submission previously fired the answers-save and the status-change as two concurrent requests, which raced on the server and intermittently failed to show a confirmation — occasionally dropping the applicant's final edits while still marking the application submitted. Submission is now a single request that saves answers and flips the status to SUBMITTED in one call, with a success toast + redirect on success, and clear error toasts on failure or when required fields are missing.

The custodian "Change application status" dialog now surfaces success/error toasts and reliably navigates back to the applications list — the cache revalidation is awaited so its router refresh no longer clobbers the redirect (previously the first "set to Draft" often stayed on the page).

Finally, the "Save draft" button is now hidden when an application is no longer editable (submitted/in review, or already decided) rather than offering an action the API rejects.

Also - a sometimes failing Cohort test was improved.

## Issue ticket link
https://hdruk.atlassian.net/browse/GAT-8821

## Checklist before requesting a review

- [x] I have performed a self-review of my code
- [x] I have added appropriate unit tests / e2e tests (where relevant)
- [ ] I have created mocks for api endpoints (where appropriate)
- [ ] The interface is responsive (where ticket is relevant)
- [ ] The interface is at least AA (where ticket is relevant)
- [ ] Commits are described as "(chore|fix|feature|test|maintenance): description"
