### PR TITLE
feat(GAT-9442): Implements frontend for the recent changes to emails.…

### DIFF
--- a/mocks/data/emailTemplates/emailTemplates.data.ts
+++ b/mocks/data/emailTemplates/emailTemplates.data.ts
@@ -1,0 +1,20 @@
+import { faker } from "@faker-js/faker";
+import { EmailTemplate } from "@/interfaces/EmailTemplate";
+
+export const generateEmailTemplate = (
+    overrides: Partial<EmailTemplate> = {}
+) => {
+    const template: EmailTemplate = {
+        id: faker.datatype.number(),
+        identifier: faker.lorem.slug(),
+        subject: faker.lorem.sentence(),
+        body: faker.lorem.paragraph(),
+        enabled: true,
+        created_at: faker.date.past().toString(),
+        updated_at: faker.date.past().toString(),
+        deleted_at: null,
+        ...overrides,
+    };
+
+    return template;
+};

--- a/mocks/data/emailTemplates/index.ts
+++ b/mocks/data/emailTemplates/index.ts
@@ -1,0 +1,1 @@
+export * from "./emailTemplates.data";

--- a/src/app/[locale]/account/profile/search-admin/DeleteEmailTemplateDialog.tsx
+++ b/src/app/[locale]/account/profile/search-admin/DeleteEmailTemplateDialog.tsx
@@ -1,0 +1,70 @@
+"use client";
+
+import { useTranslations } from "next-intl";
+import MuiDialogActions from "@mui/material/DialogActions";
+import MuiDialogContent from "@mui/material/DialogContent";
+import Button from "@/components/Button";
+import Dialog from "@/components/Dialog";
+import Typography from "@/components/Typography";
+import useDelete from "@/hooks/useDelete";
+import useDialog from "@/hooks/useDialog";
+import apis from "@/config/apis";
+import { GlobalDialogContextProps } from "@/providers/DialogProvider";
+
+const TRANSLATION_PATH = "modules.dialogs.DeleteEmailTemplateDialog";
+
+interface DeleteEmailTemplateDialogProps {
+    templateId: number;
+    templateIdentifier: string;
+    callback?: () => void;
+}
+
+const DeleteEmailTemplateDialog = ({
+    templateId,
+    templateIdentifier,
+    callback,
+}: DeleteEmailTemplateDialogProps) => {
+    const t = useTranslations(TRANSLATION_PATH);
+    const { hideDialog } = useDialog() as GlobalDialogContextProps;
+
+    const deleteTemplate = useDelete(apis.emailTemplatesV1Url, {
+        itemName: "Email Template",
+    });
+
+    const handleDelete = async () => {
+        const result = await deleteTemplate(templateId);
+        hideDialog();
+
+        if (result && typeof callback === "function") {
+            callback();
+        }
+    };
+
+    const onCancel = () => {
+        hideDialog();
+    };
+
+    return (
+        <Dialog title={t("title")} showCloseButton={false}>
+            <MuiDialogContent>
+                <Typography>
+                    {t("message", { IDENTIFIER: templateIdentifier })}
+                </Typography>
+            </MuiDialogContent>
+            <MuiDialogActions>
+                <Button
+                    variant="outlined"
+                    autoFocus
+                    color="secondary"
+                    onClick={onCancel}>
+                    {t("cancelButton")}
+                </Button>
+                <Button color="error" onClick={handleDelete}>
+                    {t("confirmButton")}
+                </Button>
+            </MuiDialogActions>
+        </Dialog>
+    );
+};
+
+export default DeleteEmailTemplateDialog;

