### PR TITLE
feat(GAT-9353): filter stlyingtweaks

### DIFF
--- a/src/app/[locale]/(logged-out)/search/components/DateRangeFilter/DateRangeFilter.styles.ts
+++ b/src/app/[locale]/(logged-out)/search/components/DateRangeFilter/DateRangeFilter.styles.ts
@@ -4,7 +4,7 @@ export const DateFilterWrapper = styled("div")(({ theme }) => ({
     display: "flex",
     alignItems: "center",
     gap: theme.spacing(1),
-
+    flexWrap: "wrap",
     [theme.breakpoints.down("desktop")]: {
         flexDirection: "column",
     },

--- a/src/app/[locale]/(logged-out)/search/components/DateRangeFilter/DateRangeFilter.tsx
+++ b/src/app/[locale]/(logged-out)/search/components/DateRangeFilter/DateRangeFilter.tsx
@@ -78,7 +78,7 @@ const DateRangeFilter = ({
         <>
             <DateFilterWrapper>
                 <DatePickerControlled
-                    formControlSx={{ mb: 0, maxWidth: "140px" }}
+                    formControlSx={{ mb: 0, maxWidth: "130px" }}
                     sx={{ mt: 0 }}
                     label=""
                     name={MIN_YEAR_FIELD}
@@ -99,7 +99,7 @@ const DateRangeFilter = ({
                 />
                 {` ${t("to")} `}
                 <DatePickerControlled
-                    formControlSx={{ mb: 0, maxWidth: "140px" }}
+                    formControlSx={{ mb: 0, maxWidth: "130px" }}
                     sx={{ mt: 0 }}
                     label=""
                     name={MAX_YEAR_FIELD}

--- a/src/app/[locale]/(logged-out)/search/components/PopulationFilter/PopulationFilter.tsx
+++ b/src/app/[locale]/(logged-out)/search/components/PopulationFilter/PopulationFilter.tsx
@@ -120,7 +120,7 @@ const PopulationFilter = ({
                 </Typography>
             </Box>
             <CheckboxControlled
-                formControlSx={{ pl: 1, pr: 1 }}
+                formControlSx={{ pl: 1, pr: 1, textWrap: "wrap" }}
                 label={t(INCLUDE_UNREPORTED, { unreportedCount })}
                 checked={
                     !!selectedFilters?.populationSize?.includes(


### PR DESCRIPTION
## Screenshots (if relevant)
<img width="363" height="456" alt="image" src="https://github.com/user-attachments/assets/5b1bb5b7-9cdf-4d6b-988d-6cef34b77414" />

<img width="348" height="494" alt="image" src="https://github.com/user-attachments/assets/f714a91c-5846-419c-9176-99ee8ccaa1b0" />

## Describe your changes
A couple of the filters had odd styling. The population filter label was being cut off, and the date range search button was also being hidden

## Issue ticket link
https://hdruk.atlassian.net/browse/GAT-9353

## Checklist before requesting a review

-   [ ] I have performed a self-review of my code
-   [ ] I have added appropriate unit tests
-   [ ] I have created mocks for unit tests (where appropriate)
-   [ ] The interface is responsive (where appropriate)
-   [ ] The interface is at least AA (where appropriate)
