### PR TITLE
feat(GAT-9197): add profile review step to Cohort Discovery stepper

### DIFF
--- a/src/app/[locale]/account/profile/cohort-discovery-request/components/CohortAccessStepper/CohortAccessStepper.test.tsx
+++ b/src/app/[locale]/account/profile/cohort-discovery-request/components/CohortAccessStepper/CohortAccessStepper.test.tsx
@@ -21,6 +21,21 @@ jest.mock("@/components/CohortDiscoveryButton", () => ({
     ),
 }));
 
+jest.mock("../../../components/ProfileForm", () => ({
+    __esModule: true,
+    default: ({
+        submitLabel,
+        onSaved,
+    }: {
+        submitLabel?: string;
+        onSaved?: () => void;
+    }) => (
+        <button type="button" onClick={onSaved}>
+            {submitLabel ?? "Save"}
+        </button>
+    ),
+}));
+
 const baseStatus = {
     requestStatus: null,
     requestExpiry: null,
@@ -53,6 +68,26 @@ describe("CohortAccessStepper", () => {
         );
 
         expect(screen.getByText("Review Your Profile")).toBeInTheDocument();
+        expect(screen.getByText("Terms and Conditions")).toBeInTheDocument();
+    });
+
+    it("advances past the profile step to terms when the profile is saved", async () => {
+        render(<CohortAccessStepper />);
+
+        await userEvent.click(
+            screen.getByRole("button", { name: "Apply for Cohort Discovery" })
+        );
+
+        const saveButton = screen.getByRole("button", {
+            name: "Save & continue",
+        });
+        expect(saveButton).toBeInTheDocument();
+
+        await userEvent.click(saveButton);
+
+        expect(
+            screen.queryByRole("button", { name: "Save & continue" })
+        ).not.toBeInTheDocument();
         expect(screen.getByText("Terms and Conditions")).toBeInTheDocument();
     });
 

--- a/src/app/[locale]/account/profile/cohort-discovery-request/components/CohortAccessStepper/CohortAccessStepper.tsx
+++ b/src/app/[locale]/account/profile/cohort-discovery-request/components/CohortAccessStepper/CohortAccessStepper.tsx
@@ -1,6 +1,7 @@
 "use client";
 
-import { useState } from "react";
+import { ReactNode, useState } from "react";
+import CheckCircleIcon from "@mui/icons-material/CheckCircle";
 import QueryBuilderIcon from "@mui/icons-material/QueryBuilder";
 import { Box } from "@mui/material";
 import { useTranslations } from "next-intl";
@@ -18,12 +19,15 @@ import { statusMapping, STEP_STATE } from "@/consts/cohortDiscovery";
 import { RouteName } from "@/consts/routeName";
 import { differenceInDays } from "@/utils/date";
 import { capitalise } from "@/utils/general";
+import ProfileForm from "@/app/[locale]/account/profile/components/ProfileForm";
 import { CircleState, StepNode, StepTitle } from "../Stepper";
 
 const TRANSLATION_PATH = "pages.account.profile.cohortDiscovery.stepper";
 const RESOLVED_STATUSES = ["APPROVED", "REJECTED", "EXPIRED", "BANNED"];
 
 const INFO_HREF = `/${RouteName.ABOUT}/${RouteName.COHORT_DISCOVERY}`;