--- a/src/app/[locale]/account/profile/search-admin/EmailTemplateForm.test.tsx
+++ b/src/app/[locale]/account/profile/search-admin/EmailTemplateForm.test.tsx
@@ -1,0 +1,103 @@
+import useGet from "@/hooks/useGet";
+import usePost from "@/hooks/usePost";
+import usePut from "@/hooks/usePut";
+import apis from "@/config/apis";
+import { generateEmailTemplate } from "@/mocks/data/emailTemplates";
+import { render, screen, waitFor } from "@/utils/testUtils";
+import EmailTemplateForm from "./EmailTemplateForm";
+
+jest.mock("@/hooks/useGet");
+jest.mock("@/hooks/usePost");
+jest.mock("@/hooks/usePut");
+jest.mock("@/hooks/useDebounce", () => ({
+    __esModule: true,
+    default: (value: string) => value,
+}));
+
+describe("EmailTemplateForm", () => {
+    const createTemplate = jest.fn();
+    const renderPreview = jest.fn().mockResolvedValue({ html: "<p>preview</p>" });
+
+    beforeEach(() => {
+        jest.clearAllMocks();
+
+        (usePost as jest.Mock).mockImplementation((url: string) =>
+            url === apis.emailTemplatesPreviewV1Url
+                ? renderPreview
+                : createTemplate
+        );
+        (usePut as jest.Mock).mockReturnValue(jest.fn());
+        renderPreview.mockResolvedValue({ html: "<p>preview</p>" });
+    });
+
+    it("populates the form with the existing template's content when editing", async () => {
+        const existingTemplate = generateEmailTemplate({
+            id: 7,
+            identifier: "dar.status.researcher",
+            subject: "Your application status has changed",
+            body: "<mjml><mj-body>Hello [[USER_FIRSTNAME]]</mj-body></mjml>",
+            enabled: false,
+        });
+
+        (useGet as jest.Mock).mockReturnValue({
+            data: existingTemplate,
+            isLoading: false,
+            mutate: jest.fn(),
+        });
+
+        render(
+            <EmailTemplateForm
+                templateId={7}
+                onDone={jest.fn()}
+                onCancel={jest.fn()}
+            />
+        );
+
+        expect(
+            screen.getByDisplayValue("dar.status.researcher")
+        ).toBeInTheDocument();
+        expect(
+            screen.getByDisplayValue("Your application status has changed")
+        ).toBeInTheDocument();
+        expect(
+            screen.getByDisplayValue(
+                "<mjml><mj-body>Hello [[USER_FIRSTNAME]]</mj-body></mjml>"
+            )
+        ).toBeInTheDocument();
+
+        const enabledSwitch = screen.getByRole("switch", {
+            name: "Enabled",
+        });
+        expect(enabledSwitch).not.toBeChecked();
+    });
+
+    it("renders a live HTML preview of the body via the preview endpoint", async () => {
+        const existingTemplate = generateEmailTemplate({
+            id: 7,
+            body: "<mjml><mj-body>Hello</mj-body></mjml>",
+        });
+
+        (useGet as jest.Mock).mockReturnValue({
+            data: existingTemplate,
+            isLoading: false,
+            mutate: jest.fn(),
+        });
+
+        render(
+            <EmailTemplateForm
+                templateId={7}
+                onDone={jest.fn()}
+                onCancel={jest.fn()}
+            />
+        );
+
+        await waitFor(() =>
+            expect(renderPreview).toHaveBeenCalledWith({
+                body: "<mjml><mj-body>Hello</mj-body></mjml>",
+            })
+        );
+
+        const iframe = await screen.findByTitle("Preview");
+        expect(iframe).toHaveAttribute("srcdoc", "<p>preview</p>");
+    });
+});

