### PR TITLE
feat(GAT-9193): Update sign-in modal design

### DIFF
--- a/src/config/messages/en.json
+++ b/src/config/messages/en.json
@@ -1981,13 +1981,19 @@
                 "title": "Sign in or create an account",
                 "signIn": "Sign in with username",
                 "socialProviders": {
-                    "azure": "Azure",
+                    "azure": "Microsoft",
                     "linkedIn": "LinkedIn",
                     "google": "Google",
-                    "openAthens": "institution"
+                    "openAthens": "your institute"
                 },
                 "intro1": "Anyone can search and view datasets, collections and other resources with or without an account. Creating an account allows you to:",
-                "intro2": "You can sign in or create a Gateway account with any of the organisations below, simply click your preferred organisation and follow the on-screen instructions:",
+                "bulletEnquiries": "Submit data access enquiries and applications",
+                "bulletCollections": "Add your own collections, papers and other resources",
+                "bulletCohortDiscovery": "Use the Cohort Discovery advanced search tool",
+                "preferredAccessTitle": "<bold>Preferred Access</bold> (including <bold>Cohort Discovery</bold>)",
+                "preferredAccessText": "You can sign in using one of the supported sign-in options below to access the full platform experience, including Cohort Discovery and all associated features.",
+                "notPreferredAccessTitle": "<bold>Not Preferred Access</bold>",
+                "notPreferredAccessText": "You can sign in using one of the supported sign-in options below to access the core Gateway features but <highlight>excludes Cohort Discovery</highlight> and all associated features.",
                 "suggestAnother": "Suggest another identity provider",
                 "selectAnother": "Select another provider"
             },

--- a/src/config/theme.ts
+++ b/src/config/theme.ts
@@ -144,6 +144,7 @@ export const colors = {
     purple500: "#475da7",
     purple700: "#384B91",
     purple900: "#29235C",
+    teal700: "#017397",
     darkGreen50: "#DEF0F0",
     darkGreen100: "#ADDAD9",
     yellow400: "#F4E751",

--- a/src/consts/customIcons.tsx
+++ b/src/consts/customIcons.tsx
@@ -816,7 +816,24 @@ const EmailIcon = createSvgIcon(
     "EmailIcon"
 );
 
+const InstituteIcon = createSvgIcon(
+    <svg
+        width="20"
+        height="20"
+        viewBox="0 0 20 20"
+        fill="none"
+        xmlns="http://www.w3.org/2000/svg">
+        <path
+            d="M2.6364 15.795V10.9093M7.5455 15.795V10.9093M12.4546 15.795V10.9093M17.3636 15.795V10.9093M1 18.2378H19M10 1.13785L1 6.02356V8.46642H19V6.02356L10 1.13785Z"
+            stroke="currentColor"
+            strokeWidth="2"
+        />
+    </svg>,
+    "InstituteIcon"
+);
+
 export {
+    InstituteIcon,
     BookmarksOutlinedIcon,
     BookmarkBorderIcon,
     SpeechBubbleIcon,

--- a/src/modules/ProviderLinks/ProviderLinks.test.tsx
+++ b/src/modules/ProviderLinks/ProviderLinks.test.tsx
@@ -15,8 +15,24 @@ describe("ProviderLinks", () => {
             <ProviderLinks showInstitution={() => console.log("show inst")} />
         );
 
-        expect(screen.getByAltText("Azure")).toBeInTheDocument();
+        expect(screen.getByAltText("Microsoft")).toBeInTheDocument();
         expect(screen.getByAltText("LinkedIn")).toBeInTheDocument();
         expect(screen.getByAltText("Google")).toBeInTheDocument();
+        expect(screen.getByTitle("your institute")).toBeInTheDocument();
+    });
+
+    it("should render preferred and not preferred access sections", async () => {
+        render(
+            <ProviderLinks showInstitution={() => console.log("show inst")} />
+        );
+
+        expect(
+            screen.getByRole("heading", {
+                name: /Preferred Access \(including Cohort Discovery/,
+            })
+        ).toBeInTheDocument();
+        expect(
+            screen.getByRole("heading", { name: "Not Preferred Access" })
+        ).toBeInTheDocument();
     });
 });

--- a/src/modules/ProviderLinks/ProviderLinks.tsx
+++ b/src/modules/ProviderLinks/ProviderLinks.tsx
@@ -1,3 +1,5 @@
+import { SvgIconComponent } from "@mui/icons-material";
+import { Typography } from "@mui/material";
 import { useTranslations } from "next-intl";
 import Image from "next/image";
 import { useRouter } from "next/navigation";
