### PR TITLE
feat(GAT-0000): switch dataset fetches to v3 endpoint and show GWDM schema version

### DIFF
--- a/src/app/[locale]/(logged-out)/dataset/[datasetId]/components/Sources/Sources.tsx
+++ b/src/app/[locale]/(logged-out)/dataset/[datasetId]/components/Sources/Sources.tsx
@@ -14,9 +14,10 @@ const TRANSLATION_PATH = "pages.dataset.components.Sources";
 
 interface SourcesProps {
     data: Metadata;
+    gwdmVersion?: string;
 }
 
-const Sources = ({ data }: SourcesProps) => {
+const Sources = ({ data, gwdmVersion }: SourcesProps) => {
     const t = useTranslations(TRANSLATION_PATH);
     const { datasetType } = data.provenance.origin;
 
@@ -61,6 +62,15 @@ const Sources = ({ data }: SourcesProps) => {
                     ? formatTextDelimiter(collectionSource)
                     : t("noCollectionSources")}
             </Typography>
+            {gwdmVersion && (
+                <>
+                    <Divider sx={{ my: 1 }} />
+                    <Typography variant="h4">
+                        <b>{`${t("schemaVersion")}: `}</b>
+                        {gwdmVersion}
+                    </Typography>
+                </>
+            )}
         </Paper>
     );
 };

--- a/src/app/[locale]/(logged-out)/dataset/[datasetId]/page.tsx
+++ b/src/app/[locale]/(logged-out)/dataset/[datasetId]/page.tsx
@@ -207,6 +207,7 @@ export default async function DatasetItemPage({
                                 }}>
                                 <Sources
                                     data={datasetVersion.metadata.metadata}