--- a/src/app/[locale]/account/profile/search-admin/EmailTemplateForm.tsx
+++ b/src/app/[locale]/account/profile/search-admin/EmailTemplateForm.tsx
@@ -1,0 +1,270 @@
+"use client";
+
+import { useEffect, useRef, useState } from "react";
+import { useTranslations } from "next-intl";
+import { FormProvider, useForm, useWatch } from "react-hook-form";
+import { yupResolver } from "@hookform/resolvers/yup";
+import { Skeleton } from "@mui/material";
+import { EmailTemplateFormValues, EmailTemplate } from "@/interfaces/EmailTemplate";
+import Box from "@/components/Box";
+import Button from "@/components/Button";
+import Form from "@/components/Form";
+import InputWrapper from "@/components/InputWrapper";
+import Loading from "@/components/Loading";
+import Paper from "@/components/Paper";
+import Typography from "@/components/Typography";
+import useDebounce from "@/hooks/useDebounce";
+import useGet from "@/hooks/useGet";
+import usePost from "@/hooks/usePost";
+import usePut from "@/hooks/usePut";
+import apis from "@/config/apis";
+import {
+    emailTemplateDefaultValues,
+    emailTemplateEnabledField,
+    emailTemplateFormFields,
+    emailTemplateValidationSchema,
+} from "@/config/forms/emailTemplate";
+
+interface EmailTemplateFormProps {
+    templateId?: number;
+    onDone: () => void;
+    onCancel: () => void;
+}
+
+const TRANSLATION_PATH = "pages.account.profile.searchAdmin";
+
+export default function EmailTemplateForm({
+    templateId,
+    onDone,
+    onCancel,
+}: EmailTemplateFormProps) {
+    const t = useTranslations(TRANSLATION_PATH);
+    const isEditing = !!templateId;
+    const [isSaving, setIsSaving] = useState(false);
+
+    const { data: existingTemplate, isLoading: isLoadingTemplate } =
+        useGet<EmailTemplate>(
+            isEditing ? `${apis.emailTemplatesV1Url}/${templateId}` : null
+        );
+
+    const methods = useForm<EmailTemplateFormValues>({
+        mode: "onTouched",
+        resolver: yupResolver(emailTemplateValidationSchema),
+        defaultValues: emailTemplateDefaultValues,
+    });
+
+    const { control, handleSubmit, reset } = methods;
+
+    useEffect(() => {
+        if (!existingTemplate) return;
+
+        reset({
+            identifier: existingTemplate.identifier,
+            subject: existingTemplate.subject,
+            body: existingTemplate.body,
+            enabled: existingTemplate.enabled,
+        });
+    }, [existingTemplate, reset]);
+
+    const createTemplate = usePost<EmailTemplateFormValues>(
+        apis.emailTemplatesV1Url,
+        { itemName: "Email Template" }
+    );
+
+    const editTemplate = usePut<EmailTemplateFormValues>(
+        apis.emailTemplatesV1Url,
+        { itemName: "Email Template" }
+    );
+
+    const submitForm = async (formData: EmailTemplateFormValues) => {
+        if (isSaving) return;
+
+        setIsSaving(true);
+
+        const result = isEditing
+            ? await editTemplate(templateId as number, formData)
+            : await createTemplate(formData);
+
+        setIsSaving(false);
+
+        if (result) {
+            onDone();
+        }
+    };
+
+    const bodyValue = useWatch({ control, name: "body" });
+    const debouncedBody = useDebounce(bodyValue ?? "", 600, 0);
+
+    const [previewHtml, setPreviewHtml] = useState<string | null>(null);
+    const [isPreviewLoading, setIsPreviewLoading] = useState(false);
+    const [previewFailed, setPreviewFailed] = useState(false);
+
+    const renderPreview = usePost<{ body: string }>(
+        apis.emailTemplatesPreviewV1Url,
+        { successNotificationsOn: false, errorNotificationsOn: false }
+    );
+
+    const previewRequestId = useRef(0);
+
+    useEffect(() => {
+        if (!debouncedBody) {
+            setPreviewHtml(null);
+            setPreviewFailed(false);
+            return;
+        }
+
+        const requestId = ++previewRequestId.current;
+        setIsPreviewLoading(true);
+
+        renderPreview({ body: debouncedBody }).then(result => {
+            if (requestId !== previewRequestId.current) return;
+
+            setIsPreviewLoading(false);
+
+            if (result && typeof result === "object" && "html" in result) {
+                setPreviewHtml((result as { html: string }).html);
+                setPreviewFailed(false);
+            } else {
+                setPreviewFailed(true);
+            }
+        });
+        // eslint-disable-next-line react-hooks/exhaustive-deps
+    }, [debouncedBody]);
+
+    if (isEditing && isLoadingTemplate) {
+        return <Loading />;
+    }
+
+    return (
+        <FormProvider {...methods}>
+            <Form onSubmit={handleSubmit(submitForm)}>
+                <Box
+                    sx={{
+                        display: "flex",
+                        gap: 2,
+                        alignItems: "flex-start",
+                        flexWrap: "wrap",
+                    }}>
+                    <Box sx={{ p: 0, flex: "1 1 480px", minWidth: 0 }}>
+                        <Paper sx={{ mb: 1 }}>
+                            <Box
+                                display="flex"
+                                sx={{
+                                    alignItems: "center",
+                                    justifyContent: "space-between",
+                                    gap: 2,
+                                }}>
+                                <Box sx={{ p: 0, flex: 1, minWidth: 0 }}>
+                                    <Typography variant="h3">
+                                        {isEditing
+                                            ? t("editEmailTemplateTitle")
+                                            : t("createEmailTemplateTitle")}
+                                    </Typography>
+                                </Box>
+                                <Box sx={{ p: 0, flexShrink: 0 }}>
+                                    <InputWrapper
+                                        control={control}
+                                        {...emailTemplateEnabledField}
+                                        label={t("enabled")}
+                                        formControlSx={{ mb: 0 }}
+                                    />
+                                </Box>
+                            </Box>
+                        </Paper>
+                        <Paper sx={{ mb: 1 }}>
+                            <Box padding={0}>
+                                {emailTemplateFormFields(isEditing).map(
+                                    field => (
+                                        <InputWrapper
+                                            key={field.name}
+                                            control={control}
+                                            {...field}
+                                        />
+                                    )
+                                )}
+                            </Box>
+                        </Paper>
+                        <Paper>
+                            <Box
+                                padding={0}
+                                display="flex"
+                                justifyContent="space-between">
+                                <Button
+                                    color="secondary"
+                                    variant="outlined"
+                                    onClick={onCancel}
+                                    disabled={isSaving}>
+                                    {t("cancel")}
+                                </Button>
+                                <Button type="submit" disabled={isSaving}>
+                                    {isEditing
+                                        ? t("saveChanges")
+                                        : t("createEmailTemplate")}
+                                </Button>
+                            </Box>
+                        </Paper>
+                    </Box>
+
+                    <Box
+                        sx={{
+                            p: 0,
+                            flex: "1 1 420px",
+                            minWidth: 0,
+                            position: "sticky",
+                            top: 16,
+                        }}>
+                        <Paper sx={{ p: 0, overflow: "hidden" }}>
+                            <Box
+                                sx={{
+                                    p: 2,
+                                    display: "flex",
+                                    alignItems: "center",
+                                    justifyContent: "space-between",
+                                    gap: 1,
+                                }}>
+                                <Typography sx={{ fontWeight: 500 }}>
+                                    {t("emailPreviewTitle")}
+                                </Typography>
+                                {isPreviewLoading && (
+                                    <Typography
+                                        variant="body2"
+                                        color="text.secondary">
+                                        {t("emailPreviewRendering")}
+                                    </Typography>
+                                )}
+                            </Box>
+                            {previewFailed && (
+                                <Box sx={{ px: 2, pb: 2 }}>
+                                    <Typography variant="body2" color="error">
+                                        {t("emailPreviewError")}
+                                    </Typography>
+                                </Box>
+                            )}
+                            {!previewHtml && !isPreviewLoading && (
+                                <Box sx={{ p: 2 }}>
+                                    <Skeleton
+                                        variant="rounded"
+                                        height={480}
+                                    />
+                                </Box>
+                            )}
+                            {previewHtml && (
+                                <iframe
+                                    title={t("emailPreviewTitle")}
+                                    srcDoc={previewHtml}
+                                    sandbox=""
+                                    style={{
+                                        width: "100%",
+                                        height: "70vh",
+                                        border: "none",
+                                        display: "block",
+                                    }}
+                                />
+                            )}
+                        </Paper>
+                    </Box>
+                </Box>
+            </Form>
+        </FormProvider>
+    );
+}

