### PR TITLE
feat(GAT-9001): Allow structural metadata to be removed

### DIFF
--- a/src/app/[locale]/account/team/[teamId]/(withoutLeftNav)/datasets/components/CreateDataset/CreateDataset.tsx
+++ b/src/app/[locale]/account/team/[teamId]/(withoutLeftNav)/datasets/components/CreateDataset/CreateDataset.tsx
@@ -875,6 +875,9 @@ const CreateDataset = ({
                                                 handleToggleUploading={
                                                     setIsSaving
                                                 }
+                                                onRemove={() =>
+                                                    setStructuralMetadata([])
+                                                }
                                             />
                                         )}
 

--- a/src/app/[locale]/account/team/[teamId]/(withoutLeftNav)/datasets/components/StructuralMetadata/StructuralMetadata.test.tsx
+++ b/src/app/[locale]/account/team/[teamId]/(withoutLeftNav)/datasets/components/StructuralMetadata/StructuralMetadata.test.tsx
@@ -1,0 +1,121 @@
+import { useState } from "react";
+import { fireEvent, screen } from "@testing-library/react";
+import { rest } from "msw";
+import { StructuralMetadata } from "@/interfaces/Dataset";
+import apis from "@/config/apis";
+import { server } from "@/mocks/server";
+import { render } from "@/utils/testUtils";
+import StructuralMetadataSection from "./StructuralMetadata";
+
+const metadata: StructuralMetadata[] = [
+    {
+        name: "patients",
+        description: "Patient records",
+        columns: [
+            {
+                name: "nhs_number",
+                description: "Identifier",
+                dataType: "string",
+                sensitive: true,
+                values: [],
+            },
+        ],
+    },
+];
+
+const renderSection = (structuralMetadata: StructuralMetadata[]) =>
+    render(
+        <StructuralMetadataSection
+            structuralMetadata={structuralMetadata}
+            fileProcessedAction={jest.fn()}
+            handleToggleUploading={jest.fn()}
+            onRemove={jest.fn()}
+        />
+    );
+
+const StatefulSection = ({
+    initial = [],
+}: {
+    initial?: StructuralMetadata[];
+}) => {
+    const [tables, setTables] = useState<StructuralMetadata[]>(initial);
+
+    return (
+        <StructuralMetadataSection
+            structuralMetadata={tables}
+            fileProcessedAction={setTables}
+            handleToggleUploading={jest.fn()}
+            onRemove={() => setTables([])}
+        />
+    );
+};
+
+describe("StructuralMetadata", () => {
+    it("renders the uploaded file row and the metadata accordion", () => {
+        renderSection(metadata);
+
+        expect(
+            screen.getByRole("button", { name: /^Remove file/ })
+        ).toBeInTheDocument();
+        expect(screen.getByText("patients")).toBeInTheDocument();
+    });
+
+    it("renders neither the file row nor the accordion when there is no metadata", () => {
+        renderSection([]);
+
+        expect(
+            screen.queryByRole("button", { name: /^Remove file/ })
+        ).not.toBeInTheDocument();
+        expect(screen.queryByText("patients")).not.toBeInTheDocument();
+    });
+
+    it("shows the uploaded filename once the file has been processed", async () => {
+        server.use(
+            rest.post(apis.fileUploadV1Url, (req, res, ctx) =>
+                res(
+                    ctx.status(200),
+                    ctx.json({ data: { uuid: "file-uuid" } })
+                )
+            ),
+            rest.get(`${apis.fileUploadV1Url}/file-uuid`, (req, res, ctx) =>
+                res(
+                    ctx.status(200),
+                    ctx.json({
+                        data: {
+                            uuid: "file-uuid",
+                            filename: "dictionary.xlsx",
+                            status: "PROCESSED",
+                            structural_metadata: metadata,
+                        },
+                    })
+                )
+            )
+        );
+
+        render(<StatefulSection />);
+
+        const fileInput = screen
+            .getByLabelText("Select file")
+            .querySelector("input") as HTMLInputElement;
+
+        fireEvent.change(fileInput, {
+            target: { files: [new File(["test"], "dictionary.xlsx")] },
+        });
+        fireEvent.click(screen.getByText("Upload"));
+
+        expect(
+            await screen.findByRole("button", {
+                name: "Remove file dictionary.xlsx",
+            })
+        ).toBeInTheDocument();
+        expect(screen.getByText("patients")).toBeInTheDocument();
+    });
+
+    it("clears the metadata and the filename when the file is removed", () => {
+        render(<StatefulSection initial={metadata} />);
+
+        fireEvent.click(screen.getByRole("button", { name: /^Remove file/ }));
+
+        expect(screen.queryByText("patients")).not.toBeInTheDocument();
+    });
+});

