### PR TITLE
feat(GAT-9201): Add NHS SDE access stepper scaffold

### DIFF
--- a/src/app/[locale]/account/profile/cohort-discovery-request/components/CohortDiscoveryCoverPage/CohortDiscoveryCoverPage.tsx
+++ b/src/app/[locale]/account/profile/cohort-discovery-request/components/CohortDiscoveryCoverPage/CohortDiscoveryCoverPage.tsx
@@ -1,24 +1,14 @@
 "use client";
 
 import { useMemo } from "react";
-import { Grid, Link, Typography } from "@mui/material";
+import { Grid, Typography } from "@mui/material";
 import { useTranslations } from "next-intl";
 import { useSearchParams } from "next/navigation";
 import { templateRepeatFields } from "@/interfaces/Cms";
 import Box from "@/components/Box";
-import Chip from "@/components/Chip";
 import Container from "@/components/Container";
-import IndicateNhseSdeAccessButton from "@/components/IndicateNhseSdeAccessButton";
-import { MarkDownSanitizedWithHtml } from "@/components/MarkDownSanitizedWithHTML";
-import Paper from "@/components/Paper";
-import RequestNhseSdeAccessButton from "@/components/RequestNhseSdeAccessButton";
-import useAuth from "@/hooks/useAuth";
-import { useCohortStatus } from "@/hooks/useCohortStatus";
-import { colors } from "@/config/theme";
-import { NHSSDEStatusMapping } from "@/consts/cohortDiscovery";
-import { capitalise } from "@/utils/general";
-import { useFeatures } from "@/providers/FeatureProvider";
 import CohortAccessStepper from "../CohortAccessStepper";