--- a/src/app/[locale]/account/profile/search-admin/EmailTemplatesTab.test.tsx
+++ b/src/app/[locale]/account/profile/search-admin/EmailTemplatesTab.test.tsx
@@ -1,0 +1,124 @@
+import useGet from "@/hooks/useGet";
+import usePatch from "@/hooks/usePatch";
+import { generateEmailTemplate } from "@/mocks/data/emailTemplates";
+import { render, screen, fireEvent } from "@/utils/testUtils";
+import EmailTemplatesTab from "./EmailTemplatesTab";
+
+jest.mock("@/hooks/useGet");
+jest.mock("@/hooks/usePatch");
+
+describe("EmailTemplatesTab", () => {
+    // Mimics SWR's real mutate() behaviour closely enough for these tests:
+    // it invokes the async updater function passed to it (a bare jest.fn()
+    // would not, since it never calls its own arguments).
+    const mutate = jest.fn((updater: unknown) =>
+        typeof updater === "function" ? updater() : Promise.resolve(updater)
+    );
+    const templates = [
+        generateEmailTemplate({
+            id: 1,
+            identifier: "dar.status.researcher",
+            subject: "Your application status has changed",
+            enabled: true,
+        }),
+        generateEmailTemplate({
+            id: 2,
+            identifier: "dar.submission.custodian",
+            subject: "A new application has been submitted",
+            enabled: false,
+        }),
+    ];
+
+    beforeEach(() => {
+        jest.clearAllMocks();
+
+        (useGet as jest.Mock).mockReturnValue({
+            data: templates,
+            isLoading: false,
+            mutate,
+        });
+    });
+
+    it("renders each template's identifier and subject", () => {
+        (usePatch as jest.Mock).mockReturnValue(jest.fn());
+
+        render(<EmailTemplatesTab />);
+
+        expect(screen.getByText("dar.status.researcher")).toBeInTheDocument();
+        expect(
+            screen.getByText("Your application status has changed")
+        ).toBeInTheDocument();
+        expect(
+            screen.getByText("dar.submission.custodian")
+        ).toBeInTheDocument();
+    });
+
+    it("reflects each template's enabled state in its switch", () => {
+        (usePatch as jest.Mock).mockReturnValue(jest.fn());
+
+        render(<EmailTemplatesTab />);
+
+        const enabledSwitch = screen.getByRole("checkbox", {
+            name: "Toggle dar.status.researcher enabled",
+        });
+        const disabledSwitch = screen.getByRole("checkbox", {
+            name: "Toggle dar.submission.custodian enabled",
+        });
+
+        expect(enabledSwitch).toBeChecked();
+        expect(disabledSwitch).not.toBeChecked();
+    });
+
+    it("applies an optimistic update and calls the PATCH hook when toggling", async () => {
+        const toggle = jest.fn().mockResolvedValue({ id: 1 });
+        (usePatch as jest.Mock).mockReturnValue(toggle);
+
+        render(<EmailTemplatesTab />);
+
+        fireEvent.click(
+            screen.getByRole("checkbox", {
+                name: "Toggle dar.status.researcher enabled",
+            })
+        );
+
+        // mutate() must be called with optimisticData reflecting the flip
+        // immediately (synchronously), before the PATCH request resolves —
+        // this is what makes the switch feel instant instead of blocking.
+        expect(mutate).toHaveBeenCalledWith(
+            expect.any(Function),
+            expect.objectContaining({
+                optimisticData: [
+                    expect.objectContaining({ id: 1, enabled: false }),
+                    expect.objectContaining({ id: 2, enabled: false }),
+                ],
+                revalidate: false,
+            })
+        );
+
+        await Promise.resolve();
+        expect(toggle).toHaveBeenCalledWith(1, { enabled: false });
+    });
+
+    it("reverts the optimistic update when the PATCH request fails", async () => {
+        const toggle = jest.fn().mockResolvedValue(null);
+        (usePatch as jest.Mock).mockReturnValue(toggle);
+
+        render(<EmailTemplatesTab />);
+
+        fireEvent.click(
+            screen.getByRole("checkbox", {
+                name: "Toggle dar.status.researcher enabled",
+            })
+        );
+
+        const resolved = await mutate.mock.results[
+            mutate.mock.results.length - 1
+        ].value;
+
+        expect(resolved).toEqual(
+            expect.arrayContaining([
+                expect.objectContaining({ id: 1, enabled: true }),
+            ])
+        );
+    });
+});

