### PR TITLE
feat(GAT-2905): Add card actions to integrations list

### DIFF
--- a/mocks/data/integration/v1/integration.data.ts
+++ b/mocks/data/integration/v1/integration.data.ts
@@ -22,6 +22,9 @@ const generateIntegrationV1 = (data = {}): Integration => {
         created_at: faker.date
             .between("2020-01-01T00:00:00.000Z", "2020-03-01T00:00:00.000Z")
             .toISOString(),
+        last_run_at: faker.date
+            .between("2020-01-01T00:00:00.000Z", "2020-03-01T00:00:00.000Z")
+            .toISOString(),
         auth_secret_key: faker.datatype.string(),
         endpoint_baseurl: faker.datatype.string(),
         endpoint_datasets: faker.datatype.string(),

--- a/src/app/[locale]/account/team/[teamId]/(withLeftNav)/datasets/components/TeamDatasets/TeamDatasets.test.tsx
+++ b/src/app/[locale]/account/team/[teamId]/(withLeftNav)/datasets/components/TeamDatasets/TeamDatasets.test.tsx
@@ -117,4 +117,37 @@ describe("TeamDatasets", () => {
             ).toBeInTheDocument();
         });
     });
+
+    it("should carry the draft status and duplicate flag through to the duplicate action's link", async () => {
+        const mockDatasets = [
+            generateDatasetForTeamV1("1.0", {
+                create_origin: "MANUAL",
+                status: "DRAFT",
+            }),
+        ];
+        server.use(getTeamDatasetsV2(mockDatasets));
+        render(
+            <TeamDatasets
+                permissions={{
+                    "datasets.update": true,
+                    "datasets.create": true,
+                }}
+                teamId="1"
+            />
+        );
+
+        await waitFor(() => {
+            const duplicateLink = screen.getByRole("link", {
+                name: "Duplicate dataset metadata",
+            });
+            expect(duplicateLink).toHaveAttribute(
+                "href",
+                expect.stringContaining("duplicate=true")
+            );
+            expect(duplicateLink).toHaveAttribute(
+                "href",
+                expect.stringContaining("status=DRAFT")
+            );
+        });
+    });
 });

--- a/src/app/[locale]/account/team/[teamId]/(withLeftNav)/datasets/components/TeamDatasets/TeamDatasets.tsx
+++ b/src/app/[locale]/account/team/[teamId]/(withLeftNav)/datasets/components/TeamDatasets/TeamDatasets.tsx
@@ -185,6 +185,7 @@ const TeamDatasets = ({ permissions, teamId }: TeamDatasetsProps) => {
                       href: `/${RouteName.ACCOUNT}/${RouteName.TEAM}/${params?.teamId}/${RouteName.DATASETS}`,
                       icon: ContentCopyIcon,
                       label: t("actions.duplicate.label"),
+                      query: { duplicate: "true" },
                   },
               ]
             : []),

--- a/src/app/[locale]/account/team/[teamId]/(withLeftNav)/integrations/integration/list/components/IntegrationList/IntegrationList.test.tsx
+++ b/src/app/[locale]/account/team/[teamId]/(withLeftNav)/integrations/integration/list/components/IntegrationList/IntegrationList.test.tsx
@@ -29,16 +29,8 @@ describe("IntegrationList", () => {
 
     it("should render list", async () => {
         await waitFor(() => {
-            expect(
-                screen.getByText(
-                    `Integration 1 - ${integrationsV1[0].federation_type}`
-                )
-            ).toBeInTheDocument();
-            expect(
-                screen.getByText(
-                    `Integration 10 - ${integrationsV1[9].federation_type}`
-                )
-            ).toBeInTheDocument();
+            expect(screen.getByText("Integration 1")).toBeInTheDocument();
+            expect(screen.getByText("Integration 10")).toBeInTheDocument();
         });
     });
 });

