### PR TITLE
feat(GAT-9459): Add RENEWING status in the cohort discovery admin view

### DIFF
--- a/mocks/data/cohortRequest/v1/cohortRequest.data.ts
+++ b/mocks/data/cohortRequest/v1/cohortRequest.data.ts
@@ -7,6 +7,7 @@ const generateCohortRequestV1 = (data = {}): CohortRequest => {
         id: faker.datatype.number(),
         request_status: faker.helpers.arrayElement([
             "APPROVED",
+            "RENEWING",
             "REJECTED",
             "PENDING",
             "BANNED",

--- a/src/app/[locale]/account/profile/cohort-discovery-admin/[cohortId]/StatusForm.test.tsx
+++ b/src/app/[locale]/account/profile/cohort-discovery-admin/[cohortId]/StatusForm.test.tsx
@@ -1,0 +1,72 @@
+import { fireEvent, render, screen, waitFor } from "@/utils/testUtils";
+import { generateCohortRequestV1 } from "@/mocks/data/cohortRequest";
+import ActionBar from "@/components/ActionBar";
+import StatusForm from "./StatusForm";
+
+jest.mock("@/hooks/useGet", () => ({
+    __esModule: true,
+    default: () => ({ data: [], isLoading: false }),
+}));
+
+jest.mock("@/hooks/useUnsavedChanges", () => ({
+    __esModule: true,
+    useUnsavedChanges: () => undefined,
+}));
+
+const updateCohort = jest.fn();
+jest.mock("@/hooks/usePut", () => ({
+    __esModule: true,
+    default: () => updateCohort,
+}));
+
+describe("StatusForm", () => {
+    beforeEach(() => {
+        updateCohort.mockClear();
+    });
+
+    it("shows the current status of a renewing request", () => {
+        const cohortRequest = generateCohortRequestV1({
+            request_status: "RENEWING",
+        });
+
+        render(<StatusForm cohortRequest={cohortRequest} />);
+
+        expect(
+            screen.getByRole("combobox", { name: "Cohort Status" })
+        ).toHaveTextContent("Renewing");
+    });
+
+    it("approves a renewal the same way any other request is approved", async () => {
+        const cohortRequest = generateCohortRequestV1({
+            request_status: "RENEWING",
+        });
+
+        render(
+            <>
+                <StatusForm cohortRequest={cohortRequest} />
+                <ActionBar />
+            </>
+        );
+
+        fireEvent.mouseDown(
+            screen.getByRole("combobox", { name: "Cohort Status" })
+        );
+        fireEvent.click(screen.getByRole("option", { name: "Approved" }));
+
+        const detailsField = await screen.findByLabelText(
+            "Why did you make this action?"
+        );
+        fireEvent.change(detailsField, {
+            target: { value: "Renewal reviewed and approved for another year." },
+        });
+
+        fireEvent.click(await screen.findByRole("button", { name: "Save" }));
+
+        await waitFor(() => {
+            expect(updateCohort).toHaveBeenCalledWith(
+                cohortRequest.id,
+                expect.objectContaining({ request_status: "APPROVED" })
+            );
+        });
+    });
+});

--- a/src/app/[locale]/account/profile/cohort-discovery-admin/[cohortId]/config.tsx
+++ b/src/app/[locale]/account/profile/cohort-discovery-admin/[cohortId]/config.tsx
@@ -4,6 +4,7 @@ import { inputComponents } from "@/config/forms";
 
 const cohortStatusOptions = [
     { label: "Approved", value: "APPROVED" },
+    { label: "Renewing", value: "RENEWING" },
     { label: "Rejected", value: "REJECTED" },
     { label: "Banned", value: "BANNED" },
     { label: "Suspended", value: "SUSPENDED" },

--- a/src/app/[locale]/account/profile/cohort-discovery-admin/components/CohortTable/CohortTable.test.tsx
+++ b/src/app/[locale]/account/profile/cohort-discovery-admin/components/CohortTable/CohortTable.test.tsx
@@ -1,8 +1,10 @@
+import { rest } from "msw";
 import { formatDate } from "@/utils/date";
-import { render, screen, waitFor, within } from "@/utils/testUtils";
+import { render, screen, fireEvent, waitFor, within } from "@/utils/testUtils";
 import { generateCohortRequestV1 } from "@/mocks/data/cohortRequest";
 import { getCohortRequestsV1 } from "@/mocks/handlers/cohortRequest";
 import { server } from "@/mocks/server";
+import apis from "@/config/apis";
 import CohortTable from "./CohortTable";
 
 const requests = [
@@ -123,6 +125,64 @@ describe("Cohort Table", () => {
             expect(
                 within(tableRows[7]).getByText("Suspended")
             ).toBeInTheDocument();
+        });
+    });
+
+    it("requests a needs-attention-first sort by default", async () => {
+        const requestedSorts: (string | null)[] = [];
+        server.use(
+            rest.get(apis.cohortRequestsV1Url, (req, res, ctx) => {
+                requestedSorts.push(req.url.searchParams.get("sort"));
+                return res(
+                    ctx.status(200),
+                    ctx.json({
+                        lastPage: 1,
+                        to: requests.length,
+                        from: 1,
+                        currentPage: 1,
+                        total: requests.length,
+                        list: requests,
+                    })
+                );
+            })
+        );
+
+        render(<CohortTable />);
+
+        await waitFor(() => {
+            expect(requestedSorts).toContain("priority:desc,created_at:desc");
+        });
+    });
+
+    it("falls back to a plain sort once a reviewer picks a different column", async () => {
+        const requestedSorts: (string | null)[] = [];
+        server.use(
+            rest.get(apis.cohortRequestsV1Url, (req, res, ctx) => {
+                requestedSorts.push(req.url.searchParams.get("sort"));
+                return res(
+                    ctx.status(200),
+                    ctx.json({
+                        lastPage: 1,
+                        to: requests.length,
+                        from: 1,
+                        currentPage: 1,
+                        total: requests.length,
+                        list: requests,
+                    })
+                );
+            })
+        );
+
+        render(<CohortTable />);
+
+        await waitFor(() => {
+            expect(requestedSorts).toContain("priority:desc,created_at:desc");
+        });
+
+        fireEvent.click(screen.getByRole("button", { name: "Sort by name" }));
+
+        await waitFor(() => {
+            expect(requestedSorts).toContain("name:asc");
         });
     });
 });

--- a/src/app/[locale]/account/profile/cohort-discovery-admin/components/CohortTable/CohortTable.test.tsx
+++ b/src/app/[locale]/account/profile/cohort-discovery-admin/components/CohortTable/CohortTable.test.tsx
@@ -13,6 +13,10 @@ const requests = [
         updated_at: "2025-06-20T00:00:00.000Z",
     }),
     generateCohortRequestV1({
+        request_status: "RENEWING",
+        nhse_sde_request_status: "APPROVAL REQUESTED",
+    }),
+    generateCohortRequestV1({
         request_status: "REJECTED",
         nhse_sde_request_status: "APPROVAL REQUESTED",
     }),