--- a/src/app/[locale]/account/profile/search-admin/EmailTemplatesTab.tsx
+++ b/src/app/[locale]/account/profile/search-admin/EmailTemplatesTab.tsx
@@ -1,0 +1,218 @@
+"use client";
+
+import { useMemo, useState } from "react";
+import { useTranslations } from "next-intl";
+import { Divider, Skeleton, Switch } from "@mui/material";
+import Box from "@/components/Box";
+import Paper from "@/components/Paper";
+import Typography from "@/components/Typography";
+import Button from "@/components/Button";
+import ActionMenu from "@/components/ActionMenu";
+import useGet from "@/hooks/useGet";
+import usePatch from "@/hooks/usePatch";
+import useDialog from "@/hooks/useDialog";
+import apis from "@/config/apis";
+import { EditIcon, DeleteForeverIcon } from "@/consts/icons";
+import { EmailTemplate } from "@/interfaces/EmailTemplate";
+import { GlobalDialogContextProps } from "@/providers/DialogProvider";
+import EmailTemplateForm from "./EmailTemplateForm";
+import DeleteEmailTemplateDialog from "./DeleteEmailTemplateDialog";
+
+export enum ViewMode {
+    LIST = "list",
+    CREATE = "create",
+    EDIT = "edit",
+}
+
+type View =
+    | { mode: ViewMode.LIST }
+    | { mode: ViewMode.CREATE }
+    | { mode: ViewMode.EDIT; templateId: number };
+
+const TRANSLATION_PATH = "pages.account.profile.searchAdmin";
+
+export default function EmailTemplatesTab() {
+    const t = useTranslations(TRANSLATION_PATH);
+    const [view, setView] = useState<View>({ mode: ViewMode.LIST });
+    const { showDialog } = useDialog() as GlobalDialogContextProps;
+
+    const { data, isLoading, mutate } = useGet<EmailTemplate[]>(
+        apis.emailTemplatesV1Url
+    );
+
+    const templates = useMemo(() => data ?? [], [data]);
+
+    const toggleEnabled = usePatch<{ enabled: boolean }>(
+        apis.emailTemplatesV1Url,
+        { itemName: "Email Template" }
+    );
+
+    const handleToggle = (template: EmailTemplate) => {
+        const nextEnabled = !template.enabled;
+        const optimisticTemplates = templates.map(t =>
+            t.id === template.id ? { ...t, enabled: nextEnabled } : t
+        );
+
+        mutate(
+            async () => {
+                const result = await toggleEnabled(template.id, {
+                    enabled: nextEnabled,
+                });
+
+                return result ? optimisticTemplates : templates;
+            },
+            {
+                optimisticData: optimisticTemplates,
+                rollbackOnError: true,
+                revalidate: false,
+            }
+        );
+    };
+
+    const handleDelete = (template: EmailTemplate) => {
+        showDialog(DeleteEmailTemplateDialog, {
+            templateId: template.id,
+            templateIdentifier: template.identifier,
+            callback: mutate,
+        });
+    };
+
+    if (view.mode === ViewMode.CREATE) {
+        return (
+            <EmailTemplateForm
+                onDone={() => {
+                    setView({ mode: ViewMode.LIST });
+                    mutate();
+                }}
+                onCancel={() => setView({ mode: ViewMode.LIST })}
+            />
+        );
+    }
+
+    if (view.mode === ViewMode.EDIT) {
+        return (
+            <EmailTemplateForm
+                templateId={view.templateId}
+                onDone={() => {
+                    setView({ mode: ViewMode.LIST });
+                    mutate();
+                }}
+                onCancel={() => setView({ mode: ViewMode.LIST })}
+            />
+        );
+    }
+
+    return (
+        <Box sx={{ p: 0 }}>
+            <Box
+                sx={{
+                    display: "flex",
+                    flexWrap: "wrap",
+                    justifyContent: "space-between",
+                    alignItems: "center",
+                    gap: 1,
+                    p: 0,
+                    mb: 2,
+                }}>
+                <Typography variant="h3">{t("emailTemplatesTitle")}</Typography>
+                <Button
+                    size="small"
+                    onClick={() => setView({ mode: ViewMode.CREATE })}>
+                    {t("createEmailTemplate")}
+                </Button>
+            </Box>
+
+            {isLoading && (
+                <Paper variant="outlined" sx={{ p: 2 }}>
+                    <Skeleton variant="rounded" height={40} sx={{ mb: 1 }} />
+                    <Skeleton variant="rounded" height={40} />
+                </Paper>
+            )}
+
+            {!isLoading && templates.length === 0 && (
+                <Paper variant="outlined" sx={{ p: 2 }}>
+                    <Typography variant="body2" color="text.secondary">
+                        {t("noEmailTemplatesFound")}
+                    </Typography>
+                </Paper>
+            )}
+
+            {!isLoading && templates.length > 0 && (
+                <Paper variant="outlined">
+                    {templates.map((template, index) => (
+                        <Box key={template.id}>
+                            <Box
+                                sx={{
+                                    p: 2,
+                                    display: "flex",
+                                    alignItems: "center",
+                                    justifyContent: "space-between",
+                                    gap: 2,
+                                    flexWrap: "wrap",
+                                }}>
+                                <Box sx={{ p: 0, minWidth: 0 }}>
+                                    <Typography
+                                        sx={{ wordBreak: "break-word" }}>
+                                        {template.identifier}
+                                    </Typography>
+                                    <Typography
+                                        variant="body2"
+                                        color="text.secondary"
+                                        sx={{ wordBreak: "break-word" }}>
+                                        {template.subject}
+                                    </Typography>
+                                </Box>
+                                <Box
+                                    sx={{
+                                        p: 0,
+                                        display: "flex",
+                                        alignItems: "center",
+                                        gap: 1,
+                                    }}>
+                                    <Switch
+                                        checked={template.enabled}
+                                        onChange={() =>
+                                            handleToggle(template)
+                                        }
+                                        slotProps={{
+                                            input: {
+                                                "aria-label": t(
+                                                    "toggleEmailTemplateEnabled",
+                                                    {
+                                                        IDENTIFIER:
+                                                            template.identifier,
+                                                    }
+                                                ),
+                                            },
+                                        }}
+                                    />
+                                    <ActionMenu
+                                        actions={[
+                                            {
+                                                label: t("edit"),
+                                                icon: EditIcon,
+                                                action: () =>
+                                                    setView({
+                                                        mode: ViewMode.EDIT,
+                                                        templateId:
+                                                            template.id,
+                                                    }),
+                                            },
+                                            {
+                                                label: t("delete"),
+                                                icon: DeleteForeverIcon,
+                                                action: () =>
+                                                    handleDelete(template),
+                                            },
+                                        ]}
+                                    />
+                                </Box>
+                            </Box>
+                            {index < templates.length - 1 && <Divider />}
+                        </Box>
+                    ))}
+                </Paper>
+            )}
+        </Box>
+    );
+}