--- a/src/app/[locale]/account/team/[teamId]/(withLeftNav)/integrations/integration/list/components/IntegrationListItem/IntegrationListItem.test.tsx
+++ b/src/app/[locale]/account/team/[teamId]/(withLeftNav)/integrations/integration/list/components/IntegrationListItem/IntegrationListItem.test.tsx
@@ -1,0 +1,140 @@
+import mockRouter from "next-router-mock";
+import { screen, render, waitFor, fireEvent } from "@/utils/testUtils";
+import { integrationV1 } from "@/mocks/data/integration";
+import { getFederationRunV1 } from "@/mocks/handlers/integration";
+import { server } from "@/mocks/server";
+import { formatDate } from "@/utils/date";
+import IntegrationListItem from "./IntegrationListItem";
+
+describe("IntegrationListItem", () => {
+    mockRouter.query = { teamId: "1" };
+    const integration = {
+        ...integrationV1,
+        id: 2,
+        federation_type: "DATASETS" as const,
+        created_at: "2020-01-15T00:00:00.000Z",
+        last_run_at: "2020-02-20T09:12:04.000Z",
+        enabled: true,
+        tested: true,
+    };
+
+    it("should render the integration's title, type, created date, last run and status", async () => {
+        render(<IntegrationListItem index={1} integration={integration} />);
+
+        expect(screen.getByText("Integration 1")).toBeInTheDocument();
+        expect(screen.getByText("Datasets")).toBeInTheDocument();
+        expect(screen.getByText("Enabled")).toBeInTheDocument();
+        expect(
+            screen.getByText(
+                formatDate(
+                    integration.created_at,
+                    "DD MMMM YYYY HH:mm"
+                ) as string
+            )
+        ).toBeInTheDocument();
+        expect(
+            screen.getByText(
+                formatDate(
+                    integration.last_run_at as string,
+                    "DD MMMM YYYY HH:mm"
+                ) as string
+            )
+        ).toBeInTheDocument();
+    });
+
+    it("should show 'Never' as the last run when the integration has not yet run", async () => {
+        render(
+            <IntegrationListItem
+                index={1}
+                integration={{ ...integration, last_run_at: null }}
+            />
+        );
+
+        expect(screen.getByText("Never")).toBeInTheDocument();
+    });
+
+    it("should show a Disabled status when the integration is not enabled", async () => {
+        render(
+            <IntegrationListItem
+                index={1}
+                integration={{ ...integration, enabled: false }}
+            />
+        );
+
+        expect(screen.getByText("Disabled")).toBeInTheDocument();
+    });
+
+    it("should link the Edit action to the integration's detail page", async () => {
+        render(<IntegrationListItem index={1} integration={integration} />);
+
+        const editLink = screen.getByRole("link", { name: "Edit" });
+        expect(editLink).toHaveAttribute(
+            "href",
+            "/account/team/1/integrations/integration/list/2"
+        );
+    });
+
+    it("should link the History action to the detail page's history tab", async () => {
+        render(<IntegrationListItem index={1} integration={integration} />);
+
+        const historyLink = screen.getByRole("link", { name: "History" });
+        expect(historyLink).toHaveAttribute(
+            "href",
+            "/account/team/1/integrations/integration/list/2?tab=history"
+        );
+    });
+
+    it("should disable Run now when the integration is not enabled", async () => {
+        render(
+            <IntegrationListItem
+                index={1}
+                integration={{ ...integration, enabled: false }}
+            />
+        );
+
+        expect(screen.getByRole("button", { name: "Run now" })).toBeDisabled();
+    });
+
+    it("should disable Run now when the integration has not been tested", async () => {
+        render(
+            <IntegrationListItem
+                index={1}
+                integration={{ ...integration, tested: false }}
+            />
+        );
+
+        expect(screen.getByRole("button", { name: "Run now" })).toBeDisabled();
+    });
+
+    it("should run the Run now action through Run now -> Running -> Complete -> Run now", async () => {
+        server.use(getFederationRunV1({ teamId: 1, federationId: 2 }));
+
+        render(<IntegrationListItem index={1} integration={integration} />);
+
+        const runButton = screen.getByRole("button", { name: "Run now" });
+        expect(runButton).not.toBeDisabled();
+
+        fireEvent.click(runButton);
+
+        await waitFor(() => {
+            expect(
+                screen.getByRole("button", { name: "Running" })
+            ).toBeDisabled();
+        });
+
+        await waitFor(() => {
+            expect(
+                screen.getByRole("button", { name: "Complete" })
+            ).toBeInTheDocument();
+        });
+
+        await waitFor(
+            () => {
+                expect(
+                    screen.getByRole("button", { name: "Run now" })
+                ).not.toBeDisabled();
+            },
+            { timeout: 4000 }
+        );
+    }, 10000);
+});