@@ -5,11 +7,20 @@ import Box from "@/components/Box";
 import Button from "@/components/Button";
 import apis from "@/config/apis";
 import { colors } from "@/config/theme";
+import { InstituteIcon } from "@/consts/customIcons";
 
 interface LinkItem {
     label: string;
     href?: string;
-    image: string;
+    image?: string;
+    Icon?: SvgIconComponent;
+}
+
+interface ProviderGroup {
+    key: string;
+    title: React.ReactNode;
+    description: React.ReactNode;
+    links: LinkItem[];
 }
 
 interface ProviderLinksProps {
@@ -17,11 +28,23 @@ interface ProviderLinksProps {
     redirectPath?: string;
 }
 
+const highlight = (chunks: React.ReactNode) => (
+    <Box component="span" sx={{ color: colors.red700, p: 0 }}>
+        {chunks}
+    </Box>
+);
+
+const bold = (chunks: React.ReactNode) => (
+    <Box component="span" sx={{ fontWeight: 600, p: 0 }}>
+        {chunks}
+    </Box>
+);
+
 const ProviderLinks = ({
     showInstitution,
     redirectPath,
 }: ProviderLinksProps) => {
-    const t = useTranslations("modules");
+    const t = useTranslations("modules.dialogs.ProvidersDialog");
     const { push } = useRouter();
 
     let effectiveRedirectPath = "";
@@ -30,76 +53,112 @@ const ProviderLinks = ({
         effectiveRedirectPath = `?redirect=${encodeURIComponent(redirectPath)}`;
     }
 
-    const providerLinks: LinkItem[] = [
+    const providerGroups: ProviderGroup[] = [
         {
-            label: t("dialogs.ProvidersDialog.socialProviders.google"),
-            href: `${apis.authGoogleV1Url}${effectiveRedirectPath}`,
-            image: "google-logo.png",
+            key: "preferred",
+            title: t.rich("preferredAccessTitle", { bold }),
+            description: t("preferredAccessText"),
+            links: [
+                {
+                    label: t("socialProviders.openAthens"),
+                    Icon: InstituteIcon,
+                },
+                {
+                    label: t("socialProviders.azure"),
+                    href: `${apis.authAzureV1Url}${effectiveRedirectPath}`,
+                    image: "microsoft-logo.png",
+                },
+            ],
         },
         {
-            label: t("dialogs.ProvidersDialog.socialProviders.openAthens"),
-            image: "openathens-logo.png",
-        },
-        {
-            label: t("dialogs.ProvidersDialog.socialProviders.linkedIn"),
-            image: "linkedIn-logo.png",
-            href: `${apis.authLinkedinV1Url}${effectiveRedirectPath}`,
-        },
-        {
-            label: t("dialogs.ProvidersDialog.socialProviders.azure"),
-            href: `${apis.authAzureV1Url}${effectiveRedirectPath}`,
-            image: "microsoft-logo.png",
+            key: "notPreferred",
+            title: t.rich("notPreferredAccessTitle", { bold }),
+            description: t.rich("notPreferredAccessText", { highlight }),
+            links: [
+                {
+                    label: t("socialProviders.google"),
+                    href: `${apis.authGoogleV1Url}${effectiveRedirectPath}`,
+                    image: "google-logo.png",
+                },
+                {
+                    label: t("socialProviders.linkedIn"),
+                    href: `${apis.authLinkedinV1Url}${effectiveRedirectPath}`,
+                    image: "linkedIn-logo.png",
+                },
+            ],
         },
     ];
+
     return (
-        <Box
-            sx={{
-                padding: 0,
-                display: "grid",
-                columnGap: 3,
-                rowGap: 2,
-                gridTemplateColumns: {
-                    mobile: "repeat(1, 1fr)",
-                    tablet: "repeat(2, 1fr)",
-                },
-                marginTop: 3,
-                marginBottom: 3,
-            }}>
-            {providerLinks.map(link => {
-                return (
-                    <Button
-                        key={link.image}
-                        onClick={() =>
-                            link.href ? push(link.href) : showInstitution()
-                        }
+        <Box sx={{ padding: 0 }}>
+            {providerGroups.map(group => (
+                <Box
+                    key={group.key}
+                    sx={{ padding: 0, marginTop: 3, marginBottom: 3 }}>
+                    <Typography variant="h4" sx={{ marginBottom: 1 }}>
+                        {group.title}
+                    </Typography>
+                    <Typography variant="body2" sx={{ marginBottom: 2 }}>
+                        {group.description}
+                    </Typography>
+                    <Box
                         sx={{
-                            p: 0,
-                            color: colors.grey700,
-                            display: "block",
-                            lineHeight: "inherit",
-                            fontWeight: "inherit",
-                        }}
-                        variant="text">
-                        <Box
-                            component="span"
-                            sx={{
-                                border: `solid 1px ${colors.grey400}`,
-                                borderRadius: 1,
-                                padding: 1,
-                                display: "flex",
-                                gap: 2,
-                            }}>
-                            <Image
-                                src={`/images/logos/${link.image}`}
-                                alt={link.label}
-                                width="20"
-                                height="20"
-                            />
-                            Sign in with {link.label}
-                        </Box>
-                    </Button>
-                );
-            })}
+                            padding: 0,
+                            display: "grid",
+                            columnGap: 3,
+                            rowGap: 2,
+                            gridTemplateColumns: {
+                                mobile: "repeat(1, 1fr)",
+                                tablet: "repeat(2, 1fr)",
+                            },
+                        }}>
+                        {group.links.map(link => (
+                            <Button
+                                key={link.label}
+                                onClick={() =>
+                                    link.href
+                                        ? push(link.href)
+                                        : showInstitution()
+                                }
+                                sx={{
+                                    p: 0,
+                                    color: colors.grey700,
+                                    display: "block",
+                                    lineHeight: "inherit",
+                                    fontWeight: "inherit",
+                                }}
+                                variant="text">
+                                <Box
+                                    component="span"
+                                    sx={{
+                                        border: `solid 1px ${colors.grey400}`,
+                                        borderRadius: 1,
+                                        padding: 1,
+                                        display: "flex",
+                                        alignItems: "center",
+                                        gap: 2,
+                                    }}>
+                                    {link.Icon ? (
+                                        <link.Icon
+                                            fontSize="small"
+                                            titleAccess={link.label}
+                                            sx={{ color: colors.teal700 }}
+                                        />
+                                    ) : (
+                                        <Image
+                                            src={`/images/logos/${link.image}`}
+                                            alt={link.label}
+                                            width="20"
+                                            height="20"
+                                        />
+                                    )}
+                                    Sign in with {link.label}
+                                </Box>
+                            </Button>
+                        ))}
+                    </Box>
+                </Box>
+            ))}
         </Box>
     );
 };

--- a/src/modules/ProviderLinks/__snapshots__/ProviderLinks.test.tsx.snap
+++ b/src/modules/ProviderLinks/__snapshots__/ProviderLinks.test.tsx.snap
@@ -3,100 +3,166 @@
 exports[`ProviderLinks should match snapshot 1`] = `
 <div>
   <div
-    class="MuiBox-root mui-style-1uxy81i"
+    class="MuiBox-root mui-style-old1by"
   >
-    <button
-      class="MuiButtonBase-root MuiButton-root MuiButton-text MuiButton-textPrimary MuiButton-sizeMedium MuiButton-textSizeMedium MuiButton-colorPrimary MuiButton-root MuiButton-text MuiButton-textPrimary MuiButton-sizeMedium MuiButton-textSizeMedium MuiButton-colorPrimary mui-style-14ilbmx-MuiButtonBase-root-MuiButton-root"
-      tabindex="0"
-      type="button"
+    <div
+      class="MuiBox-root mui-style-hp0c5l"
     >
-      <span
-        class="MuiBox-root mui-style-16zk172"
+      <h4
+        class="MuiTypography-root MuiTypography-h4 mui-style-1hry5sm-MuiTypography-root"
       >
-        <img
-          alt="Google"
-          data-nimg="1"
-          decoding="async"
-          height="20"
-          loading="lazy"
-          src="/_next/image?url=%2Fimages%2Flogos%2Fgoogle-logo.png&w=48&q=75"
-          srcset="/_next/image?url=%2Fimages%2Flogos%2Fgoogle-logo.png&w=32&q=75 1x, /_next/image?url=%2Fimages%2Flogos%2Fgoogle-logo.png&w=48&q=75 2x"
-          style="color: transparent;"
-          width="20"
-        />
-        Sign in with 
-        Google
-      </span>
-    </button>
-    <button
-      class="MuiButtonBase-root MuiButton-root MuiButton-text MuiButton-textPrimary MuiButton-sizeMedium MuiButton-textSizeMedium MuiButton-colorPrimary MuiButton-root MuiButton-text MuiButton-textPrimary MuiButton-sizeMedium MuiButton-textSizeMedium MuiButton-colorPrimary mui-style-14ilbmx-MuiButtonBase-root-MuiButton-root"
-      tabindex="0"
-      type="button"
+        <span
+          class="MuiBox-root mui-style-1w7ybou"
+        >
+          Preferred Access
+        </span>
+         (including 
+        <span
+          class="MuiBox-root mui-style-1w7ybou"
+        >
+          Cohort Discovery
+        </span>
+        )
+      </h4>
+      <p
+        class="MuiTypography-root MuiTypography-body2 mui-style-1hw0f9c-MuiTypography-root"
+      >
+        You can sign in using one of the supported sign-in options below to access the full platform experience, including Cohort Discovery and all associated features.
+      </p>
+      <div
+        class="MuiBox-root mui-style-1k5ajcd"
+      >
+        <button
+          class="MuiButtonBase-root MuiButton-root MuiButton-text MuiButton-textPrimary MuiButton-sizeMedium MuiButton-textSizeMedium MuiButton-colorPrimary MuiButton-root MuiButton-text MuiButton-textPrimary MuiButton-sizeMedium MuiButton-textSizeMedium MuiButton-colorPrimary mui-style-14ilbmx-MuiButtonBase-root-MuiButton-root"
+          tabindex="0"
+          type="button"
+        >
+          <span
+            class="MuiBox-root mui-style-1tkaydf"
+          >
+            <svg
+              class="MuiSvgIcon-root MuiSvgIcon-fontSizeSmall mui-style-wr9cpa-MuiSvgIcon-root"
+              data-testid="InstituteIconIcon"
+              fill="none"
+              focusable="false"
+              height="20"
+              role="img"
+              viewBox="0 0 20 20"
+              width="20"
+              xmlns="http://www.w3.org/2000/svg"
+            >
+              <path
+                d="M2.6364 15.795V10.9093M7.5455 15.795V10.9093M12.4546 15.795V10.9093M17.3636 15.795V10.9093M1 18.2378H19M10 1.13785L1 6.02356V8.46642H19V6.02356L10 1.13785Z"
+                stroke="currentColor"
+                stroke-width="2"
+              />
+              <title>
+                your institute
+              </title>
+            </svg>
+            Sign in with 
+            your institute
+          </span>
+        </button>
+        <button
+          class="MuiButtonBase-root MuiButton-root MuiButton-text MuiButton-textPrimary MuiButton-sizeMedium MuiButton-textSizeMedium MuiButton-colorPrimary MuiButton-root MuiButton-text MuiButton-textPrimary MuiButton-sizeMedium MuiButton-textSizeMedium MuiButton-colorPrimary mui-style-14ilbmx-MuiButtonBase-root-MuiButton-root"
+          tabindex="0"
+          type="button"
+        >
+          <span
+            class="MuiBox-root mui-style-1tkaydf"
+          >
+            <img
+              alt="Microsoft"
+              data-nimg="1"
+              decoding="async"
+              height="20"
+              loading="lazy"
+              src="/_next/image?url=%2Fimages%2Flogos%2Fmicrosoft-logo.png&w=48&q=75"
+              srcset="/_next/image?url=%2Fimages%2Flogos%2Fmicrosoft-logo.png&w=32&q=75 1x, /_next/image?url=%2Fimages%2Flogos%2Fmicrosoft-logo.png&w=48&q=75 2x"
+              style="color: transparent;"
+              width="20"
+            />
+            Sign in with 
+            Microsoft
+          </span>
+        </button>
+      </div>
+    </div>
+    <div
+      class="MuiBox-root mui-style-hp0c5l"
     >
-      <span
-        class="MuiBox-root mui-style-16zk172"
+      <h4
+        class="MuiTypography-root MuiTypography-h4 mui-style-1hry5sm-MuiTypography-root"
       >
-        <img
-          alt="institution"
-          data-nimg="1"
-          decoding="async"
-          height="20"
-          loading="lazy"
-          src="/_next/image?url=%2Fimages%2Flogos%2Fopenathens-logo.png&w=48&q=75"
-          srcset="/_next/image?url=%2Fimages%2Flogos%2Fopenathens-logo.png&w=32&q=75 1x, /_next/image?url=%2Fimages%2Flogos%2Fopenathens-logo.png&w=48&q=75 2x"
-          style="color: transparent;"
-          width="20"
-        />
-        Sign in with 
-        institution
-      </span>
-    </button>
-    <button
-      class="MuiButtonBase-root MuiButton-root MuiButton-text MuiButton-textPrimary MuiButton-sizeMedium MuiButton-textSizeMedium MuiButton-colorPrimary MuiButton-root MuiButton-text MuiButton-textPrimary MuiButton-sizeMedium MuiButton-textSizeMedium MuiButton-colorPrimary mui-style-14ilbmx-MuiButtonBase-root-MuiButton-root"
-      tabindex="0"
-      type="button"
-    >
-      <span
-        class="MuiBox-root mui-style-16zk172"
+        <span
+          class="MuiBox-root mui-style-1w7ybou"
+        >
+          Not Preferred Access
+        </span>
+      </h4>
+      <p
+        class="MuiTypography-root MuiTypography-body2 mui-style-1hw0f9c-MuiTypography-root"
       >
-        <img
-          alt="LinkedIn"
-          data-nimg="1"
-          decoding="async"
-          height="20"
-          loading="lazy"
-          src="/_next/image?url=%2Fimages%2Flogos%2FlinkedIn-logo.png&w=48&q=75"
-          srcset="/_next/image?url=%2Fimages%2Flogos%2FlinkedIn-logo.png&w=32&q=75 1x, /_next/image?url=%2Fimages%2Flogos%2FlinkedIn-logo.png&w=48&q=75 2x"
-          style="color: transparent;"
-          width="20"
-        />
-        Sign in with 
-        LinkedIn
-      </span>
-    </button>
-    <button
-      class="MuiButtonBase-root MuiButton-root MuiButton-text MuiButton-textPrimary MuiButton-sizeMedium MuiButton-textSizeMedium MuiButton-colorPrimary MuiButton-root MuiButton-text MuiButton-textPrimary MuiButton-sizeMedium MuiButton-textSizeMedium MuiButton-colorPrimary mui-style-14ilbmx-MuiButtonBase-root-MuiButton-root"
-      tabindex="0"
-      type="button"
-    >
-      <span
-        class="MuiBox-root mui-style-16zk172"
+        You can sign in using one of the supported sign-in options below to access the core Gateway features but 
+        <span
+          class="MuiBox-root mui-style-j9gea7"
+        >
+          excludes Cohort Discovery
+        </span>
+         and all associated features.
+      </p>
+      <div
+        class="MuiBox-root mui-style-1k5ajcd"
       >
-        <img
-          alt="Azure"
-          data-nimg="1"
-          decoding="async"
-          height="20"
-          loading="lazy"
-          src="/_next/image?url=%2Fimages%2Flogos%2Fmicrosoft-logo.png&w=48&q=75"
-          srcset="/_next/image?url=%2Fimages%2Flogos%2Fmicrosoft-logo.png&w=32&q=75 1x, /_next/image?url=%2Fimages%2Flogos%2Fmicrosoft-logo.png&w=48&q=75 2x"
-          style="color: transparent;"
-          width="20"
-        />
-        Sign in with 
-        Azure
-      </span>
-    </button>
+        <button
+          class="MuiButtonBase-root MuiButton-root MuiButton-text MuiButton-textPrimary MuiButton-sizeMedium MuiButton-textSizeMedium MuiButton-colorPrimary MuiButton-root MuiButton-text MuiButton-textPrimary MuiButton-sizeMedium MuiButton-textSizeMedium MuiButton-colorPrimary mui-style-14ilbmx-MuiButtonBase-root-MuiButton-root"
+          tabindex="0"
+          type="button"
+        >
+          <span
+            class="MuiBox-root mui-style-1tkaydf"
+          >
+            <img
+              alt="Google"
+              data-nimg="1"
+              decoding="async"
+              height="20"
+              loading="lazy"
+              src="/_next/image?url=%2Fimages%2Flogos%2Fgoogle-logo.png&w=48&q=75"
+              srcset="/_next/image?url=%2Fimages%2Flogos%2Fgoogle-logo.png&w=32&q=75 1x, /_next/image?url=%2Fimages%2Flogos%2Fgoogle-logo.png&w=48&q=75 2x"
+              style="color: transparent;"
+              width="20"
+            />
+            Sign in with 
+            Google
+          </span>
+        </button>
+        <button
+          class="MuiButtonBase-root MuiButton-root MuiButton-text MuiButton-textPrimary MuiButton-sizeMedium MuiButton-textSizeMedium MuiButton-colorPrimary MuiButton-root MuiButton-text MuiButton-textPrimary MuiButton-sizeMedium MuiButton-textSizeMedium MuiButton-colorPrimary mui-style-14ilbmx-MuiButtonBase-root-MuiButton-root"
+          tabindex="0"
+          type="button"
+        >
+          <span
+            class="MuiBox-root mui-style-1tkaydf"
+          >
+            <img
+              alt="LinkedIn"
+              data-nimg="1"
+              decoding="async"
+              height="20"
+              loading="lazy"
+              src="/_next/image?url=%2Fimages%2Flogos%2FlinkedIn-logo.png&w=48&q=75"
+              srcset="/_next/image?url=%2Fimages%2Flogos%2FlinkedIn-logo.png&w=32&q=75 1x, /_next/image?url=%2Fimages%2Flogos%2FlinkedIn-logo.png&w=48&q=75 2x"
+              style="color: transparent;"
+              width="20"
+            />
+            Sign in with 
+            LinkedIn
+          </span>
+        </button>
+      </div>
+    </div>
   </div>
 </div>
 `;

--- a/src/modules/ProvidersDialog/ProvidersDialog.test.tsx
+++ b/src/modules/ProvidersDialog/ProvidersDialog.test.tsx
@@ -20,7 +20,7 @@ describe("ProvidersDialog", () => {
     });
     it("should render azure link", async () => {
         render(<ProvidersDialog />);
-        const azureButton = screen.getByText("Sign in with Azure", {
+        const azureButton = screen.getByText("Sign in with Microsoft", {
             exact: false,
         });
         expect(azureButton).toBeInTheDocument();

--- a/src/modules/ProvidersDialog/ProvidersDialog.tsx
+++ b/src/modules/ProvidersDialog/ProvidersDialog.tsx
@@ -45,18 +45,11 @@ const ProvidersDialog = () => {
 
                         <BulletList
                             items={[
-                                {
-                                    label: "Submit data access enquiries and applications",
-                                },
-                                {
-                                    label: "Add your collections and other resources",
-                                },
-                                {
-                                    label: "Use the Cohort Discovery advanced search tool (requires institutional or Azure logins)",
-                                },
+                                { label: t("bulletEnquiries") },
+                                { label: t("bulletCollections") },
+                                { label: t("bulletCohortDiscovery") },
                             ]}
                         />
-                        <p>{t("intro2")}</p>
                         <ProviderLinks
                             showInstitution={() =>
                                 setInstitutionSelectVisible(true)


### PR DESCRIPTION
## Screenshots / videos (if relevant)
<img width="698" height="616" alt="image" src="https://github.com/user-attachments/assets/08471ba8-0bc0-488c-b577-d25185b5a292" />

## Describe your changes
Redesigns the "Sign in or create an account" modal (`ProvidersDialog`) so identity providers are split into two clearly-labelled tiers — "Preferred Access (including Cohort Discovery)" (institution + Microsoft) and "Not Preferred Access" (Google + LinkedIn) — each with its own heading and descriptive text so users understand which sign-in methods unlock Cohort Discovery. 

The institution option now uses a dedicated themed `InstituteIcon` and reads "Sign in with your institute", the Microsoft label replaces "Azure", the intro bullet copy is refreshed, and "excludes Cohort Discovery" is highlighted in the theme red. Section headings use rich-text `<bold>` emphasis (weight 600) while keeping "(including …)" at normal weight. Copy is moved into `en.json` translation keys.

## Issue ticket link
https://hdruk.atlassian.net/browse/GAT-9193

## Checklist before requesting a review

- [x] I have performed a self-review of my code
- [x] I have added appropriate unit tests / e2e tests (where relevant)
- [ ] I have created mocks for api endpoints (where appropriate)
- [ ] The interface is responsive (where ticket is relevant)
- [ ] The interface is at least AA (where ticket is relevant)
- [ ] Commits are described as "(chore|fix|feature|test|maintenance): description"