--- a/src/app/[locale]/account/profile/search-admin/SearchAdminPanel.tsx
+++ b/src/app/[locale]/account/profile/search-admin/SearchAdminPanel.tsx
@@ -12,6 +12,7 @@ import FeatureFlagsTable from "./FeatureFlagsTable";
 import SearchEntitiesTab from "./SearchEntitiesTab";
 import DataCustodianNetworksTab from "./DataCustodianNetworksTab";
 import NightlyDatasetTestsTab from "./NightlyDatasetTestsTab";
+import EmailTemplatesTab from "./EmailTemplatesTab";
 
 const TRANSLATION_PATH = "pages.account.profile.searchAdmin";
 
@@ -68,6 +69,15 @@ export default function SearchAdminPanel() {
                             content: (
                                 <Box sx={{ p: 0, pt: 2 }}>
                                     <NightlyDatasetTestsTab />
+                                </Box>
+                            ),
+                        },
+                        {
+                            label: t("emailTemplatesTab"),
+                            value: "emailTemplates",
+                            content: (
+                                <Box sx={{ p: 0, pt: 2 }}>
+                                    <EmailTemplatesTab />
                                 </Box>
                             ),
                         },

--- a/src/config/apis.ts
+++ b/src/config/apis.ts
@@ -108,6 +108,8 @@ const apis = {
     workgroupsV1Url: `${apiV1Url}/workgroups`,
     metricsV2Url: `${apiV2Url}/metrics`,
     nightlyDatasetTestsV2Url: `${apiV2IPUrl}/nightly_dataset_tests`,
+    emailTemplatesV1Url: `${apiV1IPUrl}/emailtemplates`,
+    emailTemplatesPreviewV1Url: `${apiV1IPUrl}/emailtemplates/preview`,
 };
 
 export default apis;