--- a/src/app/[locale]/account/team/[teamId]/(withLeftNav)/integrations/integration/list/components/IntegrationListItem/IntegrationListItem.tsx
+++ b/src/app/[locale]/account/team/[teamId]/(withLeftNav)/integrations/integration/list/components/IntegrationListItem/IntegrationListItem.tsx
@@ -1,14 +1,32 @@
 "use client";
 
-import { Card } from "@mui/material";
-import Link from "next/link";
+import { useEffect, useRef, useState } from "react";
+import { useTranslations } from "next-intl";
 import { useParams } from "next/navigation";
+import { FederationRunStatus } from "@/interfaces/Federation";
 import { Integration } from "@/interfaces/Integration";
 import Box from "@/components/Box";
+import CardActions from "@/components/CardActions";
 import Chip from "@/components/Chip";
+import KeyValueList from "@/components/KeyValueList";
+import Paper from "@/components/Paper";
 import Typography from "@/components/Typography";
+import apis from "@/config/apis";
+import { colors } from "@/config/theme";
+import {
+    AutorenewIcon,
+    CheckIcon,
+    EditIcon,
+    HistoryIcon,
+    PlayArrowIcon,
+} from "@/consts/icons";
 import { RouteName } from "@/consts/routeName";
+import apiService from "@/services/api";
 import { formatDate } from "@/utils/date";
