### PR TITLE
feat(GAT-9190): add History tab to integration detail page

### DIFF
--- a/mocks/data/integration/v1/integration.data.ts
+++ b/mocks/data/integration/v1/integration.data.ts
@@ -5,6 +5,7 @@ import {
     FederationType,
     AuthType,
 } from "@/interfaces/Integration";
+import { IntegrationHistory } from "@/interfaces/IntegrationHistory";
 
 const generateIntegrationV1 = (data = {}): Integration => {
     return {
@@ -50,14 +51,46 @@ const generateIntegrationsV1 = (n = 3): Integration[] => {
     return Array.from({ length: n }).map(() => generateIntegrationV1());
 };
 
+const generateIntegrationHistoryV1 = (data = {}): IntegrationHistory => {
+    const status = faker.helpers.arrayElement([
+        "success",
+        "failed",
+    ]) as IntegrationHistory["status"];
+
+    return {
+        job_uuid: faker.datatype.uuid(),
+        started_at: faker.date
+            .between("2020-01-01T00:00:00.000Z", "2020-03-01T00:00:00.000Z")
+            .toISOString(),
+        finished_at: faker.date
+            .between("2020-01-01T00:00:00.000Z", "2020-03-01T00:00:00.000Z")
+            .toISOString(),
+        status,
+        message: status === "failed" ? faker.lorem.sentence() : null,
+        failed_datasets:
+            status === "failed"
+                ? [{ pid: faker.datatype.uuid(), message: faker.lorem.sentence() }]
+                : [],
+        ...data,
+    };
+};
+
+const generateIntegrationHistoriesV1 = (n = 3): IntegrationHistory[] => {
+    return Array.from({ length: n }).map(() => generateIntegrationHistoryV1());
+};
+
 const integrationV1 = generateIntegrationV1();
 const federationTestResponseV1 = generateFederationTestResponseV1();
 const integrationsV1 = generateIntegrationsV1();
+const integrationHistoriesV1 = generateIntegrationHistoriesV1();
 
 export {
     generateIntegrationsV1,
     generateIntegrationV1,
+    generateIntegrationHistoryV1,
+    generateIntegrationHistoriesV1,
     integrationsV1,
     integrationV1,
+    integrationHistoriesV1,
     federationTestResponseV1,
 };

--- a/mocks/handlers/integration/v1/integration.handler.ts
+++ b/mocks/handlers/integration/v1/integration.handler.ts
@@ -1,10 +1,12 @@
 import { rest } from "msw";
 import { FederationTestResponse } from "@/interfaces/Federation";
 import { Integration } from "@/interfaces/Integration";
+import { IntegrationHistory } from "@/interfaces/IntegrationHistory";
 import { PaginationType } from "@/interfaces/Pagination";
 import apis from "@/config/apis";
 import {
     federationTestResponseV1,
+    integrationHistoriesV1,
     integrationV1,
     integrationsV1,
 } from "@/mocks/data/integration";
@@ -150,10 +152,52 @@ const getFederationRunV1 = ({
     );
 };
 
+interface getFederationHistoryProps {
+    data?: IntegrationHistory[];
+    teamId?: number;
+    federationId?: number;
+    status?: number;
+    pagination?: Omit<PaginationType<IntegrationHistory>, "list">;
+}
+
+const getFederationHistoryV1 = ({
+    data = integrationHistoriesV1,
+    teamId = teamV1.id,
+    federationId = integrationV1.id,
+    status = 200,
+    pagination,
+}: getFederationHistoryProps = {}) => {
+    return rest.get(
+        `${apis.teamsV1Url}/${teamId}/federations/${federationId}/history`,
+        (req, res, ctx) => {
+            if (status !== 200) {
+                return res(
+                    ctx.status(status),
+                    ctx.json(`Request failed with status code ${status}`)
+                );
+            }
+            if (pagination) {
+                return res(
+                    ctx.status(status),
+                    ctx.json<PaginationType<IntegrationHistory>>({
+                        list: data,
+                        ...pagination,
+                    })
+                );
+            }
+            return res(
+                ctx.status(status),
+                ctx.json<{ data: IntegrationHistory[] }>({ data })
+            );
+        }
+    );
+};
+
 export {
     getIntegrationV1,
     getIntegrationsV1,
     postIntegrationV1,
     postFederationsTestV1,
     getFederationRunV1,
+    getFederationHistoryV1,
 };

--- a/src/app/[locale]/account/team/[teamId]/(withLeftNav)/integrations/integration/list/[intId]/components/IntegrationHistoryTable/IntegrationHistoryTable.test.tsx
+++ b/src/app/[locale]/account/team/[teamId]/(withLeftNav)/integrations/integration/list/[intId]/components/IntegrationHistoryTable/IntegrationHistoryTable.test.tsx
@@ -1,0 +1,340 @@
+import { rest } from "msw";
+import mockRouter from "next-router-mock";
+import { IntegrationHistory } from "@/interfaces/IntegrationHistory";
+import { render, screen, waitFor, fireEvent, within } from "@/utils/testUtils";
+import { integrationV1 } from "@/mocks/data/integration";
+import { teamV1 } from "@/mocks/data/team";
+import { getFederationHistoryV1 } from "@/mocks/handlers/integration";
+import { server } from "@/mocks/server";
+import apis from "@/config/apis";
+import { formatDate } from "@/utils/date";
+import IntegrationHistoryTable from "./IntegrationHistoryTable";
+
+const getSidebar = () => screen.getByTestId("integration-history-detail");
+const dt = (date: string) => formatDate(date, "DD MMM YYYY HH:mm") as string;
+
+describe("IntegrationHistoryTable", () => {
+    mockRouter.query = {
+        teamId: teamV1.id.toString(),
+        intId: integrationV1.id.toString(),
+    };
+
+    it("renders a success row without a message or failed dataset details", async () => {
+        const successRow: IntegrationHistory = {
+            job_uuid: "1",
+            started_at: "2026-07-24 08:18:34",
+            finished_at: "2026-07-24 08:18:34",
+            status: "success",
+            message: null,
+            failed_datasets: [],
+        };
+        server.use(
+            getFederationHistoryV1({
+                data: [successRow],
+                pagination: { lastPage: 1, total: 1, from: 1, to: 1, currentPage: 1 },
+            })
+        );
+
+        render(<IntegrationHistoryTable />);
+
+        await waitFor(() => {
+            expect(screen.getByTestId("CheckCircleIcon")).toBeInTheDocument();
+        });
+        expect(screen.queryByTestId("CancelIcon")).not.toBeInTheDocument();
+    });
+
+    it("renders a failed row with its message and each failed dataset", async () => {
+        const failedRow: IntegrationHistory = {
+            job_uuid: "",
+            started_at: "2026-07-24 08:42:59",
+            finished_at: "2026-07-24 08:42:59",
+            status: "failed",
+            message: "GWDM/2.0: must have required property 'gatewayId'",
+            failed_datasets: [
+                {
+                    pid: "mock-dataset-bad",
+                    message: "GWDM/2.0: must have required property 'gatewayId'",
+                },
+            ],
+        };
+        server.use(
+            getFederationHistoryV1({
+                data: [failedRow],
+                pagination: { lastPage: 1, total: 1, from: 1, to: 1, currentPage: 1 },
+            })
+        );
+
+        render(<IntegrationHistoryTable />);
+
+        await waitFor(() => {
+            expect(screen.getByTestId("CancelIcon")).toBeInTheDocument();
+        });
+        expect(
+            screen.getByText("GWDM/2.0: must have required property 'gatewayId'")
+        ).toBeInTheDocument();
+        expect(screen.getByText(/mock-dataset-bad/)).toBeInTheDocument();
+    });
+
+    it("renders an empty state when there is no history", async () => {
+        server.use(
+            getFederationHistoryV1({
+                data: [],
+                pagination: { lastPage: 1, total: 0, from: 0, to: 0, currentPage: 1 },
+            })
+        );
+
+        render(<IntegrationHistoryTable />);
+
+        await waitFor(() => {
+            expect(
+                screen.getByText(/no history found for this integration/i)
+            ).toBeInTheDocument();
+        });
+    });
+
+    it("requests the next page when pagination is clicked", async () => {
+        const pageOneRow: IntegrationHistory = {
+            job_uuid: "1",
+            started_at: "2026-07-24 08:18:34",
+            finished_at: "2026-07-24 08:19:00",
+            status: "success",
+            message: null,
+            failed_datasets: [],
+        };
+        const pageTwoRow: IntegrationHistory = {
+            job_uuid: "2",
+            started_at: "2026-07-23 08:18:34",
+            finished_at: "2026-07-23 08:19:00",
+            status: "success",
+            message: null,
+            failed_datasets: [],
+        };
+
+        server.use(
+            rest.get(
+                `${apis.teamsV1Url}/${teamV1.id}/federations/${integrationV1.id}/history`,
+                (req, res, ctx) => {
+                    const page = req.url.searchParams.get("page") || "1";
+                    const list = page === "2" ? [pageTwoRow] : [pageOneRow];
+                    return res(
+                        ctx.status(200),
+                        ctx.json({
+                            list,
+                            lastPage: 2,
+                            total: 2,
+                            from: 1,
+                            to: 1,
+                            currentPage: Number(page),
+                        })
+                    );
+                }
+            )
+        );
+
+        render(<IntegrationHistoryTable />);
+
+        await waitFor(() => {
+            expect(screen.getByText(dt(pageOneRow.started_at))).toBeInTheDocument();
+        });
+
+        fireEvent.click(screen.getByRole("button", { name: /go to page 2/i }));
+
+        await waitFor(() => {
+            expect(screen.getByText(dt(pageTwoRow.started_at))).toBeInTheDocument();
+        });
+        expect(
+            screen.queryByText(dt(pageOneRow.started_at))
+        ).not.toBeInTheDocument();
+    });
+
+    it("shows a placeholder in the sidebar before any execution is selected", async () => {
+        const successRow: IntegrationHistory = {
+            job_uuid: "77",
+            started_at: "2026-07-24 08:18:34",
+            finished_at: "2026-07-24 08:19:00",
+            status: "success",
+            message: null,
+            failed_datasets: [],
+        };
+        server.use(
+            getFederationHistoryV1({
+                data: [successRow],
+                pagination: { lastPage: 1, total: 1, from: 1, to: 1, currentPage: 1 },
+            })
+        );
+
+        render(<IntegrationHistoryTable />);
+
+        await waitFor(() => {
+            expect(screen.getByText(dt(successRow.started_at))).toBeInTheDocument();
+        });
+        expect(
+            within(getSidebar()).getByText(/select an execution to view details/i)
+        ).toBeInTheDocument();
+    });
+
+    it("shows a success execution's details in the sidebar when its row is clicked", async () => {
+        const successRow: IntegrationHistory = {
+            job_uuid: "77",
+            started_at: "2026-07-24 08:18:34",
+            finished_at: "2026-07-24 08:19:00",
+            status: "success",
+            message: null,
+            failed_datasets: [],
+        };
+        server.use(
+            getFederationHistoryV1({
+                data: [successRow],
+                pagination: { lastPage: 1, total: 1, from: 1, to: 1, currentPage: 1 },
+            })
+        );
+
+        render(<IntegrationHistoryTable />);
+
+        await waitFor(() => {
+            expect(screen.getByText(dt(successRow.started_at))).toBeInTheDocument();
+        });
+        fireEvent.click(screen.getByText(dt(successRow.started_at)));
+
+        const sidebar = within(getSidebar());
+        expect(sidebar.getByText(dt(successRow.started_at))).toBeInTheDocument();
+        expect(sidebar.getByText(/complete/i)).toBeInTheDocument();
+        expect(sidebar.queryByText(/failed datasets/i)).not.toBeInTheDocument();
+    });
+
+    it("shows a failed execution's message and failed datasets in the sidebar when clicked", async () => {
+        const failedRow: IntegrationHistory = {
+            job_uuid: "",
+            started_at: "2026-07-24 08:42:59",
+            finished_at: "2026-07-24 08:43:00",
+            status: "failed",
+            message: "GWDM/2.0: must have required property 'gatewayId'",
+            failed_datasets: [
+                {
+                    pid: "mock-dataset-bad",
+                    message: "GWDM/2.0: must have required property 'gatewayId'",
+                },
+            ],
+        };
+        server.use(
+            getFederationHistoryV1({
+                data: [failedRow],
+                pagination: { lastPage: 1, total: 1, from: 1, to: 1, currentPage: 1 },
+            })
+        );
+
+        render(<IntegrationHistoryTable />);
+
+        await waitFor(() => {
+            expect(screen.getByText(dt(failedRow.started_at))).toBeInTheDocument();
+        });
+        fireEvent.click(screen.getByText(dt(failedRow.started_at)));
+
+        const sidebar = within(getSidebar());
+        expect(sidebar.getByText(dt(failedRow.started_at))).toBeInTheDocument();
+        expect(sidebar.getByText("Failed")).toBeInTheDocument();
+        expect(sidebar.getByText(failedRow.message as string)).toBeInTheDocument();
+        expect(sidebar.getByText(/failed datasets/i)).toBeInTheDocument();
+        expect(sidebar.getByText(/mock-dataset-bad/)).toBeInTheDocument();
+    });
+
+    it("swaps the sidebar content when a different row is clicked", async () => {
+        const successRow: IntegrationHistory = {
+            job_uuid: "1",
+            started_at: "2026-07-24 08:18:34",
+            finished_at: "2026-07-24 08:19:00",
+            status: "success",
+            message: null,
+            failed_datasets: [],
+        };
+        const failedRow: IntegrationHistory = {
+            job_uuid: "2",
+            started_at: "2026-07-24 08:42:59",
+            finished_at: "2026-07-24 08:43:00",
+            status: "failed",
+            message: "GWDM/2.0: must have required property 'gatewayId'",
+            failed_datasets: [],
+        };
+        server.use(
+            getFederationHistoryV1({
+                data: [successRow, failedRow],
+                pagination: { lastPage: 1, total: 2, from: 1, to: 2, currentPage: 1 },
+            })
+        );
+
+        render(<IntegrationHistoryTable />);
+
+        await waitFor(() => {
+            expect(screen.getByText(dt(successRow.started_at))).toBeInTheDocument();
+        });
+
+        fireEvent.click(screen.getByText(dt(successRow.started_at)));
+        expect(
+            within(getSidebar()).getByText(dt(successRow.started_at))
+        ).toBeInTheDocument();
+
+        fireEvent.click(screen.getByText(dt(failedRow.started_at)));
+        const sidebar = within(getSidebar());
+        expect(sidebar.getByText(dt(failedRow.started_at))).toBeInTheDocument();
+        expect(sidebar.queryByText(dt(successRow.started_at))).not.toBeInTheDocument();
+    });
+
+    it("resets the sidebar to the placeholder when the page changes", async () => {
+        const pageOneRow: IntegrationHistory = {
+            job_uuid: "1",
+            started_at: "2026-07-24 08:18:34",
+            finished_at: "2026-07-24 08:19:00",
+            status: "success",
+            message: null,
+            failed_datasets: [],
+        };
+        const pageTwoRow: IntegrationHistory = {
+            job_uuid: "2",
+            started_at: "2026-07-24 08:18:34",
+            finished_at: "2026-07-24 08:19:00",
+            status: "success",
+            message: null,
+            failed_datasets: [],
+        };
+
+        server.use(
+            rest.get(
+                `${apis.teamsV1Url}/${teamV1.id}/federations/${integrationV1.id}/history`,
+                (req, res, ctx) => {
+                    const page = req.url.searchParams.get("page") || "1";
+                    const list = page === "2" ? [pageTwoRow] : [pageOneRow];
+                    return res(
+                        ctx.status(200),
+                        ctx.json({
+                            list,
+                            lastPage: 2,
+                            total: 2,
+                            from: 1,
+                            to: 1,
+                            currentPage: Number(page),
+                        })
+                    );
+                }
+            )
+        );
+
+        render(<IntegrationHistoryTable />);
+
+        await waitFor(() => {
+            expect(screen.getByText(dt(pageOneRow.started_at))).toBeInTheDocument();
+        });
+        fireEvent.click(screen.getByText(dt(pageOneRow.started_at)));
+        expect(
+            within(getSidebar()).getByText(dt(pageOneRow.started_at))
+        ).toBeInTheDocument();
+
+        fireEvent.click(screen.getByRole("button", { name: /go to page 2/i }));
+
+        await waitFor(() => {
+            expect(screen.getByText(dt(pageTwoRow.started_at))).toBeInTheDocument();
+        });
+        expect(
+            within(getSidebar()).getByText(/select an execution to view details/i)
+        ).toBeInTheDocument();
+    });
+});

--- a/src/app/[locale]/account/team/[teamId]/(withLeftNav)/integrations/integration/list/[intId]/components/IntegrationHistoryTable/IntegrationHistoryTable.tsx
+++ b/src/app/[locale]/account/team/[teamId]/(withLeftNav)/integrations/integration/list/[intId]/components/IntegrationHistoryTable/IntegrationHistoryTable.tsx
@@ -9,72 +9,180 @@ import {
     TableRow,
     Typography,
 } from "@mui/material";
-import { IntegrationHistory } from "@/interfaces/IntegrationHistory";
+import { useParams } from "next/navigation";
+import {
+    FailedDataset,
+    IntegrationHistory,
+} from "@/interfaces/IntegrationHistory";
 import { PaginationType } from "@/interfaces/Pagination";
 import Box from "@/components/Box";
+import Loading from "@/components/Loading";
 import Pagination from "@/components/Pagination";
+import Paper from "@/components/Paper";
 import TickCrossIcon from "@/components/TickCrossIcon";
+import useGet from "@/hooks/useGet";
+import apis from "@/config/apis";
 import { colors } from "@/config/theme";
+import { formatDate } from "@/utils/date";
+
+const PER_PAGE = 25;
+
+const historyKey = (history: IntegrationHistory) =>
+    `${history.job_uuid}-${history.started_at}`;
+
+interface FailedDatasetDetailsProps {
+    message: string | null;
+    failedDatasets: FailedDataset[];
+    showHeading?: boolean;
+}
+
+const FailedDatasetDetails = ({
+    message,
+    failedDatasets,
+    showHeading,
+}: FailedDatasetDetailsProps) => (
+    <>
+        <Typography color={colors.red600} sx={showHeading ? { mt: 2 } : undefined}>
+            {message}
+        </Typography>
+        {showHeading && failedDatasets.length > 0 && (
+            <Typography sx={{ mt: 2 }}>Failed datasets:</Typography>
+        )}
+        {failedDatasets.map(failedDataset => (
+            <Typography
+                key={failedDataset.pid}
+                color={colors.red600}
+                sx={showHeading ? { mt: 1 } : undefined}>
+                {failedDataset.pid}: {failedDataset.message}
+            </Typography>
+        ))}
+    </>
+);
 
 const IntegrationHistoryTable = () => {
+    const params = useParams<{ teamId: string; intId: string }>();
     const [currentPage, setCurrentPage] = useState(1);
+    const [selectedKey, setSelectedKey] = useState<string | null>(null);
 
-    // Example, put data fetching in here
-    const data: PaginationType<IntegrationHistory> = {
-        lastPage: 1,
-        to: 1,
-        from: 1,
-        currentPage: 1,
-        total: 1,
-        list: [
-            {
-                run_time: "21 September 2025 12:00",
-                success: false,
-                message: "Resource not found",
-            },
-            {
-                run_time: "20 September 2025 17:00",
-                success: true,
-            },
-            {
-                run_time: "19 September 2025 08:15",
-                success: false,
-                message: "Internal server error",
-            },
-        ],
-    };
+    const queryParams = new URLSearchParams({
+        page: currentPage.toString(),
+        per_page: PER_PAGE.toString(),
+    });
 
-    const { lastPage, list } = data;
+    const { data, isLoading } = useGet<PaginationType<IntegrationHistory>>(
+        params?.teamId && params?.intId
+            ? `${apis.teamsV1Url}/${params.teamId}/federations/${params.intId}/history?${queryParams}`
+            : null,
+        { withPagination: true, keepPreviousData: true }
+    );
+
+    const { lastPage, list, total } = data || {};
+
+    if (isLoading && !list) return <Loading />;
+
+    if (!list || total === 0) {
+        return (
+            <Box>
+                <Typography>No history found for this integration.</Typography>
+            </Box>
+        );
+    }
+
+    const selected = list.find(x => historyKey(x) === selectedKey);
 
     const rows = list.map(x => (
-        <TableRow key={x?.message}>
+        <TableRow
+            key={historyKey(x)}
+            onClick={() => setSelectedKey(historyKey(x))}
+            sx={{
+                cursor: "pointer",
+                ...(historyKey(x) === selectedKey && {
+                    backgroundColor: colors.green50,
+                }),
+            }}>
+            <TableCell>{formatDate(x.started_at, "DD MMM YYYY HH:mm")}</TableCell>
+            <TableCell>{formatDate(x.finished_at, "DD MMM YYYY HH:mm")}</TableCell>
             <TableCell>
-                {x.run_time}
-                {!x.success && (
-                    <Typography color={colors.red600}>{x.message}</Typography>
-                )}
+                <TickCrossIcon isTrue={x.status === "success"} />
             </TableCell>
             <TableCell>
-                <TickCrossIcon isTrue={x.success} />
+                {x.status === "failed" && (
+                    <FailedDatasetDetails
+                        message={x.message}
+                        failedDatasets={x.failed_datasets}
+                    />
+                )}
             </TableCell>
         </TableRow>
     ));
 
     return (
-        <Box>
-            <TableContainer sx={{ width: "100%" }}>
-                <Table>
-                    <TableBody>{rows}</TableBody>
-                </Table>
-            </TableContainer>
-            <Pagination
-                isLoading={false}
-                page={currentPage}
-                count={lastPage}
-                onChange={(e: React.ChangeEvent<unknown>, page: number) =>
-                    setCurrentPage(page)
-                }
-            />
+        <Box
+            sx={{
+                p: 0,
+                gap: 1,
+                display: "grid",
+                gridTemplateColumns: "repeat(3, 1fr)",
+            }}>
+            <Paper sx={{ gridColumn: "span 2" }}>
+                <Typography variant="h3" sx={{ mb: 1 }}>
+                    Recent executions
+                </Typography>
+                <TableContainer sx={{ width: "100%" }}>
+                    <Table>
+                        <TableBody>{rows}</TableBody>
+                    </Table>
+                </TableContainer>
+                <Pagination
+                    isLoading={isLoading}
+                    page={currentPage}
+                    count={lastPage}
+                    onChange={(e: React.ChangeEvent<unknown>, page: number) => {
+                        setCurrentPage(page);
+                        setSelectedKey(null);
+                    }}
+                />
+            </Paper>
+            <Box
+                data-testid="integration-history-detail"
+                sx={{
+                    p: 3,
+                    background: colors.grey900,
+                    color: colors.white,
+                }}>
+                {!selected ? (
+                    <Typography sx={{ textAlign: "center" }}>
+                        Select an execution to view details.
+                    </Typography>
+                ) : (
+                    <>
+                        <Typography fontSize={10} color={colors.grey200}>
+                            {formatDate(selected.started_at, "DD MMM YYYY HH:mm")}
+                        </Typography>
+                        <Box
+                            sx={{
+                                p: 0,
+                                display: "flex",
+                                justifyContent: "space-between",
+                                alignItems: "center",
+                            }}>
+                            <Typography>
+                                {selected.status === "success"
+                                    ? "Complete"
+                                    : "Failed"}
+                            </Typography>
+                            <TickCrossIcon isTrue={selected.status === "success"} />
+                        </Box>
+                        {selected.status === "failed" && (
+                            <FailedDatasetDetails
+                                message={selected.message}
+                                failedDatasets={selected.failed_datasets}
+                                showHeading
+                            />
+                        )}
+                    </>
+                )}
+            </Box>
         </Box>
     );
 };

--- a/src/app/[locale]/account/team/[teamId]/(withLeftNav)/integrations/integration/list/[intId]/components/IntegrationTabs/IntegrationTabs.test.tsx
+++ b/src/app/[locale]/account/team/[teamId]/(withLeftNav)/integrations/integration/list/[intId]/components/IntegrationTabs/IntegrationTabs.test.tsx
@@ -1,0 +1,35 @@
+import mockRouter from "next-router-mock";
+import { render, screen } from "@/utils/testUtils";
+import IntegrationTabs from "./IntegrationTabs";
+
+jest.mock("../EditIntegrationForm", () => ({
+    __esModule: true,
+    default: () => <div>Configuration content</div>,
+}));
+
+jest.mock("../IntegrationHistoryTable", () => ({
+    __esModule: true,
+    default: () => <div>History content</div>,
+}));
+
+describe("IntegrationTabs", () => {
+    it("shows the Configuration tab content by default", () => {
+        mockRouter.query = { teamId: "1", intId: "2" };
+
+        render(<IntegrationTabs />);
+
+        expect(screen.getByText("Configuration content")).toBeInTheDocument();
+        expect(screen.queryByText("History content")).not.toBeInTheDocument();
+    });
+
+    it("shows the History tab content when ?tab=history is set", () => {
+        mockRouter.query = { teamId: "1", intId: "2", tab: "history" };
+
+        render(<IntegrationTabs />);
+
+        expect(screen.getByText("History content")).toBeInTheDocument();
+        expect(
+            screen.queryByText("Configuration content")
+        ).not.toBeInTheDocument();
+    });
+});

--- a/src/app/[locale]/account/team/[teamId]/(withLeftNav)/integrations/integration/list/[intId]/components/IntegrationTabs/IntegrationTabs.tsx
+++ b/src/app/[locale]/account/team/[teamId]/(withLeftNav)/integrations/integration/list/[intId]/components/IntegrationTabs/IntegrationTabs.tsx
@@ -1,0 +1,30 @@
+"use client";
+
+import Tabs from "@/components/Tabs";
+import EditIntegrationForm from "../EditIntegrationForm";
+import IntegrationHistoryTable from "../IntegrationHistoryTable";
+
+const integrationTabs = [
+    {
+        label: "Configuration",
+        value: "configuration",
+        content: <EditIntegrationForm />,
+    },
+    {
+        label: "History",
+        value: "history",
+        content: <IntegrationHistoryTable />,
+    },
+];
+
+const IntegrationTabs = () => {
+    return (
+        <Tabs
+            tabs={integrationTabs}
+            tabBoxSx={{ padding: 0 }}
+            rootBoxSx={{ padding: 0 }}
+        />
+    );
+};
+
+export default IntegrationTabs;

--- a/src/app/[locale]/account/team/[teamId]/(withLeftNav)/integrations/integration/list/[intId]/components/IntegrationTabs/index.tsx
+++ b/src/app/[locale]/account/team/[teamId]/(withLeftNav)/integrations/integration/list/[intId]/components/IntegrationTabs/index.tsx
@@ -1,0 +1,3 @@
+import IntegrationTabs from "./IntegrationTabs";
+
+export default IntegrationTabs;

--- a/src/app/[locale]/account/team/[teamId]/(withLeftNav)/integrations/integration/list/[intId]/page.tsx
+++ b/src/app/[locale]/account/team/[teamId]/(withLeftNav)/integrations/integration/list/[intId]/page.tsx
@@ -8,7 +8,7 @@ import { getTeam, getUser } from "@/utils/api";
 import metaData, { noFollowRobots } from "@/utils/metadata";
 import { getPermissions } from "@/utils/permissions";
 import { getTeamUser } from "@/utils/user";
-import EditIntegrationForm from "./components/EditIntegrationForm";
+import IntegrationTabs from "./components/IntegrationTabs";
 
 export const metadata = metaData(
     {
@@ -45,7 +45,7 @@ export default async function TeamEditIntegrationPage({
                     <Typography>{t("helper")}</Typography>
                 </Box>
             </Paper>
-            <EditIntegrationForm />
+            <IntegrationTabs />
         </ProtectedAccountRoute>
     );
 }

--- a/src/config/forms/integration.tsx
+++ b/src/config/forms/integration.tsx
@@ -22,7 +22,7 @@ const defaultValues: Partial<IntegrationForm> = {
 const validationSchema = yup.object({
     federation_type: yup.string().required().label("Integration type"),
     auth_type: yup.string().required().label("Authentication type"),
-    endpoint_baseurl: yup.string().url().required().label("Base URL"),
+    endpoint_baseurl: yup.string().required().label("Base URL"),
     endpoint_dataset: yup
         .string()
         .required()

--- a/src/interfaces/IntegrationHistory.ts
+++ b/src/interfaces/IntegrationHistory.ts
@@ -1,7 +1,15 @@
-interface IntegrationHistory {
-    run_time: string;
-    success: boolean;
-    message?: string;
+interface FailedDataset {
+    pid: string;
+    message: string;
 }
 
-export type { IntegrationHistory };
+interface IntegrationHistory {
+    job_uuid: string;
+    started_at: string;
+    finished_at: string;
+    status: "success" | "failed";
+    message: string | null;
+    failed_datasets: FailedDataset[];
+}
+
+export type { IntegrationHistory, FailedDataset };


### PR DESCRIPTION
## Describe your changes

Add an IntegrationTabs component wrapping the shared Tabs UI to switch between Configuration and History, and wire existing IntegrationHistoryTable up to the real endpoint. Paginated list of runs with a success/failed status icon, the failure message, and any failed_datasets inline.

## Screenshots (if relevant)

New tab layout

<img width="1323" height="842" alt="image" src="https://github.com/user-attachments/assets/c98a9ebe-eedd-43c4-a43a-52294379b787" />

New history tab (no job selected)

<img width="1323" height="842" alt="image" src="https://github.com/user-attachments/assets/0301a643-ff27-4da7-89f4-8378e5a84635" />

New history tab (showing completed job in sidebar)

<img width="1323" height="842" alt="image" src="https://github.com/user-attachments/assets/37e94b88-3433-4928-8e5f-619614a6ff52" />

New history tab (showing failure in sidebar)

<img width="1323" height="842" alt="image" src="https://github.com/user-attachments/assets/1304ac71-d1b7-4cba-9dd0-502edfdb1b01" />

Pagination on history tab

<img width="1330" height="714" alt="image" src="https://github.com/user-attachments/assets/27357e3e-69fe-4b72-806e-c679588253bf" />


## Issue ticket link

https://hdruk.atlassian.net/browse/GAT-9190

## Checklist before requesting a review

-   [x] I have performed a self-review of my code
-   [x] I have added appropriate unit tests
-   [x] I have created mocks for unit tests (where appropriate)
-   [x] The interface is responsive (where appropriate)
-   [ ] The interface is at least AA (where appropriate)