--- a/src/config/forms/emailTemplate.tsx
+++ b/src/config/forms/emailTemplate.tsx
@@ -1,0 +1,56 @@
+import * as yup from "yup";
+import { EmailTemplateFormValues } from "@/interfaces/EmailTemplate";
+import { inputComponents } from ".";
+
+const defaultValues: EmailTemplateFormValues = {
+    identifier: "",
+    subject: "",
+    body: "",
+    enabled: true,
+};
+
+const validationSchema = yup.object({
+    identifier: yup.string().required().label("Identifier"),
+    subject: yup.string().required().label("Subject"),
+    body: yup.string().required().label("Body"),
+    enabled: yup.boolean().required(),
+});
+
+const enabledField = {
+    name: "enabled",
+    component: inputComponents.SwitchInline,
+};
+
+const formFields = (isEditing: boolean) => [
+    {
+        label: "Identifier",
+        name: "identifier",
+        component: inputComponents.TextField,
+        required: true,
+        disabled: isEditing,
+        info: isEditing
+            ? "The identifier can't be changed once created — it's the key the API uses to look up this template when sending email."
+            : "A unique key, e.g. dar.status.researcher. This is the key the API uses to look up this template when sending email.",
+    },
+    {
+        label: "Subject",
+        name: "subject",
+        component: inputComponents.TextField,
+        required: true,
+    },
+    {
+        label: "Body",
+        name: "body",
+        info: "Raw MJML/HTML source. Use [[PLACEHOLDER]] tokens for variables substituted at send time.",
+        component: inputComponents.TextArea,
+        required: true,
+        rows: 14,
+    },
+];
+
+export {
+    defaultValues as emailTemplateDefaultValues,
+    validationSchema as emailTemplateValidationSchema,
+    formFields as emailTemplateFormFields,
+    enabledField as emailTemplateEnabledField,
+};

