### PR TITLE
fix(GAT-9356): Form hydration causing error on save as draft

### DIFF
--- a/src/consts/createDataset.ts
+++ b/src/consts/createDataset.ts
@@ -2,6 +2,9 @@ const INITIAL_FORM_SECTION = "Welcome and form builder";
 const SUBMISSON_FORM_SECTION = "Make active";
 const STRUCTURAL_METADATA_FORM_SECTION = "structuralMetadata";
 const DATASET_TYPE = "Dataset type";
+const DATASET_TYPE_ARRAY = "Dataset Type Array";
+const DATASET_SUBTYPES = "Dataset subtypes";
+const PROVENANCE_ORIGIN_DATASET_TYPE_PATH = "provenance.origin.datasetType";
 const DATA_CUSTODIAN_ID = "identifier";
 const DATA_CUSTODIAN_NAME = "Name of Data Custodian";
 const PATIENT_PATHWAY_DESCRIPTION = "Patient pathway description";
@@ -18,6 +21,9 @@ export {
     SUBMISSON_FORM_SECTION,
     STRUCTURAL_METADATA_FORM_SECTION,
     DATASET_TYPE,
+    DATASET_TYPE_ARRAY,
+    DATASET_SUBTYPES,
+    PROVENANCE_ORIGIN_DATASET_TYPE_PATH,
     DATA_CUSTODIAN_ID,
     DATA_CUSTODIAN_NAME,
     DATA_CUSTODIAN_FIELDS,

--- a/src/utils/formHydration.test.tsx
+++ b/src/utils/formHydration.test.tsx
@@ -1,9 +1,11 @@
 import { buildYup } from "schema-to-yup";
-import { FormHydrationValidation } from "@/interfaces/FormHydration";
+import { Metadata } from "@/interfaces/Dataset";
+import { FormHydration, FormHydrationValidation } from "@/interfaces/FormHydration";
 import {
     formGenerateLegendItems,
     formGetFieldsCompletedCount,
     generateValidationRules,
+    mapFormFieldsForSubmission,
 } from "./formHydration";
 
 const buildYupSchema = (validationFields: FormHydrationValidation[]) =>
@@ -157,6 +159,68 @@ describe("generateValidationRules", () => {
         expect(() =>
             schema.validateSync({ Category: ["A"] })
         ).not.toThrow();
+    });
+});
+
+describe("mapFormFieldsForSubmission", () => {
+    // A minimal schema for a single field that lives outside the provenance
+    // section, so a "partial draft" produces formattedFormData with no
+    // provenance branch at all - the exact condition that used to throw.
+    const schema = [
+        {
+            title: "Title",
+            is_array_form: false,
+            location: "summary.title",
+            field: {
+                component: "TextField",
+                name: "Title",
+                required: true,
+                hidden: false,
+            },
+        },
+    ] as unknown as FormHydration[];
+
+    const submit = (formData: Record<string, unknown>) =>
+        mapFormFieldsForSubmission(formData as unknown as Metadata, schema) as {
+            provenance?: { origin?: { datasetType?: unknown } };
+        };
+
+    // Root cause (see form hydration fix): a partial draft with an empty
+    // provenance section meant formattedFormData.provenance was undefined, so
+    // reading .origin threw an unhandled rejection and no request was sent.
+    it("does not throw when the provenance section is empty (partial draft)", () => {
+        expect(() => submit({ Title: "A partial draft" })).not.toThrow();
+    });
+
+    it("defaults datasetType to an empty array when Dataset Type Array is absent", () => {
+        const result = submit({ Title: "A partial draft" });
+
+        expect(result.provenance?.origin?.datasetType).toEqual([]);
+    });
+
+    it("maps Dataset Type Array into provenance.origin.datasetType when provenance is otherwise empty", () => {
+        const result = submit({
+            "Dataset Type Array": [
+                {
+                    "Dataset type": "Health and disease",
+                    "Dataset subtypes": ["Cancer"],
+                },
+            ],
+        });
+
+        expect(result.provenance?.origin?.datasetType).toEqual([
+            { name: "Health and disease", subTypes: ["Cancer"] },
+        ]);
+    });
+
+    it("defaults subTypes to an empty array when Dataset subtypes is missing", () => {
+        const result = submit({
+            "Dataset Type Array": [{ "Dataset type": "Health and disease" }],
+        });
+
+        expect(result.provenance?.origin?.datasetType).toEqual([
+            { name: "Health and disease", subTypes: [] },
+        ]);
     });
 });
 

--- a/src/utils/formHydration.test.tsx
+++ b/src/utils/formHydration.test.tsx
@@ -1,6 +1,9 @@
 import { buildYup } from "schema-to-yup";
 import { Metadata } from "@/interfaces/Dataset";