+import NhsSdeAccessStepper from "../NhsSdeAccessStepper";
 
 export default function CohortDiscoveryCoverPage({
     cmsContent,
@@ -26,19 +16,12 @@ export default function CohortDiscoveryCoverPage({
     cmsContent: templateRepeatFields;
 }) {
     const t = useTranslations("pages.account.profile.cohortDiscovery");
-    const { isNhsSdeApplicationsEnabled } = useFeatures();
-    const { user, isLoading: loadingUser } = useAuth();
-    const { nhseSdeRequestStatus, isLoading, refetch } = useCohortStatus(
-        user?.id
-    );
 
     const searchParams = useSearchParams();
 
     const autoOpen = useMemo(() => {
         return searchParams?.get("open") === "true";
     }, [searchParams]);
-
-    const loading = loadingUser || isLoading;
 
     return (
         <Container sx={{ display: "flex", flexDirection: "column" }}>
@@ -58,98 +41,8 @@ export default function CohortDiscoveryCoverPage({
                         autoOpen={autoOpen}
                     />
                 </Grid>
-                <Grid size={{ mobile: 12, laptop: 8 }}>
-                    <Paper
-                        sx={{
-                            bgcolor: "white",
-                            px: { mobile: 3, laptop: 8 },
-                            py: { mobile: 2, laptop: 6 },
-                        }}>
-                        <Typography variant="h1">
-                            {t("nhseSdeTitle")}
-                        </Typography>
-                        <Box sx={{ display: "flex", px: 0, pt: 0, gap: 2 }}>
-                            {nhseSdeRequestStatus && (
-                                <>
-                                    <Chip
-                                        size="small"
-                                        label={capitalise(nhseSdeRequestStatus)}
-                                        color={
-                                            NHSSDEStatusMapping[
-                                                nhseSdeRequestStatus
-                                            ]
-                                        }
-                                    />
-
-                                    {nhseSdeRequestStatus === "APPROVED" && (
-                                        <>
-                                            <Typography
-                                                sx={{
-                                                    color: colors.grey600,
-                                                    alignContent: "center",
-                                                }}>
-                                                {t("nhsExpiry")}
-                                            </Typography>
-                                        </>
-                                    )}
-                                </>
-                            )}
-                        </Box>
-                        {isNhsSdeApplicationsEnabled && (
-                            <>
-                                <Typography
-                                    color={colors.grey700}
-                                    sx={{ pb: 2 }}>
-                                    {t("nhseSdeText1")}
-                                </Typography>
-                                {!loading && !nhseSdeRequestStatus && (
-                                    <MarkDownSanitizedWithHtml
-                                        sx={{ color: colors.red700 }}
-                                        content={t("nhseSdeText2")}
-                                    />
-                                )}
-                            </>
-                        )}
-                        {!isNhsSdeApplicationsEnabled && (
-                            <Typography color={colors.grey600}>
-                                {t.rich("nhseSdeTemporaryText", {
-                                    mailto: chunks => (
-                                        <Link href={`mailto:${chunks}`}>
-                                            {chunks}
-                                        </Link>
-                                    ),
-                                })}
-                            </Typography>
-                        )}
-                    </Paper>
-                </Grid>
-
-                <Grid size={{ mobile: 12, laptop: 4 }}>
-                    <Paper
-                        sx={{
-                            bgcolor: "white",
-                            height: "100%",
-                            display: "flex",
-                            flexDirection: "column",
-                            alignItems: "center",
-                            justifyContent: "center",
-                            mb: 2,
-                            gap: 2,
-                            p: 2,
-                        }}>
-                        {!loading && nhseSdeRequestStatus !== "APPROVED" && (
-                            <>
-                                <RequestNhseSdeAccessButton
-                                    color="greyCustom"
-                                    refetchCohort={refetch}
-                                />
-                                <IndicateNhseSdeAccessButton
-                                    sx={{ width: "100%" }}
-                                    refetchCohort={refetch}
-                                />
-                            </>
-                        )}
-                    </Paper>
+                <Grid size={12}>
+                    <NhsSdeAccessStepper />
                 </Grid>
             </Grid>
         </Container>

--- a/src/app/[locale]/account/profile/cohort-discovery-request/components/NhsSdeAccessStepper/NhsSdeAccessStepper.test.tsx
+++ b/src/app/[locale]/account/profile/cohort-discovery-request/components/NhsSdeAccessStepper/NhsSdeAccessStepper.test.tsx
@@ -1,0 +1,88 @@
+import userEvent from "@testing-library/user-event";
+import NhsSdeAccessStepper from "./NhsSdeAccessStepper";
+import { render, screen } from "@/utils/testUtils";
+
+const mockUseCohortStatus = jest.fn();
+const mockUseFeatures = jest.fn();
+
+jest.mock("@/hooks/useAuth", () => ({
+    __esModule: true,
+    default: () => ({ user: { id: 1 }, isLoading: false }),
+}));
+
+jest.mock("@/hooks/useCohortStatus", () => ({
+    __esModule: true,
+    useCohortStatus: () => mockUseCohortStatus(),
+}));
+
+jest.mock("@/providers/FeatureProvider", () => ({
+    __esModule: true,
+    useFeatures: () => mockUseFeatures(),
+}));
+
+const baseStatus = {
+    requestStatus: null,
+    nhseSdeRequestStatus: null,
+    isLoading: false,
+    hasFetched: true,
+    refetch: jest.fn(),
+};
+
+const baseFeatures = { isNhsSdeApplicationsEnabled: true };
+
+const renderStepper = () => render(<NhsSdeAccessStepper />);
+
+describe("NhsSdeAccessStepper", () => {
+    beforeEach(() => {
+        mockUseCohortStatus.mockReturnValue(baseStatus);
+        mockUseFeatures.mockReturnValue(baseFeatures);
+    });
+
+    it("locks step 1 when Cohort Discovery access has not been approved", () => {
+        renderStepper();
+
+        expect(
+            screen.getByText("Existing Cohort Discovery Access")
+        ).toBeInTheDocument();
+        expect(
+            screen.queryByRole("button", {
+                name: "Apply for NHS Research SDE Cohort Data Access",
+            })
+        ).not.toBeInTheDocument();
+    });
+
+    it("shows step 1 as complete with an apply button when Cohort Discovery is approved", async () => {
+        mockUseCohortStatus.mockReturnValue({
+            ...baseStatus,
+            requestStatus: "APPROVED",
+        });
+
+        renderStepper();
+
+        const applyButton = screen.getByRole("button", {
+            name: "Apply for NHS Research SDE Cohort Data Access",
+        });
+        expect(applyButton).toBeInTheDocument();
+
+        await userEvent.click(applyButton);
+
+        expect(
+            screen.queryByRole("button", {
+                name: "Apply for NHS Research SDE Cohort Data Access",
+            })
+        ).not.toBeInTheDocument();
+    });
+
+    it("shows the pilot text and hides the steps when the feature flag is off", () => {
+        mockUseFeatures.mockReturnValue({ isNhsSdeApplicationsEnabled: false });
+
+        renderStepper();
+
+        expect(
+            screen.getByText(/currently in its pilot phase/i)
+        ).toBeInTheDocument();
+        expect(
+            screen.queryByText("Existing Cohort Discovery Access")
+        ).not.toBeInTheDocument();
+    });
+});

--- a/src/app/[locale]/account/profile/cohort-discovery-request/components/NhsSdeAccessStepper/NhsSdeAccessStepper.tsx
+++ b/src/app/[locale]/account/profile/cohort-discovery-request/components/NhsSdeAccessStepper/NhsSdeAccessStepper.tsx
@@ -1,0 +1,107 @@
+"use client";
+
+import { useState } from "react";
+import { useTranslations } from "next-intl";
+import Button from "@/components/Button";
+import Link from "@/components/Link";
+import Loading from "@/components/Loading";
+import Paper from "@/components/Paper";
+import Typography from "@/components/Typography";
+import useAuth from "@/hooks/useAuth";
+import { useCohortStatus } from "@/hooks/useCohortStatus";
+import { colors } from "@/config/theme";
+import { STEP_STATE } from "@/consts/cohortDiscovery";
+import { RouteName } from "@/consts/routeName";
+import { useFeatures } from "@/providers/FeatureProvider";
+import { CircleState, StepNode, StepTitle } from "../Stepper";
+
+const TRANSLATION_PATH = "pages.account.profile.cohortDiscovery.nhsStepper";
+const ABOUT_HREF = `/${RouteName.ABOUT}/${RouteName.COHORT_DISCOVERY}`;
+const MORE_INFO_HREF = `${ABOUT_HREF}?tab=nhs-sde-network`;
+
+const NhsSdeAccessStepper = () => {
+    const t = useTranslations(TRANSLATION_PATH);
+    const tCd = useTranslations("pages.account.profile.cohortDiscovery");
+
+    const { user, isLoading: userLoading } = useAuth();
+    const { isNhsSdeApplicationsEnabled } = useFeatures();
+    const {
+        requestStatus,
+        isLoading: statusLoading,
+        hasFetched,
+    } = useCohortStatus(user?.id);
+
+    const [applied, setApplied] = useState(false);
+
+    const loading = userLoading || statusLoading || !hasFetched;
+    const cdsApproved = requestStatus === "APPROVED";
+
+    const step1State: CircleState = cdsApproved
+        ? STEP_STATE.COMPLETE
+        : STEP_STATE.LOCKED;
+    const step2State: CircleState = STEP_STATE.LOCKED;
+    const step3State: CircleState = STEP_STATE.LOCKED;
+    const step4State: CircleState = STEP_STATE.LOCKED;
+    const step5State: CircleState = STEP_STATE.LOCKED;
+
+    return (
+        <Paper sx={{ bgcolor: "white", p: { mobile: 3, laptop: 4 } }}>
+            <Typography variant="h2">{t("title")}</Typography>
+            <Typography sx={{ mb: 2 }} color={colors.grey700}>
+                {t.rich("moreInfo", {
+                    link: chunks => <Link href={MORE_INFO_HREF}>{chunks}</Link>,
+                })}
+            </Typography>
+
+            {loading ? (
+                <Loading />
+            ) : !isNhsSdeApplicationsEnabled ? (
+                <Typography component="div" color={colors.grey600}>
+                    {tCd.rich("nhseSdeTemporaryText", {
+                        mailto: chunks => (
+                            <Link href={`mailto:${chunks}`}>{chunks}</Link>
+                        ),
+                    })}
+                </Typography>
+            ) : (
+                <>
+                    <StepNode circleState={step1State} label="1">
+                        <StepTitle>{t("step1Title")}</StepTitle>
+                        {cdsApproved && !applied && (
+                            <Button
+                                variant="outlined"
+                                color="secondary"
+                                sx={{ mt: 1 }}
+                                onClick={() => setApplied(true)}>
+                                {t("applyButton")}
+                            </Button>
+                        )}
+                        {cdsApproved && applied && (
+                            <Typography color={colors.grey600} sx={{ mt: 1 }}>
+                                {t("appliedText")}
+                            </Typography>
+                        )}
+                    </StepNode>
+
+                    <StepNode circleState={step2State} label="2">
+                        <StepTitle muted>{t("step2Title")}</StepTitle>
+                    </StepNode>
+
+                    <StepNode circleState={step3State} label="3">
+                        <StepTitle muted>{t("step3Title")}</StepTitle>
+                    </StepNode>
+
+                    <StepNode circleState={step4State} label="4">
+                        <StepTitle muted>{t("step4Title")}</StepTitle>
+                    </StepNode>
+
+                    <StepNode circleState={step5State} label="5" isLast>
+                        <StepTitle muted>{t("step5Title")}</StepTitle>
+                    </StepNode>
+                </>
+            )}
+        </Paper>
+    );
+};
+
+export default NhsSdeAccessStepper;

--- a/src/app/[locale]/account/profile/cohort-discovery-request/components/NhsSdeAccessStepper/NhsSdeAccessStepper.tsx
+++ b/src/app/[locale]/account/profile/cohort-discovery-request/components/NhsSdeAccessStepper/NhsSdeAccessStepper.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import { useState } from "react";
+import { ReactNode, useState } from "react";
 import { useTranslations } from "next-intl";
 import Button from "@/components/Button";
 import Link from "@/components/Link";
@@ -36,13 +36,61 @@ const NhsSdeAccessStepper = () => {
     const loading = userLoading || statusLoading || !hasFetched;
     const cdsApproved = requestStatus === "APPROVED";
 
-    const step1State: CircleState = cdsApproved
-        ? STEP_STATE.COMPLETE
-        : STEP_STATE.LOCKED;
-    const step2State: CircleState = STEP_STATE.LOCKED;
-    const step3State: CircleState = STEP_STATE.LOCKED;
-    const step4State: CircleState = STEP_STATE.LOCKED;
-    const step5State: CircleState = STEP_STATE.LOCKED;
+    const steps: {
+        label: string;
+        state: CircleState;
+        titleKey: string;
+        muted: boolean;
+        extra?: ReactNode;
+    }[] = [
+        {
+            label: "1",
+            state: cdsApproved ? STEP_STATE.COMPLETE : STEP_STATE.LOCKED,
+            titleKey: "step1Title",
+            muted: false,
+            extra: cdsApproved
+                ? applied
+                    ? (
+                          <Typography color={colors.grey600} sx={{ mt: 1 }}>
+                              {t("appliedText")}
+                          </Typography>
+                      )
+                    : (
+                          <Button
+                              variant="outlined"
+                              color="secondary"
+                              sx={{ mt: 1 }}
+                              onClick={() => setApplied(true)}>
+                              {t("applyButton")}
+                          </Button>
+                      )
+                : undefined,
+        },
+        {
+            label: "2",
+            state: STEP_STATE.LOCKED,
+            titleKey: "step2Title",
+            muted: true,
+        },
+        {
+            label: "3",
+            state: STEP_STATE.LOCKED,
+            titleKey: "step3Title",
+            muted: true,
+        },
+        {
+            label: "4",
+            state: STEP_STATE.LOCKED,
+            titleKey: "step4Title",
+            muted: true,
+        },
+        {
+            label: "5",
+            state: STEP_STATE.LOCKED,
+            titleKey: "step5Title",
+            muted: true,
+        },
+    ];
 
     return (
         <Paper sx={{ bgcolor: "white", p: { mobile: 3, laptop: 4 } }}>
@@ -65,39 +113,18 @@ const NhsSdeAccessStepper = () => {
                 </Typography>
             ) : (
                 <>
-                    <StepNode circleState={step1State} label="1">
-                        <StepTitle>{t("step1Title")}</StepTitle>
-                        {cdsApproved && !applied && (
-                            <Button
-                                variant="outlined"
-                                color="secondary"
-                                sx={{ mt: 1 }}
-                                onClick={() => setApplied(true)}>
-                                {t("applyButton")}
-                            </Button>
-                        )}
-                        {cdsApproved && applied && (
-                            <Typography color={colors.grey600} sx={{ mt: 1 }}>
-                                {t("appliedText")}
-                            </Typography>
-                        )}
-                    </StepNode>
-
-                    <StepNode circleState={step2State} label="2">
-                        <StepTitle muted>{t("step2Title")}</StepTitle>
-                    </StepNode>
-
-                    <StepNode circleState={step3State} label="3">
-                        <StepTitle muted>{t("step3Title")}</StepTitle>
-                    </StepNode>
-
-                    <StepNode circleState={step4State} label="4">
-                        <StepTitle muted>{t("step4Title")}</StepTitle>
-                    </StepNode>
-
-                    <StepNode circleState={step5State} label="5" isLast>
-                        <StepTitle muted>{t("step5Title")}</StepTitle>
-                    </StepNode>
+                    {steps.map((step, i) => (
+                        <StepNode
+                            key={step.label}
+                            circleState={step.state}
+                            label={step.label}
+                            isLast={i === steps.length - 1}>
+                            <StepTitle muted={step.muted}>
+                                {t(step.titleKey)}
+                            </StepTitle>
+                            {step.extra}
+                        </StepNode>
+                    ))}
                 </>
             )}
         </Paper>

--- a/src/app/[locale]/account/profile/cohort-discovery-request/components/NhsSdeAccessStepper/index.ts
+++ b/src/app/[locale]/account/profile/cohort-discovery-request/components/NhsSdeAccessStepper/index.ts
@@ -1,0 +1,1 @@
+export { default } from "./NhsSdeAccessStepper";

--- a/src/config/messages/en.json
+++ b/src/config/messages/en.json
@@ -362,7 +362,18 @@
                     "nhseSdeText1": "This service gives approved researchers, access to the additional NHS Research SDE Network datasets and subsequently those with approved projects secure access to NHS data. You must also have approved access to Cohort Discovery service to access the NHS Research SDE Network datasets.",
                     "nhseSdeText2": "By selecting ‘Confirm approval by the NHS Research SDE’, you are confirming that you have been approved by the NHS Research SDE validation service and you are consenting to HDR UK sharing your email address with the NHS Research SDE team solely for the purpose of verifying your approval status.  \nPlease note: this step involves manual validation by NHS Research SDE validation team and may take up to 10 working days. You will receive an email notification once your access to the additional datasets in cohort discovery has been granted.",
                     "nhseSdeTemporaryText": "To access SDE Network data, users must first be validated by the SDE Network. This validation process is currently in its pilot phase, with the full service expected to be operational by October 2025. In the meantime, if you would like to be added to the list for validation once the service goes live, please email <mailto>england.data.healthresearch@nhs.net</mailto>",
-                    "nhsExpiry": "SDE access is limited by access to Gateway Cohort Discovery"
+                    "nhsExpiry": "SDE access is limited by access to Gateway Cohort Discovery",
+                    "nhsStepper": {
+                        "title": "Optional NHS Research SDE Cohort Data Access",
+                        "moreInfo": "More information about this service can be found <link>here</link>",
+                        "step1Title": "Existing Cohort Discovery Access",
+                        "applyButton": "Apply for NHS Research SDE Cohort Data Access",
+                        "appliedText": "Your application for NHS Research SDE Cohort Data Access has started.",
+                        "step2Title": "Complete NHS SDE Validation Form",
+                        "step3Title": "Submit NHS SDE Validation Status to HDRUK",
+                        "step4Title": "Application Review",
+                        "step5Title": "Access Decision"
+                    }
                 },
                 "dataAccessRequests": {
                     "applications": {


### PR DESCRIPTION
> AI disclaimer - CLAUDE was used for this. The branch strategy, staged-PR split and scope boundaries were planned manually; the component build, translations and unit tests were implemented by CLAUDE against that plan.

## Screenshots / videos (if relevant)
<img width="1508" height="941" alt="image" src="https://github.com/user-attachments/assets/f327a2ca-b8da-4f1d-9111-bd36832ec104" />

## Describe your changes
Replaces the old NHS SDE cells on the Cohort Discovery cover page with a new 5-step `NhsSdeAccessStepper` panel. Step 1 ("Existing Cohort Discovery Access") is locked with a padlock until the user's Cohort Discovery request is `APPROVED`, at which point it completes and reveals a local "Apply for NHS…" opt-in. Steps 2–5 are titles-only scaffolding for now — the interactive validation flow (open form, consent, indicate, status badges) lands in GAT-9203, which stacks on this branch. When the `isNhsSdeApplicationsEnabled` flag is off, the panel shows the existing pilot text instead of the steps.

## Issue ticket link
https://hdruk.atlassian.net/browse/GAT-9201

## Checklist before requesting a review

- [x] I have performed a self-review of my code
- [x] I have added appropriate unit tests / e2e tests (where relevant)
- [ ] I have created mocks for api endpoints (where appropriate)
- [x] The interface is responsive (where ticket is relevant)
- [ ] The interface is at least AA (where ticket is relevant)
- [x] Commits are described as "(chore|fix|feature|test|maintenance): description"
