### PR TITLE
feat(GAT-9134): Add delete widget confirmation modal

### DIFF
--- a/src/app/[locale]/account/team/[teamId]/(withLeftNav)/integrations/widgets/components/WidgetList/WidgetList.tsx
+++ b/src/app/[locale]/account/team/[teamId]/(withLeftNav)/integrations/widgets/components/WidgetList/WidgetList.tsx
@@ -11,6 +11,7 @@ import Loading from "@/components/Loading";
 import Paper from "@/components/Paper";
 import useDelete from "@/hooks/useDelete";
 import useGet from "@/hooks/useGet";
+import useModal from "@/hooks/useModal";
 import apis from "@/config/apis";
 import { colors } from "@/config/theme";
 import { DarEditIcon, DeleteIcon, EyeIcon } from "@/consts/icons";
@@ -27,6 +28,7 @@ const TRANSLATION_PATH = `pages.account.team.widgets`;
 const WidgetList = ({ permissions, teamId }: WidgetListProps) => {
     const t = useTranslations(TRANSLATION_PATH);
     const params = useParams<{ teamId: string }>();
+    const { showModal } = useModal();
 
     const baseWidgetUrl = `${apis.teamsV1Url}/${teamId}/widgets`;
 
@@ -66,9 +68,22 @@ const WidgetList = ({ permissions, teamId }: WidgetListProps) => {
         ...(showDeleteButton
             ? [
                   {
-                      action: async (id: number) => {
-                          await deleteWidget(id);
-                          mutateWidgets();
+                      action: (id: number) => {
+                          showModal({
+                              title: t("actions.delete.title"),
+                              content: t("actions.delete.content", {
+                                  WIDGET_NAME:
+                                      widgetList?.find(
+                                          widget => widget.id === id
+                                      )?.widget_name ?? "",
+                              }),
+                              confirmText: t("actions.delete.confirmText"),
+                              cancelText: t("actions.delete.cancelText"),
+                              onSuccess: async () => {
+                                  await deleteWidget(id);
+                                  mutateWidgets();
+                              },
+                          });
                       },
                       icon: DeleteIcon,
                       label: t("actions.delete.label"),

--- a/src/config/messages/en.json
+++ b/src/config/messages/en.json
@@ -1079,7 +1079,13 @@
                     "actions": {
                         "edit": { "label": "Edit widget" },
                         "preview": { "label": "Preview widget" },
-                        "delete": { "label": "Delete widget" }
+                        "delete": {
+                            "label": "Delete widget",
+                            "title": "Delete widget",
+                            "content": "Are you sure you want to delete \"{WIDGET_NAME}\"? This cannot be undone.",
+                            "confirmText": "Delete",
+                            "cancelText": "Cancel"
+                        }
                     },
                     "createmodal": {
                         "create": "Create new widget",


### PR DESCRIPTION
> AI disclaimer - CLAUDE was used for this. The approach was planned and reviewed manually — reusing the existing shared `Modal`/`useModal` rather than adding another bespoke delete dialog — and CLAUDE implemented it from that plan. The change is small (~25 lines across 2 files); wording of the confirmation copy was checked by hand against the existing delete dialogs for consistency.

## Screenshots / videos (if relevant)
<img width="675" height="202" alt="image" src="https://github.com/user-attachments/assets/fe2e1799-b29b-47c8-903b-5c95ffdcd947" />

## Describe your changes
Deleting a widget from the team widgets page previously happened the instant the bin icon was clicked — no confirmation, no undo, and no way back from a misclick. This adds a confirmation step using the shared `Modal` component (via `useModal`), the same pattern already used for the archive/unarchive actions on the Collections and Tools lists, so no new dialog component was introduced. The modal names the widget being deleted and warns the action can't be undone; cancelling or closing it fires no request at all, and confirming performs the delete and revalidates the list as before.

Copy follows the house style already used by the team, network and email-template delete dialogs ("Delete X" title, quoted entity name in the body, "This cannot be undone."). Worth noting for review: there are now five near-identical bespoke delete dialogs elsewhere in the account area that could be consolidated onto this same shared modal — a follow-up review of modals and dialogs across the site is planned separately.

## Issue ticket link
https://hdruk.atlassian.net/browse/GAT-9134

## Checklist before requesting a review

- [x] I have performed a self-review of my code
- [ ] I have added appropriate unit tests / e2e tests (where relevant)
- [ ] I have created mocks for api endpoints (where appropriate)
- [ ] The interface is responsive (where ticket is relevant)
- [ ] The interface is at least AA (where ticket is relevant)
- [x] Commits are described as "(chore|fix|feature|test|maintenance): description"