+import { toTitleCase } from "@/utils/string";
+
+const MIN_RUNNING_DISPLAY_MS = 600;
+const COMPLETE_DISPLAY_MS = 3000;
 
 interface IntegrationListItemProps {
     index: number;
@@ -19,55 +37,127 @@ const IntegrationListItem = ({
     index,
     integration,
 }: IntegrationListItemProps) => {
+    const t = useTranslations("api");
     const params = useParams<{ teamId: string }>();
+    const [runStatus, setRunStatus] = useState(FederationRunStatus.IDLE);
+    const revertTimeoutRef = useRef<ReturnType<typeof setTimeout>>();
+
+    useEffect(() => {
+        return () => clearTimeout(revertTimeoutRef.current);
+    }, []);
+
+    const detailPath = `/${RouteName.ACCOUNT}/${RouteName.TEAM}/${params?.teamId}/${RouteName.INTEGRATIONS}/${RouteName.INTEGRATION}/${RouteName.LIST}`;
+
+    const handleRunNow = async () => {
+        setRunStatus(FederationRunStatus.RUNNING);
+
+        const minDisplay = new Promise(resolve =>
+            setTimeout(resolve, MIN_RUNNING_DISPLAY_MS)
+        );
+        const [response] = await Promise.all([
+            apiService.getRequest(
+                `${apis.teamsV1Url}/${params?.teamId}/federations/${integration.id}/run`,
+                { notificationOptions: { itemName: "Integration", t } }
+            ),
+            minDisplay,
+        ]);
+
+        setRunStatus(
+            response !== null
+                ? FederationRunStatus.COMPLETE
+                : FederationRunStatus.IDLE
+        );
+        if (response !== null) {
+            revertTimeoutRef.current = setTimeout(
+                () => setRunStatus(FederationRunStatus.IDLE),
+                COMPLETE_DISPLAY_MS
+            );
+        }
+    };
+
+    const runIcon =
+        runStatus === FederationRunStatus.RUNNING
+            ? AutorenewIcon
+            : runStatus === FederationRunStatus.COMPLETE
+            ? CheckIcon
+            : PlayArrowIcon;
+
+    const runLabel =
+        runStatus === FederationRunStatus.RUNNING
+            ? "Running"
+            : runStatus === FederationRunStatus.COMPLETE
+            ? "Complete"
+            : "Run now";
+
+    const actions = [
+        { href: detailPath, icon: EditIcon, label: "Edit" },
+        {
+            action: handleRunNow,
+            icon: runIcon,
+            disabled:
+                runStatus !== FederationRunStatus.IDLE ||
+                !integration.enabled ||
+                !integration.tested,
+            label: runLabel,
+        },
+        {
+            href: detailPath,
+            icon: HistoryIcon,
+            label: "History",
+            query: { tab: "history" },
+        },
+    ];
 
     return (
-        <Card>
-            <Link
-                href={`/${RouteName.ACCOUNT}/${RouteName.TEAM}/${params?.teamId}/${RouteName.INTEGRATIONS}/${RouteName.INTEGRATION}/${RouteName.LIST}/${integration.id}`}
-                style={{
-                    textDecoration: "none",
-                    color: "#000",
-                }}>
-                <Box
-                    sx={{
-                        display: "grid",
-                        gridTemplateColumns: "repeat(3, 1fr)",
-                    }}>
-                    <Typography
-                        component="span"
-                        sx={{
-                            fontWeight: "bold",
-                            padding: "10px",
-                            fontSize: 14,
-                        }}>
-                        Integration {index} - {integration.federation_type}
-                    </Typography>
-                    <Box>
-                        <Typography
-                            sx={{
-                                textAlign: "right",
-                                verticalAlign: "top",
-                                color: "#868E96",
-                            }}>
-                            Created - {formatDate(integration.created_at)}
-                        </Typography>
-                    </Box>
+        <Paper sx={{ m: 0, width: "100%" }}>
+            <Box sx={{ display: "grid", gridTemplateColumns: "1fr 50px" }}>
+                <Box sx={{ p: 2 }}>
                     <Box
                         sx={{
-                            m: 0.2,
                             display: "flex",
-                            justifyContent: "end",
+                            justifyContent: "space-between",
+                            alignItems: "center",
+                            mb: 1,
                         }}>
+                        <Typography sx={{ fontWeight: "bold", fontSize: 14 }}>
+                            Integration {index}
+                        </Typography>
                         {integration.enabled ? (
                             <Chip label="Enabled" color="success" />
                         ) : (
                             <Chip label="Disabled" color="error" />
                         )}
                     </Box>
+                    <KeyValueList
+                        rows={[
+                            {
+                                key: "Type",
+                                value: toTitleCase(integration.federation_type),
+                            },
+                            {
+                                key: "Created",
+                                value: formatDate(
+                                    integration.created_at,
+                                    "DD MMMM YYYY HH:mm"
+                                ),
+                            },
+                            {
+                                key: "Last run",
+                                value: integration.last_run_at
+                                    ? formatDate(
+                                          integration.last_run_at,
+                                          "DD MMMM YYYY HH:mm"
+                                      )
+                                    : "Never",
+                            },
+                        ]}
+                    />
                 </Box>
-            </Link>
-        </Card>
+                <Box sx={{ borderLeft: `solid 1px ${colors.grey600}` }}>
+                    <CardActions actions={actions} id={integration.id} />
+                </Box>
+            </Box>
+        </Paper>
     );
 };
 

--- a/src/app/[locale]/account/team/[teamId]/(withLeftNav)/integrations/widgets/components/WidgetList/WidgetList.tsx
+++ b/src/app/[locale]/account/team/[teamId]/(withLeftNav)/integrations/widgets/components/WidgetList/WidgetList.tsx
@@ -59,6 +59,7 @@ const WidgetList = ({ permissions, teamId }: WidgetListProps) => {
                       href: `/${RouteName.ACCOUNT}/${RouteName.TEAM}/${params.teamId}/${RouteName.INTEGRATIONS}/${RouteName.WIDGETS}`,
                       icon: EyeIcon,
                       label: t("actions.preview.label"),
+                      query: { tab: "preview" },
                   },
               ]
             : []),