--- a/src/app/[locale]/account/team/[teamId]/(withoutLeftNav)/datasets/components/StructuralMetadata/StructuralMetadata.tsx
+++ b/src/app/[locale]/account/team/[teamId]/(withoutLeftNav)/datasets/components/StructuralMetadata/StructuralMetadata.tsx
@@ -35,6 +35,7 @@ interface StructuralMetadataProps {
     structuralMetadata?: StructuralMetadata[];
     fileProcessedAction: (metadata: StructuralMetadata[]) => void;
     handleToggleUploading: (isUploading: boolean) => void;
+    onRemove: () => void;
 }
 
 const columnHelper = createColumnHelper();
@@ -72,10 +73,23 @@ const StructuralMetadataSection = ({
     structuralMetadata,
     fileProcessedAction,
     handleToggleUploading,
+    onRemove,
 }: StructuralMetadataProps) => {
     const t = useTranslations(TRANSLATION_PATH);
 
     const [isUploading, setIsUploading] = useState<boolean>(false);
+    const [uploadedFilename, setUploadedFilename] = useState<string>();
+
+    const hasMetadata = !!structuralMetadata?.length;
+
+    const existingFiles = hasMetadata
+        ? [
+              {
+                  uuid: "structural-metadata",
+                  filename: uploadedFilename || t("existingFile"),
+              },
+          ]
+        : [];
 
     const tableColumns = [
         {
@@ -137,21 +151,29 @@ const StructuralMetadataSection = ({
 
             <UploadFile
                 apiPath={`${apis.fileUploadV1Url}?entity_flag=structural-metadata-upload`}
-                onFileUploaded={file =>
-                    file.structural_metadata &&
-                    fileProcessedAction(file.structural_metadata)
-                }
+                onFileUploaded={file => {
+                    if (!file?.structural_metadata) {
+                        return;
+                    }
+                    setUploadedFilename(file.filename);
+                    fileProcessedAction(file.structural_metadata);
+                }}
                 isUploading={setIsUploading}
                 allowReuploading
                 acceptedFileTypes=".xlsx"
+                existingFiles={existingFiles}
+                onFileRemove={() => {
+                    setUploadedFilename(undefined);
+                    onRemove();
+                }}
             />
 
             {isUploading && (
                 <Typography sx={{ mt: 2 }}>{t("uploadMessage")}</Typography>
             )}
 
-            {structuralMetadata && !isUploading && (
-                <Box sx={{ mt: 4, p: 0 }}>
+            {hasMetadata && !isUploading && (
+                <Box sx={{ mt: 2, p: 0 }}>
                     <StructuralMetadataAccordion
                         metadata={structuralMetadata}
                     />

--- a/src/components/UploadFile/UploadFile.tsx
+++ b/src/components/UploadFile/UploadFile.tsx
@@ -3,7 +3,7 @@ import { useController, Control, useForm, FieldError } from "react-hook-form";
 import { IconButton, List, ListItem, Stack, SxProps } from "@mui/material";
 import { get } from "lodash";
 import { useTranslations } from "next-intl";
-import { FileUpload, UploadedFileMetadata } from "@/interfaces/FileUpload";
+import { FileUpload, UploadedFileMetadataValue } from "@/interfaces/FileUpload";
 import useGet from "@/hooks/useGet";
 import usePost from "@/hooks/usePost";
 import notificationService from "@/services/notification";
@@ -46,7 +46,8 @@ export interface UploadFileProps {
     label?: string;
     required?: boolean;
     name?: string;
-    control: Control;
+    control?: Control;
+    existingFiles?: UploadedFileMetadataValue[];
     allowMultipleFiles?: boolean;
     disabled?: boolean;
     fileDownloadApiPath?: string;
@@ -77,6 +78,7 @@ const UploadFile = ({
     required,
     name = "upload",
     control,
+    existingFiles,
     allowMultipleFiles,
     disabled = false,
     fileDownloadApiPath,
@@ -120,7 +122,8 @@ const UploadFile = ({
         default: t("imageError"),
     };
 
-    const existingFileArray: UploadedFileMetadata[] = [].concat(value || []);
+    const existingFileArray: UploadedFileMetadataValue[] =
+        existingFiles ?? [].concat(value || []);
 
     const { data: fileScanStatus } = useGet<FileUpload>(
         `${apis.fileUploadV1Url}/${fileId}`,

--- a/src/config/messages/en.json
+++ b/src/config/messages/en.json
@@ -738,6 +738,7 @@
                                 "completionGuidance5": "Type of data contained in the column.",
                                 "completionGuidance6": "Please indicate (using True / False) whether the information must be treated as sensitive and may need additional constraints / removal / anonymisation / masking through the data access request process. <bold>Definition:</bold> An ODRL conformant policy expressing the rights associated with the resource.",
                                 "downloadTemplate": "Download data dictionary template",
+                                "existingFile": "Uploaded structural metadata",
                                 "uploadSuccess": "Warning! Uploaded files are automatically saved to the dataset metadata. Uploading a new file will delete the previously uploaded structural metadata.",
                                 "uploadMessage": "Please wait while we scan and process your file. When processing has finished, your data will display below and you will be able to submit the Metadata to the Gateway. Scanning and processing typically takes 30-45 seconds, please do not leave this page"
                             },


### PR DESCRIPTION
> AI disclaimer - CLAUDE was used for this. The scoping and the review decisions were manual — including the call to reuse the existing UploadFile file list rather than duplicate its markup, and several rounds of trimming redundant locals and tests — with CLAUDE writing the implementation and the test suite off the back of that direction. 

## Screenshots / videos (if relevant)
<img width="1078" height="579" alt="image" src="https://github.com/user-attachments/assets/cb7b8dfa-87bb-46a0-afd4-f593f6ccfcee" />
<img width="1054" height="318" alt="image" src="https://github.com/user-attachments/assets/31e36654-ec68-4524-93f8-e560f60b8c6f" />

## Describe your changes
Custodians editing a dataset previously had no way to remove an uploaded data dictionary — once structural metadata was attached, the only way to change it was to upload a replacement file. The upload section now lists the currently attached dictionary with a delete button, so it can be cleared and the change persisted by saving the form. The row shows the real filename when the file was uploaded in the current session, falling back to a generic label for metadata loaded from a saved dataset, since no filename is persisted server-side.

This reuses UploadFile's existing file list rather than adding a bespoke one: the list previously only rendered from a react-hook-form field value, so it gained an optional `existingFiles` prop for callers that hold their file state elsewhere. Two incidental fixes came along with it — `control` is now correctly optional (the component already fell back to its own internal form control), and the file array's type was corrected from `UploadedFileMetadata` to `UploadedFileMetadataValue`. Also fixed a latent bug where an empty accordion rendered for datasets with no dictionary at all, because the guard tested an always-truthy empty array.

## Issue ticket link
https://hdruk.atlassian.net/browse/GAT-9001

## Checklist before requesting a review

- [x] I have performed a self-review of my code
- [x] I have added appropriate unit tests / e2e tests (where relevant)
- [ ] I have created mocks for api endpoints (where appropriate)
- [ ] The interface is responsive (where ticket is relevant)
- [ ] The interface is at least AA (where ticket is relevant)
- [ ] Commits are described as "(chore|fix|feature|test|maintenance): description"