--- a/src/config/messages/en.json
+++ b/src/config/messages/en.json
@@ -620,7 +620,17 @@
                     "editNetworkTitle": "Edit Data Custodian Network",
                     "createNetworkTitle": "Create Data Custodian Network",
                     "cancel": "Cancel",
-                    "saveChanges": "Save changes"
+                    "saveChanges": "Save changes",
+                    "emailTemplatesTab": "Email Templates",
+                    "emailTemplatesTitle": "Email Templates",
+                    "createEmailTemplate": "Create template",
+                    "noEmailTemplatesFound": "No email templates found.",
+                    "toggleEmailTemplateEnabled": "Toggle {IDENTIFIER} enabled",
+                    "editEmailTemplateTitle": "Edit Email Template",
+                    "createEmailTemplateTitle": "Create Email Template",
+                    "emailPreviewTitle": "Preview",
+                    "emailPreviewRendering": "Rendering...",
+                    "emailPreviewError": "Couldn't render a preview. Check the MJML in the body field for errors."
                 }
             },
             "team": {
@@ -2110,6 +2120,12 @@
             "DeleteDataCustodianNetworkDialog": {
                 "title": "Delete network",
                 "message": "Are you sure you want to delete \"{NETWORK_NAME}\"? This cannot be undone.",
+                "confirmButton": "Delete",
+                "cancelButton": "Cancel"
+            },
+            "DeleteEmailTemplateDialog": {
+                "title": "Delete email template",
+                "message": "Are you sure you want to delete \"{IDENTIFIER}\"? Any part of the application that still sends this email will silently stop sending it. This cannot be undone.",
                 "confirmButton": "Delete",
                 "cancelButton": "Cancel"
             },

--- a/src/interfaces/EmailTemplate.ts
+++ b/src/interfaces/EmailTemplate.ts
@@ -1,0 +1,17 @@
+export interface EmailTemplate {
+    id: number;
+    identifier: string;
+    subject: string;
+    body: string;
+    enabled: boolean;
+    created_at: string;
+    updated_at: string;
+    deleted_at: string | null;
+}
+
+export interface EmailTemplateFormValues {
+    identifier: string;
+    subject: string;
+    body: string;
+    enabled: boolean;
+}


### PR DESCRIPTION
… Allows creation and editing of email templates and the toggling on/off the sending of specific emails when necessary

> AI disclaimer: Claude Sonnet 5 was used heavily in the creation of these changes.

## Screenshots (if relevant)

https://github.com/user-attachments/assets/a638b254-3c36-41f4-9650-24c5b8a2e12d


## Describe your changes
Adds administration capabilities to admin panel for managing email templates.

## Issue ticket link
https://hdruk.atlassian.net/browse/GAT-9442

## Checklist before requesting a review

-   [x] I have performed a self-review of my code
-   [x] I have added appropriate unit tests
-   [ ] I have created mocks for unit tests (where appropriate)
-   [ ] The interface is responsive (where appropriate)
-   [ ] The interface is at least AA (where appropriate)