--- a/src/components/CardActions/CardActions.test.tsx
+++ b/src/components/CardActions/CardActions.test.tsx
@@ -1,12 +1,11 @@
-import { DataStatus } from "@/consts/application";
 import { EditIcon, ArchiveIcon } from "@/consts/icons";
 import { render, screen, fireEvent, within } from "@/utils/testUtils";
-import CardActions from "./CardActions";
+import CardActions, { CardAction } from "./CardActions";
 
 describe("CardActions", () => {
     const mockAction = jest.fn();
 
-    const actions = [
+    const actions: CardAction[] = [
         {
             label: "First item",
             icon: EditIcon,
@@ -18,14 +17,16 @@ describe("CardActions", () => {
             action: mockAction,
         },
         {
-            label: "Third item duplicate",
+            label: "Third item",
             icon: ArchiveIcon,
             href: "/duplicate/path",
+            query: { duplicate: "true" },
         },
         {
-            label: "Fourth item preview",
+            label: "Fourth item",
             icon: ArchiveIcon,
             href: "/preview/path",
+            query: { tab: "preview" },
         },
     ];
 
@@ -65,12 +66,10 @@ describe("CardActions", () => {
         expect(mockAction).toHaveBeenCalledWith(1);
     });
 
-    it("should tag on duplicate if label contains duplicate", async () => {
+    it("should apply an action's own query params to its link", async () => {
         render(<CardActions id={10} actions={actions} />);
 
-        const dupLink = screen.getByRole("link", {
-            name: "Third item duplicate",
-        });
+        const dupLink = screen.getByRole("link", { name: "Third item" });
         expect(dupLink).toHaveAttribute(
             "href",
             expect.stringContaining("/duplicate/path")
@@ -79,33 +78,37 @@ describe("CardActions", () => {
             "href",
             expect.stringContaining("duplicate=true")
         );
-    });
 
-    it("should tag on preview if label contains preview", async () => {
-        render(<CardActions id={5} actions={actions} />);
-
-        const previewLink = screen.getByRole("link", {
-            name: "Fourth item preview",
-        });
-        expect(previewLink).toHaveAttribute(
-            "href",
-            expect.stringContaining("/preview/path")
-        );
+        const previewLink = screen.getByRole("link", { name: "Fourth item" });
         expect(previewLink).toHaveAttribute(
             "href",
             expect.stringContaining("tab=preview")
         );
     });
 
-    it("adds status=DRAFT when status is DRAFT", () => {
+    it("applies the shared query prop to every href action", () => {
         render(
-            <CardActions id={2} actions={actions} status={DataStatus.DRAFT} />
+            <CardActions
+                id={2}
+                actions={actions}
+                query={{ status: "DRAFT" }}
+            />
         );
 
         const firstLink = screen.getByRole("link", { name: "First item" });
         expect(firstLink).toHaveAttribute(
             "href",
             expect.stringContaining("status=DRAFT")
+        );
+
+        const dupLink = screen.getByRole("link", { name: "Third item" });
+        expect(dupLink).toHaveAttribute(
+            "href",
+            expect.stringContaining("status=DRAFT")
+        );
+        expect(dupLink).toHaveAttribute(
+            "href",
+            expect.stringContaining("duplicate=true")
         );
     });
 });

--- a/src/components/CardActions/CardActions.tsx
+++ b/src/components/CardActions/CardActions.tsx
@@ -1,61 +1,55 @@
 import { IconButton, Tooltip } from "@mui/material";
 import { IconType } from "@/interfaces/Ui";
-import { DataStatus } from "@/consts/application";
+
+interface CardAction {
+    icon: IconType;
+    href?: string;
+    action?: (id: number) => void;
+    disabled?: boolean;
+    label: string;
+    query?: Record<string, string>;
+}
 
 interface CardActionsProps {
     id: number;
-    status?: string;
-    actions: {
-        icon: IconType;
-        href?: string;
-        action?: (id: number) => void;
-        disabled?: boolean;
-        label: string;
-    }[];
+    query?: Record<string, string>;
+    actions: CardAction[];
 }
 
-const CardActions = ({ actions, id, status }: CardActionsProps) => {
-    return actions.map(({ icon: Icon, href, label, disabled, action }) => {
-        const searchParams = new URLSearchParams();
+const CardActions = ({ actions, id, query }: CardActionsProps) => {
+    return actions.map(
+        ({ icon: Icon, href, label, disabled, action, query: actionQuery }) => {
+            const params = new URLSearchParams({
+                ...query,
+                ...actionQuery,
+            }).toString();
 
-        if (href) {
-            if (status === DataStatus.DRAFT) {
-                searchParams.set("status", status);
-            }
-
-            if (label.toLowerCase().includes("duplicate")) {
-                searchParams.set("duplicate", "true");
-            }
-
-            if (label.toLowerCase().includes("preview")) {
-                searchParams.set("tab", "preview");
-            }
+            return (
+                <Tooltip key={label} placement="left" title={label}>
+                    <IconButton
+                        {...(action &&
+                            !disabled && {
+                                onClick: () => {
+                                    action(id);
+                                },
+                            })}
+                        disableRipple
+                        size="large"
+                        disabled={disabled}
+                        aria-label={label}
+                        {...(href &&
+                            !disabled && {
+                                href: `${href}/${id}${
+                                    params ? `?${params}` : ""
+                                }`,
+                            })}>
+                        <Icon color={disabled ? "disabled" : "primary"} />
+                    </IconButton>
+                </Tooltip>
+            );
         }
-
-        const params = searchParams.toString();
-
-        return (
-            <Tooltip key={label} placement="left" title={label}>
-                <IconButton
-                    {...(action &&
-                        !disabled && {
-                            onClick: () => {
-                                action(id);
-                            },
-                        })}
-                    disableRipple
-                    size="large"
-                    disabled={disabled}
-                    aria-label={label}
-                    {...(href &&
-                        !disabled && {
-                            href: `${href}/${id}${params ? `?${params}` : ""}`,
-                        })}>
-                    <Icon color={disabled ? "disabled" : "primary"} />
-                </IconButton>
-            </Tooltip>
-        );
-    });
+    );
 };
 
 export default CardActions;
+export type { CardAction };

--- a/src/components/CollectionCard/CollectionCard.tsx
+++ b/src/components/CollectionCard/CollectionCard.tsx
@@ -5,6 +5,7 @@ import Box from "@/components/Box";
 import Paper from "@/components/Paper";
 import Typography from "@/components/Typography";
 import theme, { colors } from "@/config/theme";
+import { DataStatus } from "@/consts/application";
 import { formatDate } from "@/utils/date";
 import CardActions from "../CardActions";
 import KeyValueList from "../KeyValueList";
@@ -142,7 +143,11 @@ const CollectionCard = ({ collection, actions }: CollectionCardProps) => {
                     <CardActions
                         actions={actions}
                         id={collection.id}
-                        status={collection.status}
+                        query={
+                            collection.status === DataStatus.DRAFT
+                                ? { status: DataStatus.DRAFT }
+                                : undefined
+                        }
                     />
                 </Box>
             </Box>

--- a/src/components/DatasetCard/DatasetCard.tsx
+++ b/src/components/DatasetCard/DatasetCard.tsx
@@ -7,6 +7,7 @@ import Paper from "@/components/Paper";
 import Typography from "@/components/Typography";
 import { colors } from "@/config/theme";
 import { nonManualDatasetCardActions } from "@/consts/actions";
+import { DataStatus } from "@/consts/application";
 import { getLatestVersion } from "@/utils/dataset";
 import { formatDate } from "@/utils/date";
 import CardActions from "../CardActions";
@@ -108,7 +109,11 @@ const DatasetCard = ({ dataset, actions }: DatasetCardProps) => {
                                 : nonManualDatasetCardActions
                         }
                         id={dataset.id}
-                        status={dataset.status}
+                        query={
+                            dataset.status === DataStatus.DRAFT
+                                ? { status: DataStatus.DRAFT }
+                                : undefined
+                        }
                     />
                 </Box>
             </Box>

--- a/src/components/PublicationCard/PublicationCard.tsx
+++ b/src/components/PublicationCard/PublicationCard.tsx
@@ -67,7 +67,7 @@ const PublicationCard = ({ publication, actions }: PublicationCardProps) => {
                 </Box>
 
                 <Box sx={{ p: 0, borderLeft: `solid 1px ${colors.grey600}` }}>
-                    <CardActions actions={actions} id={publication.id} status />
+                    <CardActions actions={actions} id={publication.id} />
                 </Box>
             </Box>
         </Paper>

--- a/src/components/ToolCard/ToolCard.tsx
+++ b/src/components/ToolCard/ToolCard.tsx
@@ -72,11 +72,7 @@ const ToolCard = ({ tool, actions }: ToolCardProps) => {
                     </Box>
                 </Box>
                 <Box sx={{ p: 0, borderLeft: `solid 1px ${colors.grey600}` }}>
-                    <CardActions
-                        actions={actions}
-                        id={tool.id}
-                        status={tool.status}
-                    />
+                    <CardActions actions={actions} id={tool.id} />
                 </Box>
             </Box>
         </Paper>

--- a/src/consts/icons.tsx
+++ b/src/consts/icons.tsx
@@ -51,6 +51,7 @@ import GroupsIcon from "@mui/icons-material/Groups";
 import GroupsOutlinedIcon from "@mui/icons-material/GroupsOutlined";
 import HandymanOutlinedIcon from "@mui/icons-material/HandymanOutlined";
 import HelpIcon from "@mui/icons-material/Help";
+import HistoryIcon from "@mui/icons-material/History";
 import HelpOutlineIcon from "@mui/icons-material/HelpOutline";
 import HelpOutlineOutlinedIcon from "@mui/icons-material/HelpOutlineOutlined";
 import IndeterminateCheckBoxSharpIcon from "@mui/icons-material/IndeterminateCheckBoxSharp";
@@ -61,6 +62,7 @@ import LockIcon from "@mui/icons-material/Lock";
 import MenuIcon from "@mui/icons-material/Menu";
 import OpenInNewIcon from "@mui/icons-material/OpenInNew";
 import PersonOutlineOutlinedIcon from "@mui/icons-material/PersonOutlineOutlined";
+import PlayArrowIcon from "@mui/icons-material/PlayArrow";
 import PriorityHighIcon from "@mui/icons-material/PriorityHigh";
 import QueryBuilderOutlinedIcon from "@mui/icons-material/QueryBuilderOutlined";
 import QuestionAnswerIcon from "@mui/icons-material/QuestionAnswer";
@@ -170,4 +172,6 @@ export {
     ArrowUpwardIcon,
     GridViewOutlinedIcon,
     CalendarMonthOutlinedIcon,
+    HistoryIcon,
+    PlayArrowIcon,
 };

--- a/src/interfaces/Integration.ts
+++ b/src/interfaces/Integration.ts
@@ -16,6 +16,7 @@ interface Integration {
     run_time_minute: string;
     enabled: boolean;
     tested: boolean;
+    last_run_at: string | null;
     notifications: Notification[] | undefined;
 }
 


### PR DESCRIPTION
## Screenshots (if relevant)

<img width="1269" height="347" alt="image" src="https://github.com/user-attachments/assets/50ac3176-0db0-45c1-b6a1-802353e768f4" />


## Describe your changes

1. Refactor to CardActions. Adds a query prop and removes domain logic from the component. I only noticed this because I had to add another branch for the history tab and it feels like a good time to nip it in the bud. I have updated the callers that use this component.

2. Adds actions to the card, also the last run at information.

## Issue ticket link

https://hdruk.atlassian.net/browse/GAT-2905

## Checklist before requesting a review

-   [x] I have performed a self-review of my code
-   [x] I have added appropriate unit tests
-   [ ] I have created mocks for unit tests (where appropriate)
-   [ ] The interface is responsive (where appropriate)
-   [ ] The interface is at least AA (where appropriate)