+const TERMS_HREF =
+    "https://digital.nhs.uk/data-and-information/research-powered-by-data/registration-service";
 
 interface CohortAccessStepperProps {
     autoOpen?: boolean;
@@ -44,6 +48,7 @@ const CohortAccessStepper = ({
     } = useCohortStatus(user?.id);
 
     const [expanded, setExpanded] = useState<boolean | null>(null);
+    const [activeSubStep, setActiveSubStep] = useState(0);
 
     const started = expanded === null ? autoOpen && !requestStatus : expanded;
 
@@ -70,6 +75,31 @@ const CohortAccessStepper = ({
         isApproved && requestExpiry
             ? differenceInDays(requestExpiry, new Date())
             : null;
+
+    const checklist: { key: string }[] = [
+        { key: "checklistEmail" },
+        { key: "checklistOrcid" },
+        { key: "checklistSector" },
+        { key: "checklistRole" },
+    ];
+
+    const richTags = {
+        warn: (chunks: ReactNode) => (
+            <Typography component="span" color={colors.red600}>
+                {chunks}
+            </Typography>
+        ),
+        note: (chunks: ReactNode) => (
+            <Typography component="span" color={colors.grey600}>
+                {chunks}
+            </Typography>
+        ),
+        terms: (chunks: ReactNode) => (
+            <Link href={TERMS_HREF} target="_blank" rel="noopener noreferrer">
+                {chunks}
+            </Link>
+        ),
+    };
 
     const loading = userLoading || statusLoading || !hasFetched;
 
@@ -150,19 +180,75 @@ const CohortAccessStepper = ({
                                 ) : (
                                     <Box sx={{ mt: 3 }}>
                                         <StepNode
-                                            circleState="active"
+                                            circleState={
+                                                activeSubStep >= 1
+                                                    ? STEP_STATE.COMPLETE
+                                                    : STEP_STATE.ACTIVE
+                                            }
                                             label="1.1"
                                             small>
                                             <StepTitle small>
                                                 {t("reviewProfileTitle")}
                                             </StepTitle>
+                                            {activeSubStep === 0 && (
+                                                <>
+                                                    <Typography
+                                                        sx={{ mt: 1, mb: 1 }}>
+                                                        {t("reviewProfileIntro")}
+                                                    </Typography>
+                                                    <Box sx={{ mb: 2 }}>
+                                                        {checklist.map(item => (
+                                                            <Box
+                                                                key={item.key}
+                                                                sx={{
+                                                                    display:
+                                                                        "flex",
+                                                                    alignItems:
+                                                                        "flex-start",
+                                                                    gap: 1,
+                                                                    mb: 0.5,
+                                                                }}>
+                                                                <CheckCircleIcon
+                                                                    sx={{
+                                                                        color: colors.green400,
+                                                                        fontSize: 20,
+                                                                        mt: 0.25,
+                                                                        flexShrink: 0,
+                                                                    }}
+                                                                />
+                                                                <Typography component="div">
+                                                                    {t.rich(
+                                                                        item.key,
+                                                                        richTags
+                                                                    )}
+                                                                </Typography>
+                                                            </Box>
+                                                        ))}
+                                                    </Box>
+                                                    <ProfileForm
+                                                        hideKeepingUpdated
+                                                        submitLabel={t(
+                                                            "profileContinueButton"
+                                                        )}
+                                                        onSaved={() =>
+                                                            setActiveSubStep(1)
+                                                        }
+                                                    />
+                                                </>
+                                            )}
                                         </StepNode>
                                         <StepNode
-                                            circleState="locked"
+                                            circleState={
+                                                activeSubStep >= 1
+                                                    ? STEP_STATE.ACTIVE
+                                                    : STEP_STATE.LOCKED
+                                            }
                                             label="1.2"
                                             small
                                             isLast>
-                                            <StepTitle small muted>
+                                            <StepTitle
+                                                small
+                                                muted={activeSubStep < 1}>
                                                 {t("termsStepTitle")}
                                             </StepTitle>
                                         </StepNode>

--- a/src/app/[locale]/account/profile/components/ProfileForm/ProfileForm.test.tsx
+++ b/src/app/[locale]/account/profile/components/ProfileForm/ProfileForm.test.tsx
@@ -1,0 +1,63 @@
+import ProfileForm from "./ProfileForm";
+import { render, screen } from "@/utils/testUtils";
+
+jest.mock("@/hooks/useAuth", () => {
+    const user = {
+        id: 1,
+        firstname: "Jo",
+        lastname: "Bloggs",
+        email: "jo@example.ac.uk",
+        provider: "azure",
+        secondary_email: null,
+        secondary_email_verified_at: null,
+    };
+    return { __esModule: true, default: () => ({ user }) };
+});
+
+jest.mock("@/hooks/useGet", () => {
+    const result = { data: [], isLoading: false };
+    return { __esModule: true, default: () => result };
+});
+
+jest.mock("@/hooks/usePut", () => ({
+    __esModule: true,
+    default: () => () => Promise.resolve({}),
+}));
+
+jest.mock("@/hooks/usePost", () => ({
+    __esModule: true,
+    default: () => () => Promise.resolve({}),
+}));
+
+jest.mock("@/hooks/useUnsavedChanges", () => ({
+    __esModule: true,
+    useUnsavedChanges: () => undefined,
+}));
+
+const KEEPING_UPDATED_HEADING = "Keeping you updated";
+
+describe("ProfileForm", () => {
+    it("renders a custom submit label", () => {
+        render(<ProfileForm submitLabel="Save & continue" />);
+
+        expect(
+            screen.getByRole("button", { name: "Save & continue" })
+        ).toBeInTheDocument();
+    });
+
+    it("shows the Keeping updated block by default", () => {
+        render(<ProfileForm />);
+
+        expect(
+            screen.getByText(KEEPING_UPDATED_HEADING)
+        ).toBeInTheDocument();
+    });
+
+    it("hides the Keeping updated block when hideKeepingUpdated is set", () => {
+        render(<ProfileForm hideKeepingUpdated />);
+
+        expect(
+            screen.queryByText(KEEPING_UPDATED_HEADING)
+        ).not.toBeInTheDocument();
+    });
+});

--- a/src/app/[locale]/account/profile/components/ProfileForm/ProfileForm.tsx
+++ b/src/app/[locale]/account/profile/components/ProfileForm/ProfileForm.tsx
@@ -66,7 +66,17 @@ const getRichTextComponents = (onClick: () => void) => ({
     ),
 });
 
-const ProfileForm = () => {
+interface ProfileFormProps {
+    hideKeepingUpdated?: boolean;
+    onSaved?: () => void;
+    submitLabel?: string;
+}
+
+const ProfileForm = ({
+    hideKeepingUpdated = false,
+    onSaved,
+    submitLabel,
+}: ProfileFormProps = {}) => {
     const t = useTranslations("pages.profile");
     const { user } = useAuth();
     const [
@@ -196,7 +206,9 @@ const ProfileForm = () => {
             setSecondaryEmailVerificationRequested(true);
         }
         const payload = { ...user, ...formData };
-        updateProfile(payload.id, payload);
+        updateProfile(payload.id, payload).then(() => {
+            onSaved && onSaved();
+        });
     };
 
     useEffect(() => {
@@ -245,13 +257,17 @@ const ProfileForm = () => {
                 );
             })}
 
-            <KeepingUpdated
-                fields={profileContactFormFields}
-                control={control}
-            />
+            {!hideKeepingUpdated && (
+                <KeepingUpdated
+                    fields={profileContactFormFields}
+                    control={control}
+                />
+            )}
 
             <Box sx={{ p: 0, display: "flex", justifyContent: "end" }}>
-                <Button type="submit">{t("saveChanges")}</Button>
+                <Button type="submit">
+                    {submitLabel ?? t("saveChanges")}
+                </Button>
             </Box>
         </Form>
     );


### PR DESCRIPTION
> AI disclaimer - CLAUDE was used for this. The approach was agreed manually (reuse the existing ProfileForm via small props); implementation and tests by CLAUDE, manually reviewed

## Screenshots (if relevant)
<img width="1113" height="1125" alt="image" src="https://github.com/user-attachments/assets/7282e578-477d-40b4-9b75-aa6251492550" />

## Describe your changes
Fills in step 1.1 of the Cohort Discovery access stepper: an eligibility checklist plus the existing profile form reused inline (marketing block hidden, "Save & continue" action) which, on save, advances the applicant to the Terms step. Adds small backward-compatible props to `ProfileForm` (`hideKeepingUpdated`, `onSaved`, `submitLabel`) so it slots into the stepper without changing the standalone profile page. Stacked on GAT-9196.

## Issue ticket link
https://hdruk.atlassian.net/browse/GAT-9197

## Checklist before requesting a review

- [x] I have performed a self-review of my code
- [x] I have added appropriate unit tests / e2e tests (where relevant)
- [ ] I have created mocks for api endpoints (where appropriate)
- [ ] The interface is responsive (where ticket is relevant)
- [ ] The interface is at least AA (where ticket is relevant)
- [ ] Commits are described as "(chore|fix|feature|test|maintenance): description"