-import { FormHydration, FormHydrationValidation } from "@/interfaces/FormHydration";
+import {
+    FormHydration,
+    FormHydrationValidation,
+} from "@/interfaces/FormHydration";
 import {
     formGenerateLegendItems,
     formGetFieldsCompletedCount,
@@ -120,9 +123,9 @@ describe("generateValidationRules", () => {
     it("rejects a non-URL value in an optional url-format array field", () => {
         const schema = buildYupSchema(toolsValidation);
 
-        expect(() =>
-            schema.validateSync({ Tools: ["das"] })
-        ).toThrow(/must be a valid URL/);
+        expect(() => schema.validateSync({ Tools: ["das"] })).toThrow(
+            /must be a valid URL/
+        );
     });
 
     it("accepts a valid URL in an optional url-format array field", () => {
@@ -156,9 +159,7 @@ describe("generateValidationRules", () => {
         const schema = buildYupSchema(requiredEnumValidation);
 
         expect(() => schema.validateSync({ Category: [] })).toThrow();
-        expect(() =>
-            schema.validateSync({ Category: ["A"] })
-        ).not.toThrow();
+        expect(() => schema.validateSync({ Category: ["A"] })).not.toThrow();
     });
 });
 
@@ -185,9 +186,6 @@ describe("mapFormFieldsForSubmission", () => {
             provenance?: { origin?: { datasetType?: unknown } };
         };
 
-    // Root cause (see form hydration fix): a partial draft with an empty
-    // provenance section meant formattedFormData.provenance was undefined, so
-    // reading .origin threw an unhandled rejection and no request was sent.
     it("does not throw when the provenance section is empty (partial draft)", () => {
         expect(() => submit({ Title: "A partial draft" })).not.toThrow();
     });

--- a/src/utils/formHydration.tsx
+++ b/src/utils/formHydration.tsx
@@ -19,7 +19,11 @@ import { LegendItem, LegendStatus } from "@/interfaces/FormLegend";
 import InputWrapper from "@/components/InputWrapper";
 import { inputComponents } from "@/config/forms";
 import {
+    DATASET_SUBTYPES,
+    DATASET_TYPE,
+    DATASET_TYPE_ARRAY,
     INITIAL_FORM_SECTION,
+    PROVENANCE_ORIGIN_DATASET_TYPE_PATH,
     SUBMISSON_FORM_SECTION,
 } from "@/consts/createDataset";
 import { getLastSplitPart } from "./string";
@@ -464,10 +468,10 @@ const mapFormFieldsForSubmission = (
 
     set(
         formattedFormData,
-        "provenance.origin.datasetType",
-        (formData["Dataset Type Array"] ?? []).map(item => ({
-            name: item["Dataset type"],
-            subTypes: item["Dataset subtypes"] ?? [],
+        PROVENANCE_ORIGIN_DATASET_TYPE_PATH,
+        (formData[DATASET_TYPE_ARRAY] ?? []).map(item => ({
+            name: item[DATASET_TYPE],
+            subTypes: item[DATASET_SUBTYPES] ?? [],
         }))
     );
     const cleanUndefinedObjects = (

--- a/src/utils/formHydration.tsx
+++ b/src/utils/formHydration.tsx
@@ -462,12 +462,14 @@ const mapFormFieldsForSubmission = (
         set(formattedFormData, key, value);
     });
 
-    formattedFormData.provenance.origin.datasetType = formData[
-        "Dataset Type Array"
-    ].map(item => ({
-        name: item["Dataset type"],
-        subTypes: item["Dataset subtypes"] ?? [],
-    }));
+    set(
+        formattedFormData,
+        "provenance.origin.datasetType",
+        (formData["Dataset Type Array"] ?? []).map(item => ({
+            name: item["Dataset type"],
+            subTypes: item["Dataset subtypes"] ?? [],
+        }))
+    );
     const cleanUndefinedObjects = (
         obj: Record<string, unknown>
     ): Record<string, unknown> | undefined => {


### PR DESCRIPTION
> AI disclaimed - only used in helping me write this PR description 

## Screenshots (if relevant)

_N/A — no visual change; this fixes a silent JS error in the submit path._

## Describe your changes

Fixes the **"Save as draft"** button silently doing nothing on the dataset onboarding / form-hydration flow.

**Symptom:** Clicking *Save as draft* fired no network request and gave no error — the button appeared dead. Console showed:

```
Uncaught (in promise) TypeError: Cannot read properties of undefined (reading 'origin')
```

**Root cause:**

In `src/utils/formHydration.tsx`, `mapFormFieldsForSubmission()` builds `formattedFormData` dynamically by `set()`-ing only the fields the user actually filled in. It then assigned `formattedFormData.provenance.origin.datasetType = …` directly — assuming `provenance.origin` already existed. 

When the provenance section was left empty (typical for a partial draft), `formattedFormData.provenance` was `undefined`, so reading `.origin` threw. Because this runs inside `postForm` *before* the request is built, the throw escaped as an unhandled promise rejection, so no request was ever sent and nothing surfaced to the user.

**Temporary Fix:** Replaced the raw nested assignment with the same lodash `set()` helper already used a few lines above, which safely creates the `provenance.origin` path when absent, and guarded the source array against being missing:

```js
set(
    formattedFormData,
    "provenance.origin.datasetType",
    (formData["Dataset Type Array"] ?? []).map(item => ({
        name: item["Dataset type"],
        subTypes: item["Dataset subtypes"] ?? [],
    }))
);
```

Drafts with an empty provenance section now save correctly, and fully-populated datasets still produce the same `provenance.origin.datasetType` payload.

**Notes:**

- Frontend-only; the API (`gateway-api-2`) was never reached, so no backend/GwdmHandler changes are involved.
- Reproduces on `dev` and production — pre-existing bug, not a regression from recent work.

## Issue ticket link

https://hdruk.atlassian.net/browse/GAT-9356

## Checklist before requesting a review

- [x] I have performed a self-review of my code
- [ ] I have added appropriate unit tests
- [ ] I have created mocks for unit tests (where appropriate)
- [x] The interface is responsive (where appropriate) _— N/A, no UI change_
- [x] The interface is at least AA (where appropriate) _— N/A, no UI change_