+                                    gwdmVersion={datasetVersion.metadata.gwdmVersion}
                                 />
                                 {data?.linkages && (
                                     <Linkages linkages={data.linkages} />

--- a/src/app/[locale]/account/profile/publications/components/DatasetRelationshipFields/DatasetRelationshipFields.tsx
+++ b/src/app/[locale]/account/profile/publications/components/DatasetRelationshipFields/DatasetRelationshipFields.tsx
@@ -59,7 +59,7 @@ const DatasetRelationshipFields = <TFieldValues extends FieldValues>({
 
     const { data: datasetData, isLoading: isLoadingDatasets } = useGet<
         Dataset[]
-    >(`${apis.datasetsV2Url}?${new URLSearchParams(queryParams)}`, {
+    >(`${apis.datasetsV3Url}?${new URLSearchParams(queryParams)}`, {
         keepPreviousData: true,
     });
 

--- a/src/app/[locale]/account/team/[teamId]/(withLeftNav)/data-uses/[dataUseId]/components/EditDataUse.tsx
+++ b/src/app/[locale]/account/team/[teamId]/(withLeftNav)/data-uses/[dataUseId]/components/EditDataUse.tsx
@@ -287,7 +287,7 @@ const EditDataUse = () => {
 
     const { data: datasetData, isLoading: isLoadingDatasets } = useGet<
         Dataset[]
-    >(`${apis.datasetsV2Url}?${new URLSearchParams(queryParams)}`, {
+    >(`${apis.datasetsV3Url}?${new URLSearchParams(queryParams)}`, {
         keepPreviousData: true,
     });
     const datasetOptions = useMemo(() => {

--- a/src/app/[locale]/account/team/[teamId]/(withLeftNav)/tools/create/components/DatasetRelationshipFields/DatasetRelationshipFields.tsx
+++ b/src/app/[locale]/account/team/[teamId]/(withLeftNav)/tools/create/components/DatasetRelationshipFields/DatasetRelationshipFields.tsx
@@ -62,7 +62,7 @@ const DatasetRelationshipFields = <TFieldValues extends FieldValues>({
 
     const { data: datasetData, isLoading: isLoadingDatasets } = useGet<
         Dataset[]
-    >(`${apis.datasetsV2Url}?${new URLSearchParams(queryParams)}`, {
+    >(`${apis.datasetsV3Url}?${new URLSearchParams(queryParams)}`, {
         keepPreviousData: true,
     });
 

--- a/src/config/apis.ts
+++ b/src/config/apis.ts
@@ -48,6 +48,8 @@ const apis = {
     permissionsV1Url: `${apiV1Url}/permissions`,
     datasetsV2Url: `${apiV2Url}/datasets`,
     datasetsV2UrlIP: `${apiV2IPUrl}/datasets`,
+    datasetsV3Url: `${apiV3Url}/datasets`,
+    datasetsV3UrlIP: `${apiV3IPUrl}/datasets`,
     datasetsExportV1Url: `${apiV1Url}/datasets/export`,
     datasetsExportMetadataV1Url: `${apiV1Url}/datasets/export_metadata`,
     structuralMetadataExportV1Url: `${apiV1Url}/datasets/export/mock?type=template_dataset_structural_metadata`,

--- a/src/config/messages/en.json
+++ b/src/config/messages/en.json
@@ -1588,7 +1588,8 @@
                     "datasetTypes": "Dataset Types",
                     "datasetSubtypes": "Dataset Sub-types",
                     "collectionSources": "Collection Sources",
-                    "noCollectionSources": "No collection sources listed"
+                    "noCollectionSources": "No collection sources listed",
+                    "schemaVersion": "Schema Version"
                 }
             }
         },

--- a/src/modules/AddResourceDialog/AddResourceDialog.tsx
+++ b/src/modules/AddResourceDialog/AddResourceDialog.tsx
@@ -102,7 +102,7 @@ const AddDatasetDialog = ({
 
     const { data: datasetData, isLoading: isLoadingDatasets } = useGet<
         Dataset[]
-    >(`${apis.datasetsV2Url}?${new URLSearchParams(queryParams)}`, {
+    >(`${apis.datasetsV3Url}?${new URLSearchParams(queryParams)}`, {
         shouldFetch: resourceType === ResourceType.DATASET,
     });
 

--- a/src/modules/PublicationSearchDialog/PublicationSearchDialog.tsx
+++ b/src/modules/PublicationSearchDialog/PublicationSearchDialog.tsx
@@ -109,7 +109,7 @@ const PublicationSearchDialog = ({
 
     const { data: datasetData = [], isLoading: isLoadingDatasets } = useGet<
         Dataset[]
-    >(`${apis.datasetsV2Url}?${new URLSearchParams(searchParams)}`, {
+    >(`${apis.datasetsV3Url}?${new URLSearchParams(searchParams)}`, {
         shouldFetch: hasMinimumSearchCharLength(searchParams.title),
     });
 

--- a/src/utils/api.ts
+++ b/src/utils/api.ts
@@ -444,7 +444,7 @@ async function getDataset(
     schemaVersion?: string,
     options?: GetOptions
 ): Promise<Dataset> {
-    const baseUrl = `${apis.datasetsV2UrlIP}/${datasetId}`;
+    const baseUrl = `${apis.datasetsV3UrlIP}/${datasetId}`;
     const params = new URLSearchParams();
 
     if (schemaModel && schemaVersion) {


### PR DESCRIPTION
## Summary
- Points dataset search/fetch calls to the v3 datasets endpoint (`apis.datasetsV3Url`/`datasetsV3UrlIP`) instead of v2: dataset detail page, both `DatasetRelationshipFields` pickers (publications, tools), `EditDataUse`, `AddResourceDialog`, `PublicationSearchDialog`.
- Displays the dataset's GWDM schema version on the dataset detail page's Sources panel.

Split out of fix/GAT-9237 — this was unrelated local work that had ended up on `dev` and was pulled into that branch by accident.

## Test plan
- [ ] Confirm dataset detail page still loads and shows "Schema Version" when `gwdmVersion` is present
- [ ] Confirm dataset pickers (publications, tools, data use, add-resource dialog) still search/select datasets correctly against the v3 endpoint

🤖 Generated with [Claude Code](https://claude.com/claude-code)