@@ -81,19 +85,22 @@ describe("Cohort Table", () => {
                 within(tableRows[1]).getByText("Approved")
             ).toBeInTheDocument();
             expect(
-                within(tableRows[2]).getByText("Rejected")
+                within(tableRows[2]).getByText("Renewing")
             ).toBeInTheDocument();
             expect(
-                within(tableRows[3]).getByText("Pending")
+                within(tableRows[3]).getByText("Rejected")
             ).toBeInTheDocument();
             expect(
-                within(tableRows[4]).getByText("Banned")
+                within(tableRows[4]).getByText("Pending")
             ).toBeInTheDocument();
             expect(
-                within(tableRows[5]).getByText("Suspended")
+                within(tableRows[5]).getByText("Banned")
             ).toBeInTheDocument();
             expect(
-                within(tableRows[6]).getByText("Expired")
+                within(tableRows[6]).getByText("Suspended")
+            ).toBeInTheDocument();
+            expect(
+                within(tableRows[7]).getByText("Expired")
             ).toBeInTheDocument();
             expect(
                 within(tableRows[1]).getByText("In process")
@@ -102,16 +109,19 @@ describe("Cohort Table", () => {
                 within(tableRows[2]).getByText("Approval requested")
             ).toBeInTheDocument();
             expect(
-                within(tableRows[3]).getByText("Approved")
+                within(tableRows[3]).getByText("Approval requested")
             ).toBeInTheDocument();
             expect(
-                within(tableRows[4]).getByText("Rejected")
+                within(tableRows[4]).getByText("Approved")
             ).toBeInTheDocument();
             expect(
-                within(tableRows[5]).getByText("Banned")
+                within(tableRows[5]).getByText("Rejected")
             ).toBeInTheDocument();
             expect(
-                within(tableRows[6]).getByText("Suspended")
+                within(tableRows[6]).getByText("Banned")
+            ).toBeInTheDocument();
+            expect(
+                within(tableRows[7]).getByText("Suspended")
             ).toBeInTheDocument();
         });
     });

