### PR TITLE
feat(GAT-9205): Reapply for cohort discovery when near expiry

### DIFF
--- a/src/app/[locale]/(logged-out)/search/components/ResultsTable/ResultsTable.tsx
+++ b/src/app/[locale]/(logged-out)/search/components/ResultsTable/ResultsTable.tsx
@@ -13,6 +13,7 @@ import useAuth from "@/hooks/useAuth";
 import { useCohortStatus } from "@/hooks/useCohortStatus";
 import useGet from "@/hooks/useGet";
 import apis from "@/config/apis";
+import { isAwaitingCohortDecision } from "@/consts/cohortDiscovery";
 import { CheckIcon } from "@/consts/icons";
 import { RouteName } from "@/consts/routeName";
 import { formatTextDelimiter } from "@/utils/dataset";
@@ -275,7 +276,7 @@ const ResultTable = ({ results, showLibraryModal }: ResultTableProps) => {
     const t = useTranslations(RESULTS_TABLE_TRANSLATION_PATH);
     const { isLoggedIn, user } = useAuth();
 
-    const { requestStatus } = useCohortStatus(user?.id);
+    const { requestStatus, hasAccess } = useCohortStatus(user?.id);
 
     const { data: libraryData, mutate: mutateLibraries } = useGet<Library[]>(
         `${apis.librariesV1Url}?per_page=-1`,
@@ -283,9 +284,7 @@ const ResultTable = ({ results, showLibraryModal }: ResultTableProps) => {
     );
 
     const isCohortDiscoveryDisabled =
-        isLoggedIn && requestStatus
-            ? !["APPROVED", "REJECTED", "EXPIRED"].includes(requestStatus)
-            : false;
+        isLoggedIn && isAwaitingCohortDecision(requestStatus, hasAccess);
 
     const translations = {
         actionLabel: t("action.label"),

--- a/src/app/[locale]/(logged-out)/search/components/Search/Search.tsx
+++ b/src/app/[locale]/(logged-out)/search/components/Search/Search.tsx
@@ -86,6 +86,7 @@ import {
     sortByOptionsTool,
 } from "@/config/forms/search";
 import { colors } from "@/config/theme";
+import { isAwaitingCohortDecision } from "@/consts/cohortDiscovery";
 import {
     ChevronThinIcon,
     CloseIcon,
@@ -466,12 +467,10 @@ const Search = ({ filters, schema }: SearchProps) => {
         setIsDownloading(false);
     };
 
-    const { requestStatus } = useCohortStatus(user?.id);
+    const { requestStatus, hasAccess } = useCohortStatus(user?.id);
 
     const isCohortDiscoveryDisabled =
-        isLoggedIn && requestStatus
-            ? !["APPROVED", "REJECTED", "EXPIRED"].includes(requestStatus)
-            : false;
+        isLoggedIn && isAwaitingCohortDecision(requestStatus, hasAccess);
 
     const renderResultCard = (result: SearchResult) => {
         const { _id: resultId } = result;

--- a/src/app/[locale]/account/profile/cohort-discovery-request/components/CohortAccessStepper/CohortAccessStepper.test.tsx
+++ b/src/app/[locale]/account/profile/cohort-discovery-request/components/CohortAccessStepper/CohortAccessStepper.test.tsx
@@ -70,10 +70,17 @@ const cmsContent: templateRepeatFields = {
 const baseStatus = {
     requestStatus: null,
     requestExpiry: null,
+    hasAccess: false,
     nhseSdeRequestStatus: null,
     isLoading: false,
     hasFetched: true,
     refetch: jest.fn(),
+};
+
+const daysFromNow = (days: number) => {
+    const date = new Date();
+    date.setDate(date.getDate() + days);
+    return date.toISOString();
 };
 
 const renderStepper = () =>
@@ -163,11 +170,16 @@ describe("CohortAccessStepper", () => {
         mockUseCohortStatus.mockReturnValue({
             ...baseStatus,
             requestStatus: "APPROVED",
+            hasAccess: true,
+            requestExpiry: daysFromNow(90),
         });
 
         renderStepper();
 
         expect(screen.getByText("Approved")).toBeInTheDocument();
+        expect(
+            screen.getByText(/days remaining in current access period/)
+        ).toBeInTheDocument();
         expect(
             screen.getByRole("button", {
                 name: "Access Cohort Discovery tool",
@@ -176,12 +188,75 @@ describe("CohortAccessStepper", () => {
         expect(
             screen.queryByText("Application Review")
         ).not.toBeInTheDocument();
+        expect(
+            screen.queryByRole("button", {
+                name: "Re-apply for Cohort Discovery",
+            })
+        ).not.toBeInTheDocument();
+    });
+
+    it("offers re-apply alongside the access badge once access is expiring soon", () => {
+        mockUseCohortStatus.mockReturnValue({
+            ...baseStatus,
+            requestStatus: "APPROVED",
+            hasAccess: true,
+            requestExpiry: daysFromNow(14),
+        });
+
+        renderStepper();
+
+        expect(screen.getByText("Approved")).toBeInTheDocument();
+        expect(screen.getByText(/Access expiring in/)).toBeInTheDocument();
+        expect(
+            screen.getByText("Re-apply for Cohort Discovery Access")
+        ).toBeInTheDocument();
+        expect(
+            screen.getByRole("button", {
+                name: "Re-apply for Cohort Discovery",
+            })
+        ).toBeInTheDocument();
+        expect(
+            screen.getByRole("button", {
+                name: "Access Cohort Discovery tool",
+            })
+        ).toBeInTheDocument();
+    });
+
+    it("keeps access and advances to the review step once a renewal is submitted", () => {
+        mockUseCohortStatus.mockReturnValue({
+            ...baseStatus,
+            requestStatus: "RENEWING",
+            hasAccess: true,
+            requestExpiry: daysFromNow(14),
+        });
+
+        renderStepper();
+
+        expect(screen.getByText("Renewing")).toBeInTheDocument();
+        expect(
+            screen.getByRole("button", {
+                name: "Access Cohort Discovery tool",
+            })
+        ).toBeInTheDocument();
+        expect(screen.getByText("Application Review")).toBeInTheDocument();
+        /* step 1 is complete, so its description and button are gone */
+        expect(
+            screen.queryByRole("button", {
+                name: "Re-apply for Cohort Discovery",
+            })
+        ).not.toBeInTheDocument();
+        expect(
+            screen.getByText(
+                "This step generally takes 5-7 days. Your application will be reviewed based on your Gateway profile and submitted information. If anything is unclear, we will contact you for further information."
+            )
+        ).toBeInTheDocument();
     });
 
     it("hides the access button when hideAccessButton is set", () => {
         mockUseCohortStatus.mockReturnValue({
             ...baseStatus,
             requestStatus: "APPROVED",
+            hasAccess: true,
         });
 
         render(
@@ -206,7 +281,7 @@ describe("CohortAccessStepper", () => {
 
         expect(screen.getByText("Expired")).toBeInTheDocument();
         expect(
-            screen.getByRole("button", { name: "Re-apply for access" })
+            screen.getByRole("button", { name: "Re-apply for Cohort Discovery" })
         ).toBeInTheDocument();
         expect(
             screen.queryByRole("button", { name: "Apply for Cohort Discovery" })
@@ -224,7 +299,7 @@ describe("CohortAccessStepper", () => {
         expect(screen.getByText("Rejected")).toBeInTheDocument();
 
         await userEvent.click(
-            screen.getByRole("button", { name: "Re-apply for access" })
+            screen.getByRole("button", { name: "Re-apply for Cohort Discovery" })
         );
 
         expect(screen.getByText("Review Your Profile")).toBeInTheDocument();
@@ -255,7 +330,7 @@ describe("CohortAccessStepper", () => {
 
         expect(screen.getByText("Banned")).toBeInTheDocument();
         expect(
-            screen.queryByRole("button", { name: "Re-apply for access" })
+            screen.queryByRole("button", { name: "Re-apply for Cohort Discovery" })
         ).not.toBeInTheDocument();
         expect(
             screen.queryByRole("button", { name: "Apply for Cohort Discovery" })

--- a/src/app/[locale]/account/profile/cohort-discovery-request/components/CohortAccessStepper/CohortAccessStepper.test.tsx
+++ b/src/app/[locale]/account/profile/cohort-discovery-request/components/CohortAccessStepper/CohortAccessStepper.test.tsx
@@ -232,7 +232,12 @@ describe("CohortAccessStepper", () => {
 
         renderStepper();
 
-        expect(screen.getByText("Renewing")).toBeInTheDocument();
+        /* current access is untouched; the renewal is what is pending */
+        expect(screen.getByText("Current Access :")).toBeInTheDocument();
+        expect(screen.getByText("Approved")).toBeInTheDocument();
+        expect(screen.getByText("Access Renewal :")).toBeInTheDocument();
+        expect(screen.getByText("Pending")).toBeInTheDocument();
+        expect(screen.getByText(/Access expiring in/)).toBeInTheDocument();
         expect(
             screen.getByRole("button", {
                 name: "Access Cohort Discovery tool",

--- a/src/app/[locale]/account/profile/cohort-discovery-request/components/CohortAccessStepper/CohortAccessStepper.tsx
+++ b/src/app/[locale]/account/profile/cohort-discovery-request/components/CohortAccessStepper/CohortAccessStepper.tsx
@@ -77,12 +77,17 @@ const CohortAccessStepper = ({
             : null;
     const expiringSoon =
         hasAccess &&
-        !isRenewing &&
         daysRemaining != null &&
         daysRemaining <= COHORT_EXPIRY_WARNING_DAYS;
 
+    const indicatorColour = expiringSoon ? colors.yellow800 : colors.grey600;
+
+    /* a renewing user still holds their approved access until it lapses */
+    const accessStatus = isRenewing ? COHORT_STATUS.APPROVED : requestStatus;
+
     const canReapply =
-        COHORT_REAPPLY_STATUSES.includes(requestStatus ?? "") || expiringSoon;
+        COHORT_REAPPLY_STATUSES.includes(requestStatus ?? "") ||
+        (expiringSoon && !isRenewing);
     const showReapplyCopy = canReapply || isRenewing;
     const showSteps = !hasAccess || canReapply || isRenewing;
 
@@ -169,38 +174,70 @@ const CohortAccessStepper = ({
                     {!loading && hasApplied && (
                         <Box
                             sx={{
-                                display: "flex",
+                                display: "grid",
+                                gridTemplateColumns: "auto auto",
+                                justifyContent: "start",
+                                justifyItems: "start",
                                 alignItems: "center",
-                                gap: 2,
+                                columnGap: 1,
+                                rowGap: 1,
                                 mt: 1,
                             }}>
-                            <Chip
-                                size="small"
-                                label={capitalise(requestStatus)}
-                                color={
-                                    expiringSoon
-                                        ? "yellowCustom"
-                                        : statusMapping[requestStatus]
-                                }
-                            />
-                            {daysRemaining != null && (
-                                <>
-                                    <QueryBuilderIcon
-                                        sx={{ color: colors.grey600 }}
-                                    />
-                                    {expiringSoon ? (
-                                        <Typography>
-                                            {tCd("accessExpiringIn", {
-                                                days: daysRemaining,
-                                            })}
-                                        </Typography>
-                                    ) : (
+                            {isRenewing && (
+                                <Typography sx={{ color: colors.grey600 }}>
+                                    {tCd("currentAccessLabel")}
+                                </Typography>
+                            )}
+                            <Box
+                                sx={{
+                                    display: "flex",
+                                    alignItems: "center",
+                                    gap: 2,
+                                }}>
+                                <Chip
+                                    size="small"
+                                    label={capitalise(accessStatus)}
+                                    color={
+                                        expiringSoon
+                                            ? "yellowCustom"
+                                            : statusMapping[accessStatus]
+                                    }
+                                />
+                                {daysRemaining != null && (
+                                    <Box
+                                        sx={{
+                                            display: "flex",
+                                            alignItems: "center",
+                                            gap: 1,
+                                        }}>
+                                        <QueryBuilderIcon
+                                            sx={{ color: indicatorColour }}
+                                        />
                                         <Typography
-                                            sx={{ color: colors.grey600 }}>
-                                            {daysRemaining}{" "}
-                                            {tCd("daysRemaining")}
+                                            sx={{ color: indicatorColour }}>
+                                            {expiringSoon
+                                                ? tCd("accessExpiringIn", {
+                                                      days: daysRemaining,
+                                                  })
+                                                : `${daysRemaining} ${tCd(
+                                                      "daysRemaining"
+                                                  )}`}
                                         </Typography>
-                                    )}
+                                    </Box>
+                                )}
+                            </Box>
+                            {isRenewing && (
+                                <>
+                                    <Typography sx={{ color: colors.grey600 }}>
+                                        {tCd("accessRenewalLabel")}
+                                    </Typography>
+                                    <Chip
+                                        size="small"
+                                        label={capitalise(
+                                            COHORT_STATUS.PENDING
+                                        )}
+                                        color="greyCustom"
+                                    />
                                 </>
                             )}
                         </Box>

--- a/src/app/[locale]/account/profile/cohort-discovery-request/components/CohortAccessStepper/CohortAccessStepper.tsx
+++ b/src/app/[locale]/account/profile/cohort-discovery-request/components/CohortAccessStepper/CohortAccessStepper.tsx
@@ -19,7 +19,9 @@ import useDialog from "@/hooks/useDialog";
 import { colors } from "@/config/theme";
 import {
     COHORT_ABOUT_HREF,
+    COHORT_EXPIRY_WARNING_DAYS,
     COHORT_REAPPLY_STATUSES,
+    COHORT_STATUS,
     statusMapping,
     STEP_STATE,
 } from "@/consts/cohortDiscovery";
@@ -52,6 +54,7 @@ const CohortAccessStepper = ({
     const {
         requestStatus,
         requestExpiry,
+        hasAccess,
         isLoading: statusLoading,
         hasFetched,
         refetch,
@@ -63,10 +66,25 @@ const CohortAccessStepper = ({
     const subStepsRef = useRef<HTMLDivElement>(null);
 
     const hasApplied = !!requestStatus;
-    const isApproved = requestStatus === "APPROVED";
+    const isApproved = requestStatus === COHORT_STATUS.APPROVED;
+    const isRenewing = requestStatus === COHORT_STATUS.RENEWING;
     const isResolved = RESOLVED_STATUSES.includes(requestStatus ?? "");
     const inReview = hasApplied && !isResolved;
-    const canReapply = COHORT_REAPPLY_STATUSES.includes(requestStatus ?? "");
+
+    const daysRemaining =
+        hasAccess && requestExpiry
+            ? differenceInDays(requestExpiry, new Date())
+            : null;
+    const expiringSoon =
+        hasAccess &&
+        !isRenewing &&
+        daysRemaining != null &&
+        daysRemaining <= COHORT_EXPIRY_WARNING_DAYS;
+
+    const canReapply =
+        COHORT_REAPPLY_STATUSES.includes(requestStatus ?? "") || expiringSoon;
+    const showReapplyCopy = canReapply || isRenewing;
+    const showSteps = !hasAccess || canReapply || isRenewing;
 
     const step1State: CircleState =
         hasApplied && !canReapply ? STEP_STATE.COMPLETE : STEP_STATE.ACTIVE;
@@ -76,16 +94,12 @@ const CohortAccessStepper = ({
             : inReview
             ? STEP_STATE.ACTIVE
             : STEP_STATE.PENDING;
-    const step3State: CircleState = isApproved
-        ? STEP_STATE.COMPLETE
-        : isResolved && !canReapply
-        ? STEP_STATE.ACTIVE
-        : STEP_STATE.PENDING;
-
-    const daysRemaining =
-        isApproved && requestExpiry
-            ? differenceInDays(requestExpiry, new Date())
-            : null;
+    const step3State: CircleState =
+        isApproved && !canReapply
+            ? STEP_STATE.COMPLETE
+            : isResolved && !canReapply
+            ? STEP_STATE.ACTIVE
+            : STEP_STATE.PENDING;
 
     const continueToTerms = () => {
         const node = subStepsRef.current;
@@ -163,22 +177,36 @@ const CohortAccessStepper = ({
                             <Chip
                                 size="small"
                                 label={capitalise(requestStatus)}
-                                color={statusMapping[requestStatus]}
+                                color={
+                                    expiringSoon
+                                        ? "yellowCustom"
+                                        : statusMapping[requestStatus]
+                                }
                             />
-                            {isApproved && daysRemaining != null && (
+                            {daysRemaining != null && (
                                 <>
                                     <QueryBuilderIcon
                                         sx={{ color: colors.grey600 }}
                                     />
-                                    <Typography sx={{ color: colors.grey600 }}>
-                                        {daysRemaining} {tCd("daysRemaining")}
-                                    </Typography>
+                                    {expiringSoon ? (
+                                        <Typography>
+                                            {tCd("accessExpiringIn", {
+                                                days: daysRemaining,
+                                            })}
+                                        </Typography>
+                                    ) : (
+                                        <Typography
+                                            sx={{ color: colors.grey600 }}>
+                                            {daysRemaining}{" "}
+                                            {tCd("daysRemaining")}
+                                        </Typography>
+                                    )}
                                 </>
                             )}
                         </Box>
                     )}
                 </Box>
-                {!loading && isApproved && !hideAccessButton && (
+                {!loading && hasAccess && !hideAccessButton && (
                     <CohortDiscoveryButton
                         label={t("accessButton")}
                         wrapperSx={{ width: "auto" }}
@@ -188,14 +216,20 @@ const CohortAccessStepper = ({
 
             {loading ? (
                 <Loading />
-            ) : isApproved ? null : (
+            ) : showSteps ? (
                 <>
                     <StepNode circleState={step1State} label="1">
-                        <StepTitle>{t("applyStepTitle")}</StepTitle>
+                        <StepTitle>
+                            {showReapplyCopy
+                                ? t("reapplyStepTitle")
+                                : t("applyStepTitle")}
+                        </StepTitle>
                         {step1State !== STEP_STATE.COMPLETE && (
                             <>
                                 <Typography color={colors.grey600}>
-                                    {t("applyStepDescription")}
+                                    {showReapplyCopy
+                                        ? t("reapplyStepDescription")
+                                        : t("applyStepDescription")}
                                 </Typography>
 
                                 {!started ? (
@@ -319,7 +353,7 @@ const CohortAccessStepper = ({
                         )}
                     </StepNode>
                 </>
-            )}
+            ) : null}
         </Paper>
     );
 };

--- a/src/app/[locale]/account/profile/cohort-discovery-request/components/CohortDiscoveryCoverPage/CohortDiscoveryCoverPage.test.tsx
+++ b/src/app/[locale]/account/profile/cohort-discovery-request/components/CohortDiscoveryCoverPage/CohortDiscoveryCoverPage.test.tsx
@@ -37,6 +37,7 @@ jest.mock("@/components/CohortDiscoveryButton", () => ({
 
 const baseStatus = {
     requestStatus: null,
+    hasAccess: false,
     requestExpiry: null,
     nhseSdeRequestStatus: null,
     isLoading: false,
@@ -58,7 +59,7 @@ describe("CohortDiscoveryCoverPage", () => {
     it("does not render a shared access panel when only one access is approved", () => {
         mockUseCohortStatus.mockReturnValue({
             ...baseStatus,
-            requestStatus: "APPROVED",
+            hasAccess: true,
             nhseSdeRequestStatus: "IN PROCESS",
         });
 
@@ -75,7 +76,7 @@ describe("CohortDiscoveryCoverPage", () => {
     it("combines into a single shared access panel when both accesses are approved", () => {
         mockUseCohortStatus.mockReturnValue({
             ...baseStatus,
-            requestStatus: "APPROVED",
+            hasAccess: true,
             nhseSdeRequestStatus: "APPROVED",
         });
 

--- a/src/app/[locale]/account/profile/cohort-discovery-request/components/CohortDiscoveryCoverPage/CohortDiscoveryCoverPage.tsx
+++ b/src/app/[locale]/account/profile/cohort-discovery-request/components/CohortDiscoveryCoverPage/CohortDiscoveryCoverPage.tsx
@@ -7,7 +7,7 @@ import Box from "@/components/Box";
 import Container from "@/components/Container";
 import useAuth from "@/hooks/useAuth";
 import { useCohortStatus } from "@/hooks/useCohortStatus";
-import { COHORT_STATUS, NHS_SDE_STATUS } from "@/consts/cohortDiscovery";
+import { NHS_SDE_STATUS } from "@/consts/cohortDiscovery";
 import CohortAccessPanel from "../CohortAccessPanel";
 import CohortAccessStepper from "../CohortAccessStepper";
 import NhsSdeAccessStepper from "../NhsSdeAccessStepper";
@@ -20,11 +20,10 @@ export default function CohortDiscoveryCoverPage({
     const t = useTranslations("pages.account.profile.cohortDiscovery");
 
     const { user } = useAuth();
-    const { requestStatus, nhseSdeRequestStatus } = useCohortStatus(user?.id);
+    const { hasAccess, nhseSdeRequestStatus } = useCohortStatus(user?.id);
 
     const bothApproved =
-        requestStatus === COHORT_STATUS.APPROVED &&
-        nhseSdeRequestStatus === NHS_SDE_STATUS.APPROVED;
+        hasAccess && nhseSdeRequestStatus === NHS_SDE_STATUS.APPROVED;
 
     return (
         <Container sx={{ display: "flex", flexDirection: "column" }}>

--- a/src/app/[locale]/account/profile/cohort-discovery-request/components/NhsSdeAccessStepper/NhsSdeAccessStepper.test.tsx
+++ b/src/app/[locale]/account/profile/cohort-discovery-request/components/NhsSdeAccessStepper/NhsSdeAccessStepper.test.tsx
@@ -70,6 +70,7 @@ jest.mock("@/components/IndicateNhseSdeAccessButton", () => ({
 
 const baseStatus = {
     requestStatus: null,
+    hasAccess: false,
     nhseSdeRequestStatus: null,
     requestExpiry: null,
     isLoading: false,
@@ -105,7 +106,7 @@ describe("NhsSdeAccessStepper", () => {
     it("shows step 1 as complete with an apply button when Cohort Discovery is approved", async () => {
         mockUseCohortStatus.mockReturnValue({
             ...baseStatus,
-            requestStatus: "APPROVED",
+            hasAccess: true,
         });
 
         renderStepper();
@@ -140,7 +141,7 @@ describe("NhsSdeAccessStepper", () => {
     it("shows an Awaiting Action badge and activates step 2 when the NHS request is IN PROCESS", async () => {
         mockUseCohortStatus.mockReturnValue({
             ...baseStatus,
-            requestStatus: "APPROVED",
+            hasAccess: true,
             nhseSdeRequestStatus: "IN PROCESS",
         });
 
@@ -162,7 +163,7 @@ describe("NhsSdeAccessStepper", () => {
     it("advances to step 3 and fires the indicate POST via the confirm modal once the form is completed", async () => {
         mockUseCohortStatus.mockReturnValue({
             ...baseStatus,
-            requestStatus: "APPROVED",
+            hasAccess: true,
             nhseSdeRequestStatus: "IN PROCESS",
         });
 
@@ -194,7 +195,7 @@ describe("NhsSdeAccessStepper", () => {
     it("shows a Pending badge when NHS approval has been requested", () => {
         mockUseCohortStatus.mockReturnValue({
             ...baseStatus,
-            requestStatus: "APPROVED",
+            hasAccess: true,
             nhseSdeRequestStatus: "APPROVAL REQUESTED",
         });
 
@@ -211,7 +212,7 @@ describe("NhsSdeAccessStepper", () => {
     it("shows an Approved badge when NHS access has been granted", () => {
         mockUseCohortStatus.mockReturnValue({
             ...baseStatus,
-            requestStatus: "APPROVED",
+            hasAccess: true,
             nhseSdeRequestStatus: "APPROVED",
         });
 
@@ -223,7 +224,7 @@ describe("NhsSdeAccessStepper", () => {
     it("hides all the steps once NHS access has been granted", () => {
         mockUseCohortStatus.mockReturnValue({
             ...baseStatus,
-            requestStatus: "APPROVED",
+            hasAccess: true,
             nhseSdeRequestStatus: "APPROVED",
         });
 
@@ -243,7 +244,7 @@ describe("NhsSdeAccessStepper", () => {
         status => {
             mockUseCohortStatus.mockReturnValue({
                 ...baseStatus,
-                requestStatus: "APPROVED",
+                hasAccess: true,
                 nhseSdeRequestStatus: status,
             });
 
@@ -266,7 +267,7 @@ describe("NhsSdeAccessStepper", () => {
     it("lets an expired user restart the application from step 1", async () => {
         mockUseCohortStatus.mockReturnValue({
             ...baseStatus,
-            requestStatus: "APPROVED",
+            hasAccess: true,
             nhseSdeRequestStatus: "EXPIRED",
         });
 
@@ -296,7 +297,7 @@ describe("NhsSdeAccessStepper", () => {
     it("reveals step 2 with the registration form once the user opts in from step 1", async () => {
         mockUseCohortStatus.mockReturnValue({
             ...baseStatus,
-            requestStatus: "APPROVED",
+            hasAccess: true,
         });
 
         renderStepper();
@@ -318,7 +319,7 @@ describe("NhsSdeAccessStepper", () => {
     it("reveals the confirm button once the registration form has been opened, without waiting for the status to change", async () => {
         mockUseCohortStatus.mockReturnValue({
             ...baseStatus,
-            requestStatus: "APPROVED",
+            hasAccess: true,
         });
 
         renderStepper();

--- a/src/app/[locale]/account/profile/cohort-discovery-request/components/NhsSdeAccessStepper/NhsSdeAccessStepper.tsx
+++ b/src/app/[locale]/account/profile/cohort-discovery-request/components/NhsSdeAccessStepper/NhsSdeAccessStepper.tsx
@@ -20,7 +20,6 @@ import apis from "@/config/apis";
 import { colors } from "@/config/theme";
 import {
     COHORT_ABOUT_HREF,
-    COHORT_STATUS,
     NHS_SDE_FINAL_STATUSES,
     NHS_SDE_NEGATIVE_STATUSES,
     NHS_SDE_STATUS,
@@ -52,7 +51,7 @@ const NhsSdeAccessStepper = () => {
     const { user, isLoading: userLoading } = useAuth();
     const { isNhsSdeApplicationsEnabled } = useFeatures();
     const {
-        requestStatus,
+        hasAccess,
         nhseSdeRequestStatus,
         isLoading: statusLoading,
         hasFetched,
@@ -71,7 +70,6 @@ const NhsSdeAccessStepper = () => {
 
     const loading = userLoading || statusLoading || !hasFetched;
 
-    const cdsApproved = requestStatus === COHORT_STATUS.APPROVED;
     const nhs = nhseSdeRequestStatus;
     const isApproved = nhs === NHS_SDE_STATUS.APPROVED;
     const inProcess = nhs === NHS_SDE_STATUS.IN_PROCESS;
@@ -81,7 +79,7 @@ const NhsSdeAccessStepper = () => {
     const canApply = !nhs || nhs === NHS_SDE_STATUS.EXPIRED;
 
     const activeStep = (() => {
-        if (!cdsApproved) return STEP.EXISTING_ACCESS;
+        if (!hasAccess) return STEP.EXISTING_ACCESS;
         switch (nhs) {
             case NHS_SDE_STATUS.APPROVAL_REQUESTED:
                 return STEP.APPLICATION_REVIEW;
@@ -95,14 +93,14 @@ const NhsSdeAccessStepper = () => {
 
     const circleFor = (index: number): CircleState => {
         if (index === STEP.EXISTING_ACCESS) {
-            return cdsApproved ? STEP_STATE.COMPLETE : STEP_STATE.LOCKED;
+            return hasAccess ? STEP_STATE.COMPLETE : STEP_STATE.LOCKED;
         }
         if (index < activeStep) return STEP_STATE.COMPLETE;
         if (index === activeStep) return STEP_STATE.ACTIVE;
         return STEP_STATE.PENDING;
     };
 
-    const badge = !cdsApproved
+    const badge = !hasAccess
         ? null
         : approvalRequested
         ? { label: t("badgePending"), bg: colors.grey600 }
@@ -140,7 +138,7 @@ const NhsSdeAccessStepper = () => {
             titleKey: "step1Title",
             extra: () => (
                 <>
-                    {!cdsApproved && (
+                    {!hasAccess && (
                         <Typography
                             component="div"
                             color={colors.grey600}
@@ -152,7 +150,7 @@ const NhsSdeAccessStepper = () => {
                             })}
                         </Typography>
                     )}
-                    {cdsApproved && canApply && !applied && (
+                    {hasAccess && canApply && !applied && (
                         <Button
                             data-testid="nhs-sde-apply-button"
                             variant="outlined"

--- a/src/app/actions/getCohortStatusAndRedirectAction.test.ts
+++ b/src/app/actions/getCohortStatusAndRedirectAction.test.ts
@@ -25,6 +25,7 @@ describe("getCohortStatusAndRedirect", () => {
         const mockUserRequest = {
             request_status: "APPROVED",
             request_expire_at: "07-07-2025 10:00:00",
+            has_access: true,
         };
 
         (getUserCohortRequest as jest.Mock).mockResolvedValue(mockUserRequest);
@@ -37,6 +38,7 @@ describe("getCohortStatusAndRedirect", () => {
             nhseSdeRequestStatus: null,
             requestExpiry: "07-07-2025 10:00:00",
             redirectUrl: "",
+            hasAccess: true,
         });
     });
 
@@ -53,7 +55,7 @@ describe("getCohortStatusAndRedirect", () => {
         expect(result).toBeNull();
     });
 
-    it("should handle missing request_status or redirect_url", async () => {
+    it("should handle missing request_status, has_access or redirect_url", async () => {
         (getUserCohortRequest as jest.Mock).mockResolvedValue({});
         (getCohortAccessRedirect as jest.Mock).mockResolvedValue({});
 
@@ -64,6 +66,7 @@ describe("getCohortStatusAndRedirect", () => {
             nhseSdeRequestStatus: null,
             requestExpiry: null,
             redirectUrl: "",
+            hasAccess: false,
         });
     });
 });

--- a/src/app/actions/getCohortStatusAndRedirectAction.ts
+++ b/src/app/actions/getCohortStatusAndRedirectAction.ts
@@ -23,6 +23,7 @@ export const getCohortStatusAndRedirect = async (
             nhseSdeRequestStatus: userRequest?.nhse_sde_request_status ?? null,
             requestExpiry: userRequest?.request_expire_at ?? null,
             redirectUrl: accessRedirect?.redirect_url ?? null,
+            hasAccess: userRequest?.has_access ?? false,
         };
     } catch (error) {
         const session = await getSessionCookie();

--- a/src/components/CohortDiscoveryButton/CohortDiscoveryButton.tsx
+++ b/src/components/CohortDiscoveryButton/CohortDiscoveryButton.tsx
@@ -19,7 +19,10 @@ import { useCohortStatus } from "@/hooks/useCohortStatus";
 import useDialog from "@/hooks/useDialog";
 import useLogout from "@/hooks/useLogout";
 import useModal from "@/hooks/useModal";
-import { statusMapping } from "@/consts/cohortDiscovery";
+import {
+    isAwaitingCohortDecision,
+    statusMapping,
+} from "@/consts/cohortDiscovery";
 import { RouteName } from "@/consts/routeName";
 import { capitalise } from "@/utils/general";
 import { useFeatures } from "@/providers/FeatureProvider";
@@ -69,6 +72,7 @@ const CohortDiscoveryButton = ({
     const {
         requestStatus,
         requestExpiry,
+        hasAccess,
         isLoading: isLoadingStatus,
     } = useCohortStatus(user?.id);
 
@@ -91,7 +95,7 @@ const CohortDiscoveryButton = ({
         isLoadingRQuestRedirect ||
         isLoadingCdsRedirect;
 
-    const isApproved = isLoggedIn && requestStatus === "APPROVED";
+    const isApproved = isLoggedIn && hasAccess;
 
     const hasClaimsMismatch =
         isApproved &&
@@ -102,9 +106,7 @@ const CohortDiscoveryButton = ({
     );
 
     const isPendingApproval = Boolean(
-        isLoggedIn &&
-            requestStatus &&
-            !["APPROVED", "REJECTED", "EXPIRED"].includes(requestStatus)
+        isLoggedIn && isAwaitingCohortDecision(requestStatus, hasAccess)
     );
 
     const isDisabled = disabledOuter || openAthensInvalid || isPendingApproval;
@@ -250,7 +252,7 @@ const CohortDiscoveryButton = ({
             return;
         }
 
-        if (requestStatus !== "APPROVED") {
+        if (!hasAccess) {
             showModal({
                 title: t("modals.notApproved.title"),
                 content: nonApprovedContent,
@@ -301,6 +303,7 @@ const CohortDiscoveryButton = ({
         isLoggedIn,
         hrefOverride,
         requestStatus,
+        hasAccess,
         nonApprovedContent,
         handleRequestAccess,
         hasClaimsMismatch,

--- a/src/config/messages/en.json
+++ b/src/config/messages/en.json
@@ -338,7 +338,9 @@
                     "headerText": "Learn about Cohort Discovery and gain access to the service",
                     "accessTitle": "Cohort Data Access",
                     "daysRemaining": "days remaining in current access period",
-                    "accessExpiringIn": "Access expiring in {days} Days",
+                    "accessExpiringIn": "Access expiring in {days, plural, one {# Day} other {# Days}}",
+                    "currentAccessLabel": "Current Access :",
+                    "accessRenewalLabel": "Access Renewal :",
                     "accessText1": "Cohort Discovery allows researchers to explore and identify patient cohorts across multiple, federated health data sources without accessing identifiable patient-level data. It streamlines study feasibility assessments by providing rapid, aggregated cohort counts and characteristics across diverse datasets. To request access or log in, please click the 'Access Cohort Discovery' button.",
                     "stepper": {
                         "moreInfo": "More information about this service can be found <link>here</link>",

--- a/src/config/messages/en.json
+++ b/src/config/messages/en.json
@@ -338,6 +338,7 @@
                     "headerText": "Learn about Cohort Discovery and gain access to the service",
                     "accessTitle": "Cohort Data Access",
                     "daysRemaining": "days remaining in current access period",
+                    "accessExpiringIn": "Access expiring in {days} Days",
                     "accessText1": "Cohort Discovery allows researchers to explore and identify patient cohorts across multiple, federated health data sources without accessing identifiable patient-level data. It streamlines study feasibility assessments by providing rapid, aggregated cohort counts and characteristics across diverse datasets. To request access or log in, please click the 'Access Cohort Discovery' button.",
                     "stepper": {
                         "moreInfo": "More information about this service can be found <link>here</link>",
@@ -345,7 +346,9 @@
                         "applyStepTitle": "Apply for Cohort Discovery Access",
                         "applyStepDescription": "Start application, read terms and conditions and submit application.",
                         "applyButton": "Apply for Cohort Discovery",
-                        "reapplyButton": "Re-apply for access",
+                        "reapplyStepTitle": "Re-apply for Cohort Discovery Access",
+                        "reapplyStepDescription": "Start your application now so you don't lose access to the Cohort Discovery Service",
+                        "reapplyButton": "Re-apply for Cohort Discovery",
                         "reviewProfileTitle": "Review Your Profile",
                         "reviewProfileIntro": "Your Cohort Discovery Access Request will be assessed based on your Gateway registered user profile. Please ensure this is complete and up to date before you submit this request and includes:",
                         "checklistEmail": "Institutional email address <warn>(if this is not what appears in your SSO email field, please log out and log in using your institutional email address)</warn>",

--- a/src/config/theme.ts
+++ b/src/config/theme.ts
@@ -83,6 +83,7 @@ declare module "@mui/material/Chip" {
         warningCustom: true;
         alias: true;
         greyCustom: true;
+        yellowCustom: true;
     }
 }
 

--- a/src/config/theme.ts
+++ b/src/config/theme.ts
@@ -150,6 +150,8 @@ export const colors = {
     darkGreen100: "#ADDAD9",
     yellow400: "#F4E751",
     yellow500: "#FFC40C",
+    yellow600: "#F2D12D",
+    yellow800: "#856505",
 };
 
 const palette = {
@@ -779,6 +781,13 @@ const theme = createTheme({
                     props: { color: "warningCustom" },
                     style: {
                         background: colors.orange300,
+                    },
+                },
+                {
+                    props: { color: "yellowCustom" },
+                    style: {
+                        background: colors.yellow600,
+                        color: colors.yellow800,
                     },
                 },
                 {

--- a/src/consts/cohortDiscovery.tsx
+++ b/src/consts/cohortDiscovery.tsx
@@ -2,6 +2,7 @@ import { RouteName } from "@/consts/routeName";
 
 const COHORT_STATUS = {
     APPROVED: "APPROVED",
+    RENEWING: "RENEWING",
     REJECTED: "REJECTED",
     PENDING: "PENDING",
     BANNED: "BANNED",
@@ -24,6 +25,14 @@ const COHORT_REAPPLY_STATUSES: string[] = [
     COHORT_STATUS.EXPIRED,
 ];
 
+const isAwaitingCohortDecision = (
+    requestStatus: string | null,
+    hasAccess: boolean
+) =>
+    !!requestStatus &&
+    !hasAccess &&
+    !COHORT_REAPPLY_STATUSES.includes(requestStatus);
+
 const NHS_SDE_NEGATIVE_STATUSES: string[] = [
     NHS_SDE_STATUS.REJECTED,
     NHS_SDE_STATUS.EXPIRED,
@@ -40,6 +49,7 @@ const NHS_SDE_FINAL_STATUSES: string[] = [
 
 const statusMapping = {
     [COHORT_STATUS.APPROVED]: "secondary",
+    [COHORT_STATUS.RENEWING]: "primary",
     [COHORT_STATUS.REJECTED]: "warning",
     [COHORT_STATUS.PENDING]: "greyCustom",
     [COHORT_STATUS.BANNED]: "error",
@@ -60,6 +70,7 @@ const NHSSDEStatusMapping = {
 const NHS_SDE_FILTER = "The NHS Research Secure Data Environment (SDE) Network";
 const COHORT_DISCOVERY_EXPIRY_WARNING_DAYS = 166;
 const COHORT_DISCOVERY_SDE_EXPIRY_WARNING_DAYS = 1770;
+const COHORT_EXPIRY_WARNING_DAYS = 15;
 
 const STEP_STATE = {
     COMPLETE: "complete",
@@ -80,6 +91,8 @@ export {
     NHS_SDE_FINAL_STATUSES,
     COHORT_DISCOVERY_EXPIRY_WARNING_DAYS,
     COHORT_DISCOVERY_SDE_EXPIRY_WARNING_DAYS,
+    COHORT_EXPIRY_WARNING_DAYS,
+    isAwaitingCohortDecision,
     NHS_SDE_FILTER,
     STEP_STATE,
     COHORT_ABOUT_HREF,

--- a/src/hooks/useCohortStatus.test.tsx
+++ b/src/hooks/useCohortStatus.test.tsx
@@ -10,6 +10,7 @@ describe("useCohortStatus", () => {
     const mockData = {
         requestStatus: "APPROVED",
         redirectUrl: "https://example.com/redirect",
+        hasAccess: true,
     };
 
     beforeEach(() => {
@@ -33,6 +34,7 @@ describe("useCohortStatus", () => {
         expect(result.current.isLoading).toBe(false);
         expect(result.current.requestStatus).toBe("APPROVED");
         expect(result.current.redirectUrl).toBe("https://example.com/redirect");
+        expect(result.current.hasAccess).toBe(true);
     });
 
     it("should not fetch if userId is undefined", async () => {
@@ -60,5 +62,6 @@ describe("useCohortStatus", () => {
         expect(result.current.isLoading).toBe(false);
         expect(result.current.requestStatus).toBeNull();
         expect(result.current.redirectUrl).toBeNull();
+        expect(result.current.hasAccess).toBe(false);
     });
 });

--- a/src/hooks/useCohortStatus.ts
+++ b/src/hooks/useCohortStatus.ts
@@ -52,6 +52,7 @@ export const useCohortStatus = (
         nhseSdeRequestStatus: data?.nhseSdeRequestStatus ?? null,
         requestExpiry: data?.requestExpiry ?? null,
         redirectUrl: data?.redirectUrl ?? null,
+        hasAccess: data?.hasAccess ?? false,
         isLoading,
         hasFetched,
         refetch: fetchData,

--- a/src/interfaces/CohortRequest.ts
+++ b/src/interfaces/CohortRequest.ts
@@ -2,6 +2,7 @@ import { User } from "./User";
 
 type CohortRequestStatus =
     | "APPROVED"
+    | "RENEWING"
     | "REJECTED"
     | "PENDING"
     | "BANNED"
@@ -42,6 +43,7 @@ interface CohortRequest {
     nhse_sde_request_expire_at: string;
     nhse_sde_updated_at: string;
     access_to_env: string;
+    has_access: boolean;
 }
 
 interface CohortRequestForm {
@@ -63,6 +65,7 @@ interface CohortRequestUser {
     updated_at: string;
     deleted_at: string;
     accept_declaration: boolean;
+    has_access: boolean;
 }
 
 interface CohortRequestAccess {
@@ -74,6 +77,7 @@ interface CohortResponse {
     nhseSdeRequestStatus: NHSSDERequestStatus;
     requestExpiry: string;
     redirectUrl: string;
+    hasAccess: boolean;
 }
 
 export type {

--- a/src/providers/CohortRedirectProvider.tsx
+++ b/src/providers/CohortRedirectProvider.tsx
@@ -7,16 +7,16 @@ import { useCohortStatus } from "@/hooks/useCohortStatus";
 
 const CohortRedirectProvider = () => {
     const { user } = useAuth();
-    const { requestStatus } = useCohortStatus(user?.id);
+    const { hasAccess } = useCohortStatus(user?.id);
     const router = useRouter();
     const params = useSearchParams();
     const redirectUrl = params?.get("redirect_cohort_discovery_upon_signin");
 
     useEffect(() => {
-        if (user && requestStatus === "APPROVED" && redirectUrl) {
+        if (user && hasAccess && redirectUrl) {
             router.push(redirectUrl);
         }
-    }, [user, requestStatus, redirectUrl, router]);
+    }, [user, hasAccess, redirectUrl, router]);
 
     return null;
 };


### PR DESCRIPTION
> AI disclaimer - CLAUDE was used for this. The requirements, design direction and the product decisions along the way (two-row access/renewal layout, chip and indicator colours, scope) were mine; CLAUDE traced the new API surface, wrote the implementation, the copy and the tests, roughly 70% of the diff, reviewed line by line as it went.

## Screenshots / videos (if relevant)
<img width="494" height="179" alt="image" src="https://github.com/user-attachments/assets/6666dfdb-81a1-4ab0-a072-eeb04667dac9" />
<img width="471" height="154" alt="image" src="https://github.com/user-attachments/assets/85109f12-8845-4099-811d-532d79a89a30" />

## Describe your changes
Users can now renew Cohort Discovery access *before* it lapses rather than waiting to be locked out. Within 15 days of expiry the status area shows a yellow "Approved" chip beside an "Access expiring in X Days" warning, and Step 1 becomes a live "Re-apply for Cohort Discovery Access" step; expired and rejected users keep the same re-apply route they had.

Submitting a re-application deliberately changes nothing about how someone already uses the service — the API moves the request to the new `RENEWING` status, which still grants access — so the panel then reads `Current Access: Approved` above `Access Renewal: Pending`, with the access button intact and Step 2 (Application Review) active. Those two labels only appear while a renewal is in flight, since a single chip needs no label.

Underneath, every place that inferred access from `request_status === "APPROVED"` now reads the API's computed `has_access` flag: the stepper's access button, the NHS SDE prerequisite, the shared access panel, the CDS button (including the click handler that would otherwise have shown a renewing user the "not approved" modal), the sign-in redirect provider, and the duplicated search gate, which now shares a single `isAwaitingCohortDecision` helper.

**Depends on the API change (GAT-9459) being deployed** — `has_access` and the `RENEWING` status come from there. The admin views are intentionally untouched and handled separately, so their status dropdown has no `RENEWING` option yet.

## Issue ticket link
https://hdruk.atlassian.net/browse/GAT-9205

## Checklist before requesting a review

- [x] I have performed a self-review of my code
- [x] I have added appropriate unit tests / e2e tests (where relevant)
- [ ] I have created mocks for api endpoints (where appropriate)
- [ ] The interface is responsive (where ticket is relevant)
- [ ] The interface is at least AA (where ticket is relevant)
- [ ] Commits are described as "(chore|fix|feature|test|maintenance): description"