--- a/src/app/[locale]/account/profile/cohort-discovery-admin/components/CohortTable/CohortTable.tsx
+++ b/src/app/[locale]/account/profile/cohort-discovery-admin/components/CohortTable/CohortTable.tsx
@@ -37,8 +37,15 @@ const CohortTable = () => {
 
     const searchDebounced = useDebounce(watchAll.search, 500);
 
+    const isDefaultSort = sort.key === "created_at" && sort.direction === "desc";
+
     const queryParams = new URLSearchParams();
-    queryParams.append("sort", `${sort.key}:${sort.direction}`);
+    queryParams.append(
+        "sort",
+        isDefaultSort
+            ? "priority:desc,created_at:desc"
+            : `${sort.key}:${sort.direction}`
+    );
     queryParams.append("page", currentPage.toString());
     if (requestStatus) {
         queryParams.append("request_status", requestStatus);

--- a/src/app/[locale]/account/profile/cohort-discovery-admin/components/CohortTable/CohortTable.utils.tsx
+++ b/src/app/[locale]/account/profile/cohort-discovery-admin/components/CohortTable/CohortTable.utils.tsx
@@ -44,6 +44,7 @@ const updateSort =
 const statusRadios = [
     { label: "All", value: "" },
     { label: "Approved", value: "APPROVED" },
+    { label: "Renewing", value: "RENEWING" },
     { label: "Pending", value: "PENDING" },
     { label: "Rejected", value: "REJECTED" },
     { label: "Banned", value: "BANNED" },


### PR DESCRIPTION
## Screenshots (if relevant)

RENEWING and PENDING show first:

<img width="1512" height="866" alt="image" src="https://github.com/user-attachments/assets/53d4b293-f799-4331-93de-88b314edb51d" />

RENEWING status in dropdown:

<img width="1505" height="684" alt="image" src="https://github.com/user-attachments/assets/d3c91b88-9014-47f6-89dd-48c60f2b0ebe" />

RENEWING added to filter

<img width="967" height="744" alt="image" src="https://github.com/user-attachments/assets/6a96a36e-5e2e-477d-87d1-f2304145ff14" />


## Describe your changes

Adds RENEWING as a status to the admin view

## Issue ticket link

https://hdruk.atlassian.net/browse/GAT-9462

## Checklist before requesting a review

-   [X] I have performed a self-review of my code
-   [X] I have added appropriate unit tests
-   [X] I have created mocks for unit tests (where appropriate)
-   [ ] The interface is responsive (where appropriate)
-   [ ] The interface is at least AA (where appropriate)
